### PR TITLE
Improve the formatting of reports

### DIFF
--- a/api.requirements.txt
+++ b/api.requirements.txt
@@ -4,6 +4,7 @@ Pillow
 PyYAML
 blurhash
 boto3
+erlastic
 flask-cors
 gunicorn
 numpy

--- a/service/person/sql/__init__.py
+++ b/service/person/sql/__init__.py
@@ -2035,7 +2035,8 @@ WITH last_messages AS (
             THEN 'reporter'
             ELSE 'accused'
         END AS sent_by,
-        message
+        message,
+        search_body
     FROM
         mam_message
     JOIN
@@ -2057,7 +2058,8 @@ WITH last_messages AS (
 )
 SELECT
     sent_by,
-    message
+    message,
+    search_body
 FROM
     last_messages
 ORDER BY

--- a/service/person/sql/__init__.py
+++ b/service/person/sql/__init__.py
@@ -2035,7 +2035,7 @@ WITH last_messages AS (
             THEN 'reporter'
             ELSE 'accused'
         END AS sent_by,
-        search_body AS message
+        message
     FROM
         mam_message
     JOIN

--- a/service/person/template/__init__.py
+++ b/service/person/template/__init__.py
@@ -74,12 +74,22 @@ def otp_template(otp: str):
 
 def decode_last_messages_in_place(last_messages: list[dict]):
     for message in last_messages:
+        try:
+            search_body = message['search_body']
+        except:
+            search_body = None
+
         m = erlastic.decode(message['message'])
 
         try:
             m = m[3][0][3][0][1].decode('utf-8')
         except:
-            m = dict(error="Couldn't unpack message while generating report")
+            m = dict(
+                error=(
+                    "Couldn't unpack message while generating report. "
+                    "Falling back to message search body"),
+                search_body=search_body,
+            )
 
         message['message'] = m
 


### PR DESCRIPTION
This PR makes reports more accurate by including the text from the decoded `mam_message.message` column instead of `mam_message.search_body`. The latter contains normalized text generated by stripping characters and removing emojis.

Duolicious has MongooseIM configured with `modules.mod_mam.db_message_format` unset. According to [the docs](https://esl.github.io/MongooseDocs/latest/modules/mod_mam/#modulesmod_mamdb_message_format), this leads the default setting to be `"mam_message_compressed_eterm"`. So `mam_message.message` contains messages in that format. https://github.com/samuel/python-erlastic handles that format just fine. Amazing work, @samuel! 🙂