### PR TITLE
Start disabling disposable email addresses

### DIFF
--- a/antispam/__init__.py
+++ b/antispam/__init__.py
@@ -1,0 +1,74 @@
+from antispam.sql import *
+from database import api_tx
+import json
+import os
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+DUO_VERIFY_MAIL_API_KEY = os.environ['DUO_VERIFY_MAIL_API_KEY']
+
+is_disposable_email_file = (
+    Path(__file__).parent.parent /
+    'test' /
+    'input' /
+    'is-disposable-email')
+
+def is_disposable_email(email):
+    if is_disposable_email_file.is_file():
+        with is_disposable_email_file.open() as file:
+            flag = file.read().strip()
+            if flag == '1': return True
+            if flag == '0': return False
+
+    query = urllib.parse.quote(email)
+    url = f"https://verifymail.io/api/{query}?key={DUO_VERIFY_MAIL_API_KEY}"
+
+    try:
+        with urllib.request.urlopen(url) as response:
+            data = response.read().decode('utf-8')
+            json_data = json.loads(data)
+            return json_data.get("disposable", False)
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        return None
+    return False
+
+def check_and_update_bad_domains(email):
+    _, domain = email.split('@')
+
+    params = dict(email=email, domain=domain)
+
+    # Check if we already know about the email domain
+    with api_tx() as tx:
+        domain_status = tx.execute(
+            Q_EMAIL_INFO,
+            params=params
+        ).fetchone()['domain_status']
+
+    if domain_status == 'registered':
+        return True
+    elif domain_status == 'unregistered-good':
+        return True
+    elif domain_status == 'unregistered-bad':
+        return False
+    elif domain_status == 'unregistered-unknown':
+        pass
+    else:
+        raise Exception('Unhandled domain status')
+
+    # Query the API and update the DB if we don't know about the domain
+    is_disposable_email_ = is_disposable_email(email)
+
+    if is_disposable_email_ is True:
+        with api_tx() as tx:
+            tx.execute(Q_INSERT_BAD_DOMAIN, params=params)
+        return False
+    elif is_disposable_email_ is False:
+        with api_tx() as tx:
+            tx.execute(Q_INSERT_GOOD_DOMAIN, params=params)
+        return True
+    elif is_disposable_email_ is None:
+        return True
+    else:
+        raise Exception('Unhandled API response')

--- a/antispam/sql/__init__.py
+++ b/antispam/sql/__init__.py
@@ -1,0 +1,27 @@
+Q_EMAIL_INFO = """
+SELECT
+    CASE
+        WHEN EXISTS (SELECT 1 FROM person WHERE email = %(email)s)
+        THEN 'registered'
+
+        WHEN EXISTS (SELECT 1 FROM good_email_domain WHERE domain = %(domain)s)
+        THEN 'unregistered-good'
+
+        WHEN EXISTS (SELECT 1 FROM bad_email_domain  WHERE domain = %(domain)s)
+        THEN 'unregistered-bad'
+
+        ELSE 'unregistered-unknown'
+    END AS domain_status
+"""
+
+Q_INSERT_BAD_DOMAIN = """
+INSERT INTO bad_email_domain (domain) VALUES (
+    %(domain)s
+) ON CONFLICT (domain) DO NOTHING;
+"""
+
+Q_INSERT_GOOD_DOMAIN = """
+INSERT INTO good_email_domain (domain) VALUES (
+    %(domain)s
+) ON CONFLICT (domain) DO NOTHING;
+"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       DUO_R2_ACCESS_KEY_ID: s3-mock-access-key-id
       DUO_R2_ACCESS_KEY_SECRET: s3-mock-secret-access-key-secret
 
+      DUO_VERIFY_MAIL_API_KEY: unused-for-testing
+
       DUO_BOTO_ENDPOINT_URL: http://s3mock:9090
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]

--- a/init.sql
+++ b/init.sql
@@ -558,6 +558,13 @@ CREATE INDEX IF NOT EXISTS idx__photo__uuid
 CREATE INDEX IF NOT EXISTS idx__onboardee__created_at
     ON onboardee(created_at);
 
+
+CREATE INDEX IF NOT EXISTS idx__bad_email_domain__domain
+    ON bad_email_domain(domain);
+
+CREATE INDEX IF NOT EXISTS idx__good_email_domain__domain
+    ON good_email_domain(domain);
+
 --------------------------------------------------------------------------------
 -- DATA
 --------------------------------------------------------------------------------

--- a/service/person/__init__.py
+++ b/service/person/__init__.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 import psycopg
 from functools import lru_cache
 import random
+from antispam import check_and_update_bad_domains
 
 @dataclass
 class EmailEntry:
@@ -272,6 +273,9 @@ def _send_otp(email: str, otp: str):
     )
 
 def post_request_otp(req: t.PostRequestOtp):
+    if not check_and_update_bad_domains(req.email):
+        return 'Disposable email', 400
+
     email = req.email
     session_token = secrets.token_hex(64)
     session_token_hash = sha512(session_token)

--- a/test/functionality1/blocked-email-domains.sh
+++ b/test/functionality1/blocked-email-domains.sh
@@ -7,28 +7,67 @@ source ../util/setup.sh
 
 set -xe
 
-q "delete from person"
-q "delete from bad_email_domain"
+bad_email_domains_table_is_respected () {
+  q "delete from person"
+  q "delete from duo_session"
+  q "delete from bad_email_domain"
 
-q "INSERT INTO bad_email_domain (domain) VALUES ('bad.example.com')";
+  q "INSERT INTO bad_email_domain (domain) VALUES ('bad.example.com')";
 
-../util/create-user.sh bad-user-1  0 0
-../util/create-user.sh good-user-1 0 0
+  ../util/create-user.sh bad-user-1  0 0
+  ../util/create-user.sh good-user-1 0 0
 
-q "
-  update
-    person
-  set
-    email = 'bad-user-1@bad.example.com'
-  where
-    email = 'bad-user-1@example.com'"
+  q "
+    update
+      person
+    set
+      email = 'bad-user-1@bad.example.com'
+    where
+      email = 'bad-user-1@example.com'"
 
-echo "Existing users can continue logging in with a blocked domain"
-assume_role 'bad-user-1@bad.example.com'
-assume_role 'good-user-1@example.com'
+  echo "Existing users can continue logging in with a blocked domain"
+  assume_role 'bad-user-1@bad.example.com'
+  assume_role 'good-user-1@example.com'
 
-echo "New users can't sign up with a blocked domain"
-! jc POST /request-otp -d '{ "email": "bad-user-2@bad.example.com" }'
+  echo "New users can't sign up with a blocked domain"
+  ! jc POST /request-otp -d '{ "email": "bad-user-2@bad.example.com" }'
 
-echo "New users can sign up with a non-blocked domain"
-  jc POST /request-otp -d '{ "email": "good-user-2@example.com" }'
+  echo "New users can sign up with a non-blocked domain"
+    jc POST /request-otp -d '{ "email": "good-user-2@example.com" }'
+}
+
+good_domains_are_inserted () {
+  echo 'good domains are inserted'
+
+  q "delete from person"
+  q "delete from duo_session"
+  q "delete from good_email_domain"
+  q "delete from bad_email_domain"
+
+  printf 0  > ../../test/input/is-disposable-email
+
+  ../util/create-user.sh user@good.example.com 0 0
+
+  [[ "$(q "select count(*) from good_email_domain")" -eq 1 ]]
+  [[ "$(q "select count(*) from bad_email_domain")" -eq 0 ]]
+}
+
+bad_domains_are_inserted () {
+  echo 'bad domains are inserted'
+
+  q "delete from person"
+  q "delete from duo_session"
+  q "delete from good_email_domain"
+  q "delete from bad_email_domain"
+
+  printf 1  > ../../test/input/is-disposable-email
+
+  ! ../util/create-user.sh user@good.example.com 0 0
+
+  [[ "$(q "select count(*) from good_email_domain")" -eq 0 ]]
+  [[ "$(q "select count(*) from bad_email_domain")" -eq 1 ]]
+}
+
+bad_email_domains_table_is_respected
+good_domains_are_inserted
+bad_domains_are_inserted

--- a/test/util/setup.sh
+++ b/test/util/setup.sh
@@ -4,8 +4,13 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 cd "$script_dir"
 
 mkdir ../../test/input 2>/dev/null
-printf 1  > ../../test/input/disable-ip-rate-limit
-printf 1  > ../../test/input/disable-account-rate-limit
+printf 1 > ../../test/input/disable-ip-rate-limit
+printf 1 > ../../test/input/disable-account-rate-limit
+
+if [[ "$1" != no-disposable-email-file ]]
+then
+  printf 0 > ../../test/input/is-disposable-email
+fi
 
 trim () {
   local trimmed=$(cat)


### PR DESCRIPTION
This is yet another PR to make scraping profiles more difficult.

I suspect that whoever published [duoleak.acid.im](https://duoleak.acid.im) also wrote [this](https://archive.org/details/duolicious_analysis/page/n6/mode/1up) phoney academic paper. The author of the paper discloses the methods they used to successfully scrape the profiles:

---
![b](https://github.com/duolicious/duolicious-backend/assets/136373989/f02fd748-5a3b-41ea-84e3-0d6408a44251)
---
![a](https://github.com/duolicious/duolicious-backend/assets/136373989/a056f6b1-e819-4d44-b556-1769d0206fca)
---

That means that scraping of Duolicious as described in the paper can be mitigated in two ways:

1. Rate-limiting
  a. Rate-limiting by IP address (#306, #304, #300, and others)
  b. Rate-limiting by account (i.e. email address) (#312)
2. Phasing-out the use of disposable email domains (starting with this PR)

Once this PR is deployed, accounts using disposable email addresses should be deleted from Duolicious.