### PR TITLE
Club-specific rate limits

### DIFF
--- a/service/application/__init__.py
+++ b/service/application/__init__.py
@@ -30,6 +30,7 @@ from service.application.decorators import (
 )
 import time
 from antispam import normalize_email
+import json
 
 _init_sql_file = (
     Path(__file__).parent.parent.parent / 'init.sql')
@@ -212,20 +213,18 @@ def delete_answer(req: t.DeleteAnswer, s: t.SessionInfo):
 def get_search(s: t.SessionInfo):
     n = request.args.get('n')
     o = request.args.get('o')
+
+    rawClub = request.args.get('club')
     club = (
-        search.ClubHttpArg(
-            request.args.get('club')
-            if request.args.get('club') != '\0'
-            else None
-        )
+        search.ClubHttpArg(rawClub if rawClub != '\0' else None)
         if 'club' in request.args
         else None
     )
 
     search_type, _ = search.get_search_type(n, o)
 
-    limit = "30 per 2 minutes"
-    scope = search_type
+    limit = "15 per 2 minutes"
+    scope = json.dumps([search_type, rawClub])
 
     if search_type == 'uncached-search':
         with (

--- a/test/functionality3/rate-limiting.sh
+++ b/test/functionality3/rate-limiting.sh
@@ -36,7 +36,7 @@ echo The stricter rate limit should apply for reports
 ! jc POST "/skip/${user2id}" -d '{ "report_reason": "bad hair" }'
 
 echo Uncached search should be heavily rate-limited
-for x in {1..30}
+for x in {1..15}
 do
   c GET '/search?n=1&o=0'
 done
@@ -46,6 +46,16 @@ echo "Cached search shouldn't be heavily rate-limited"
 c GET '/search?n=1&o=1'
 c GET '/search?n=1&o=1'
 c GET '/search?n=1&o=1'
+
+echo "Rate limit should apply independently to clubs"
+jc POST /join-club -d '{ "name": "Anime" }'
+jc POST /join-club -d '{ "name": "Manga" }'
+for x in {1..15}
+do
+  c GET '/search?n=1&o=0&club=Anime'
+done
+! c GET '/search?n=1&o=0&club=Anime'
+  c GET '/search?n=1&o=0&club=Manga'
 
 echo Account-based rate limit should apply even if the IP address changes
 printf 1 > ../../test/input/disable-ip-rate-limit


### PR DESCRIPTION
Adding the ability to search by club has made rate limiting feel too aggressive if you want to obsessively check members, club-by-club.