### PR TITLE
autodeactivate2: 30 days again

### DIFF
--- a/service/cron/autodeactivate2/sql/__init__.py
+++ b/service/cron/autodeactivate2/sql/__init__.py
@@ -4,9 +4,9 @@ SELECT DISTINCT
 FROM
     last
 WHERE
-    seconds < EXTRACT(EPOCH FROM NOW() - INTERVAL '10 days')
+    seconds < EXTRACT(EPOCH FROM NOW() - INTERVAL '30 days')
 AND
-    seconds > EXTRACT(EPOCH FROM NOW() - INTERVAL '20 days')
+    seconds > EXTRACT(EPOCH FROM NOW() - INTERVAL '50 days')
 """
 
 Q_DEACTIVATE = """

--- a/test/functionality1/cron-autodeactivate2.sh
+++ b/test/functionality1/cron-autodeactivate2.sh
@@ -100,9 +100,9 @@ do_test () {
   local user4uuid=$(get_uuid 'will-remain-active3@duolicious.app')
 
   local  days_ago_0=$(db_now as-seconds)
-  local  days_ago_1=$(db_now as-seconds '-  1 days')
-  local  days_ago_2=$(db_now as-seconds '-  9 days')
-  local  days_ago_3=$(db_now as-seconds '- 11 days')
+  local  days_ago_1=$(db_now as-seconds '- 11   days')
+  local  days_ago_2=$(db_now as-seconds '- 21   days')
+  local  days_ago_3=$(db_now as-seconds '- 31   days')
 
   delete_emails
 


### PR DESCRIPTION
I'm increasing the deactivation window to 30 days as https://github.com/duolicious/duolicious-frontend/issues/710 and https://github.com/duolicious/duolicious-frontend/issues/709 started getting reported fairly frequently after tightening the deactivation window.

Active users seems to have fallen more rapidly in the days after the autodeactivation window was tightened.

The percentage of verified users has increased, which might sound like a good thing, but I think this is because they tend to be more enthusiastic users than unverified users, and therefore less likely to leave when the app is misbehaving. Unverified users are a canary in a coal mine.