### PR TITLE
XMPP auth changes

### DIFF
--- a/service/chat/auth.py
+++ b/service/chat/auth.py
@@ -101,7 +101,7 @@ def main():
                 allow()
             else:
                 deny()
-        except struct.error as e:
+        except:
             deny()
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change is mostly in response to the authentication message queue length boundlessly increasing. If this PR doesn't improve the situation, I might use [http](https://esl.github.io/MongooseDocs/latest/authentication-methods/http/) auth.