### PR TITLE
More restrictive rate limit

### DIFF
--- a/service/chat/__init__.py
+++ b/service/chat/__init__.py
@@ -37,7 +37,7 @@ PORT = sys.argv[1] if len(sys.argv) >= 2 else 5443
 class IntroRateLimit(Enum):
     NONE = 0
     UNVERIFIED = 10
-    BASICS = 40
+    BASICS = 20
     PHOTOS = 100
 
 # TODO: Tables to migrate to monolithic DB:

--- a/test/functionality4/xmpp-rate-limit.sh
+++ b/test/functionality4/xmpp-rate-limit.sh
@@ -216,7 +216,7 @@ test_rate_limit \
   '<duo_message_blocked id="id999" reason="rate-limited-1day" subreason="unverified-basics"/>'
 
 test_rate_limit \
-  40 \
+  20 \
   2 \
   '<duo_message_blocked id="id999" reason="rate-limited-1day" subreason="unverified-photos"/>'
 


### PR DESCRIPTION
Tightening rate limits seems to have improved user retention and the gender ratio. While it's hard to estimate how big its effect is relative to other measures like promoting verified profiles (#598), or adding a word filter to intros (#536 and others), I suspect the effect is significant, so I'm going to tighten the limit further and see what happens. Before any limits were introduced, [97.24% of users sent 20 or fewer messages per day](https://github.com/duolicious/duolicious-backend/pull/560), so the limit in this PR is still generous IMO.