### PR TITLE
Fix "Furthest Distance" filter

### DIFF
--- a/service/search/__init__.py
+++ b/service/search/__init__.py
@@ -16,7 +16,7 @@ WITH deleted_search_cache AS (
     WHERE searcher_person_id = %(searcher_person_id)s
 )
 SELECT
-    distance
+    1000 * distance AS distance
 FROM
     person
 JOIN


### PR DESCRIPTION
`distance` was off by a factor of 1000. When you set "50 km" in the UI as your furthest distance for a match, the backend interpreted it as 50 metres. (I confused myself by not choosing variable name which included units.)