### PR TITLE
Marginally less infuriating selfie checker

### DIFF
--- a/service/application/__init__.py
+++ b/service/application/__init__.py
@@ -410,7 +410,7 @@ def post_verification_selfie(req: t.PostVerificationSelfie, s: t.SessionInfo):
 
 @apost('/verify')
 def post_verify(s: t.SessionInfo):
-    limit = "5 per day"
+    limit = "8 per day"
     scope = "verify"
 
     with (

--- a/verification/__init__.py
+++ b/verification/__init__.py
@@ -74,7 +74,7 @@ def get_system_content(
         '  // Image #1 contains a person who is smiling',
         '  image_1_has_smiling_person: number',
         '',
-        '  // Image #1 contains a person who is touching their eyebrow',
+        '  // Image #1 contains a person whose hand is in contact with their eyebrow or a part of their face adjacent to their eyebrow (e.g. their forehead)',
         '  image_1_has_eyebrow_touch: number',
         '',
         '  // Image #1 contains a person whose thumb is visible',
@@ -104,7 +104,7 @@ def get_user_content(
                 "type": "image_url",
                 "image_url": {
                     "url": get_image_url(uuid),
-                    "detail": "low"
+                    "detail": "high" if i == 0 else "low"
                 }
             }
 

--- a/verification/test_init.py
+++ b/verification/test_init.py
@@ -296,7 +296,7 @@ You have been given one or more image(s) by a user attempting to verify their id
   // Image #1 contains a person who is smiling
   image_1_has_smiling_person: number
 
-  // Image #1 contains a person who is touching their eyebrow
+  // Image #1 contains a person whose hand is in contact with their eyebrow or a part of their face adjacent to their eyebrow (e.g. their forehead)
   image_1_has_eyebrow_touch: number
 
   // Image #1 contains a person whose thumb is visible
@@ -320,7 +320,7 @@ You have been given one or more image(s) by a user attempting to verify their id
                             "type": "image_url",
                             "image_url": {
                                 "url": 'https://user-images.duolicious.app/450-u1.jpg',
-                                "detail": "low"
+                                "detail": "high"
                             }
                         },
                     ]
@@ -380,7 +380,7 @@ You have been given one or more image(s) by a user attempting to verify their id
   // Image #1 contains a person who is smiling
   image_1_has_smiling_person: number
 
-  // Image #1 contains a person who is touching their eyebrow
+  // Image #1 contains a person whose hand is in contact with their eyebrow or a part of their face adjacent to their eyebrow (e.g. their forehead)
   image_1_has_eyebrow_touch: number
 
   // Image #1 contains a person whose thumb is visible
@@ -410,7 +410,7 @@ You have been given one or more image(s) by a user attempting to verify their id
                             "type": "image_url",
                             "image_url": {
                                 "url": 'https://user-images.duolicious.app/450-u1.jpg',
-                                "detail": "low"
+                                "detail": "high"
                             }
                         },
                         {
@@ -489,7 +489,7 @@ You have been given one or more image(s) by a user attempting to verify their id
   // Image #1 contains a person who is smiling
   image_1_has_smiling_person: number
 
-  // Image #1 contains a person who is touching their eyebrow
+  // Image #1 contains a person whose hand is in contact with their eyebrow or a part of their face adjacent to their eyebrow (e.g. their forehead)
   image_1_has_eyebrow_touch: number
 
   // Image #1 contains a person whose thumb is visible
@@ -555,7 +555,7 @@ You have been given one or more image(s) by a user attempting to verify their id
   // Image #1 contains a person who is smiling
   image_1_has_smiling_person: number
 
-  // Image #1 contains a person who is touching their eyebrow
+  // Image #1 contains a person whose hand is in contact with their eyebrow or a part of their face adjacent to their eyebrow (e.g. their forehead)
   image_1_has_eyebrow_touch: number
 
   // Image #1 contains a person whose thumb is visible


### PR DESCRIPTION
`gpt-4o-2024-08-06` and `gpt-4o-mini-2024-07-18` seem to give equally poor results. I don't know how `gpt-4o` works, but I'm guessing that OpenAI uses the same image model on both of them, and that the image model passes only very coarse-grained information to the downstream language model. So I'm trying `detail: "high"` on the selfie and seeing if that works any better.

I also noticed that the model frequently believed that the person was touching their forehead rather than their eyebrow, so I made the prompt slightly more permissive.