### PR TITLE
More flattering stats for old friends

### DIFF
--- a/service/person/sql/__init__.py
+++ b/service/person/sql/__init__.py
@@ -2855,20 +2855,20 @@ WITH message_sent AS (
 ), absolute_numbers AS (
     SELECT
         count(*) FILTER (
-            WHERE message_sent_at < message_received_at)::real
+            WHERE message_sent_at <= message_received_at)::real
             AS num_intros_sent_with_reply,
 
         count(*) FILTER (
-            WHERE message_sent_at < message_received_at
+            WHERE message_sent_at <= message_received_at
             OR message_received_at IS NULL)::real
             AS num_intros_sent,
 
         count(*) FILTER (
-            WHERE message_received_at < message_sent_at)::real
+            WHERE message_received_at <= message_sent_at)::real
             AS num_intros_received_with_reply,
 
         count(*) FILTER (
-            WHERE message_received_at < message_sent_at
+            WHERE message_received_at <= message_sent_at
             OR message_sent_at IS NULL)::real
             AS num_intros_received
     FROM


### PR DESCRIPTION
The intro-related stats introduced in #502 are only approximately correct. The approximations are lower than the true value for conversations started before `2024-05-13 18:17:10.327775` UTC. This is because that's when #296 introduced the `messaged.created_at` column which the computation of the stats depends on. For conversations that existed at the time #296 was deployed, `created_at` was just set to the time the column was added, rather than getting back-filled with the real dates.

Instead of back-filling `messaged.created_at` with the real dates (which would be hard), this PR chooses a more flattering approximation (i.e. an overly high approximation) of the true reply rates for anyone with conversations predating `2024-05-13`.