### PR TITLE
I give up on aws config

### DIFF
--- a/api.requirements.txt
+++ b/api.requirements.txt
@@ -3,7 +3,7 @@ Flask-Limiter
 Pillow
 PyYAML
 blurhash
-boto3
+boto3==1.35.99
 confusable-homoglyphs
 erlastic
 flask-cors

--- a/cron.requirements.txt
+++ b/cron.requirements.txt
@@ -1,6 +1,6 @@
 Pillow
 blurhash
-boto3
+boto3==1.35.99
 numpy
 numpy==1.26.4
 onnxruntime

--- a/service/cron/checkphotos/__init__.py
+++ b/service/cron/checkphotos/__init__.py
@@ -8,7 +8,6 @@ from service.cron.util import (
 )
 import asyncio
 import boto3
-from botocore.config import Config
 import os
 import random
 import io
@@ -43,10 +42,6 @@ s3_client = boto3.client(
     endpoint_url=BOTO_ENDPOINT_URL,
     aws_access_key_id=R2_ACCESS_KEY_ID,
     aws_secret_access_key=R2_ACCESS_KEY_SECRET,
-    config=Config(
-        request_checksum_calculation='WHEN_REQUIRED',
-        response_checksum_validation='WHEN_REQUIRED',
-    ),
 )
 
 async def update_blurhashes(uuids: list[str]):

--- a/service/cron/util/__init__.py
+++ b/service/cron/util/__init__.py
@@ -116,10 +116,6 @@ async def delete_audio_from_object_store(
         endpoint_url=BOTO_ENDPOINT_URL,
         aws_access_key_id=R2_ACCESS_KEY_ID,
         aws_secret_access_key=R2_ACCESS_KEY_SECRET,
-        config=Config(
-            request_checksum_calculation='WHEN_REQUIRED',
-            response_checksum_validation='WHEN_REQUIRED',
-        ),
     )
 
     for chunk in chunks:
@@ -172,10 +168,6 @@ async def download_450_images(
         endpoint_url=BOTO_ENDPOINT_URL,
         aws_access_key_id=R2_ACCESS_KEY_ID,
         aws_secret_access_key=R2_ACCESS_KEY_SECRET,
-        config=Config(
-            request_checksum_calculation='WHEN_REQUIRED',
-            response_checksum_validation='WHEN_REQUIRED',
-        ),
     )
 
     def download_one(uuid):

--- a/service/cron/util/__init__.py
+++ b/service/cron/util/__init__.py
@@ -4,7 +4,6 @@ from botocore.exceptions import ClientError
 from service.cron.util.sql import *
 import asyncio
 import boto3
-from botocore.config import Config
 import io
 import os
 import traceback
@@ -54,10 +53,6 @@ async def delete_images_from_object_store(
         endpoint_url=BOTO_ENDPOINT_URL,
         aws_access_key_id=R2_ACCESS_KEY_ID,
         aws_secret_access_key=R2_ACCESS_KEY_SECRET,
-        config=Config(
-            request_checksum_calculation='WHEN_REQUIRED',
-            response_checksum_validation='WHEN_REQUIRED',
-        ),
     )
 
     for chunk in chunks:

--- a/service/person/__init__.py
+++ b/service/person/__init__.py
@@ -8,7 +8,6 @@ from duohash import sha512
 from PIL import Image
 import io
 import boto3
-from botocore.config import Config
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from service.person.sql import *
 from service.search.sql import *
@@ -86,10 +85,6 @@ s3 = boto3.resource(
     endpoint_url=BOTO_ENDPOINT_URL,
     aws_access_key_id=R2_ACCESS_KEY_ID,
     aws_secret_access_key=R2_ACCESS_KEY_SECRET,
-    config=Config(
-        request_checksum_calculation='WHEN_REQUIRED',
-        response_checksum_validation='WHEN_REQUIRED',
-    ),
 )
 
 bucket = s3.Bucket(R2_BUCKET_NAME)


### PR DESCRIPTION
Cloudflare's documentation says:

>Client version 1.36.0 introduced a modification to the default checksum behavior from the client that is currently incompatible with R2 APIs.
>
>To mitigate, users can use 1.35.99 or add the following to their s3 resource config: [...]

I tried adjusting the config but it didn't work, so I'm downgrading to `boto==1.35.99`.