### PR TITLE
Log verification failure reason

### DIFF
--- a/verification/__init__.py
+++ b/verification/__init__.py
@@ -191,6 +191,7 @@ def process_response(
         image_1_has_person_from_image_8 = float(image_1_has_person_from_image_8) if image_1_has_person_from_image_8 is not None else None
     except:
         print(traceback.format_exc())
+        print('JSON was:', str(response))
         return failure("Something went wrong.")
 
     general_truthiness_threshold = 0.7
@@ -329,7 +330,7 @@ async def verify(
                     claimed_gender=claimed_gender,
                     claimed_ethnicity=claimed_ethnicity,
                 ),
-                max_tokens=300,
+                max_tokens=500,
                 timeout=45,
             )).choices[0].message.content
         except:


### PR DESCRIPTION
I'm seeing lots of errors like this and I'm not sure why:

```
Traceback (most recent call last):                                                                                                                                                                                                
  File "/app/verification/__init__.py", line 151, in process_response                                                                                                                                                             
    json_obj = json.loads(response)                                                                                                                                                                                                              ^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                               
  File "/usr/local/lib/python3.11/json/__init__.py", line 346, in loads                                                                                                                                                           
    return _default_decoder.decode(s)                                                                                                                                                                                             
           ^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                               File "/usr/local/lib/python3.11/json/decoder.py", line 337, in decode                                                                                                                                                           
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())                                                                                                                                                                             
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                             
  File "/usr/local/lib/python3.11/json/decoder.py", line 353, in raw_decode                                                                                                                                                           obj, end = self.scan_once(s, idx)                                                                                                                                                                                             
               ^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                             
json.decoder.JSONDecodeError: Unterminated string starting at: line 20 column 3 (char 704)  
```

All the errors I've seen are at `line 20 column 3 (char 704) `. ChatGPT wasn't instructed to produce output containing strings, so I'm not sure what's going on. I'm going to log the response to check.

One possible culprit is the limit on output tokens, but it was set to 300, which should be enough to encode 704 characters. I've set it to 500 anyway. Further evidence that the culprit is the token limit is the fact that these errors tend to be from users who have as many photos on their profile as possible, which increases the output length.