### PR TITLE
Reduce rate limit for photo verified users to 40

### DIFF
--- a/service/chat/ratelimit/__init__.py
+++ b/service/chat/ratelimit/__init__.py
@@ -7,7 +7,7 @@ class DefaultRateLimit(Enum):
     NONE = 0
     UNVERIFIED = 10
     BASICS = 20
-    PHOTOS = 50
+    PHOTOS = 40
 
 
 Q_RATE_LIMIT_REASON = f"""

--- a/service/chat/ratelimit/test_init.py
+++ b/service/chat/ratelimit/test_init.py
@@ -21,20 +21,20 @@ def make_row(**overrides):
 
 class TestRateLimit(unittest.TestCase):
     # ──────────────────────────────────────────────────────────────
-    #  PHOTOS default (verification_level_id = 3, value = 50)
+    #  PHOTOS default (verification_level_id = 3, value = 40)
     # ──────────────────────────────────────────────────────────────
     def test_photos_default_normal(self):
         """
-        recent_manual_report_count = 0 ⇒ limit = 50
+        recent_manual_report_count = 0 ⇒ limit = 40
         """
         self.assertEqual(
             get_default_rate_limit(make_row(
-                verification_level_id=3, daily_message_count=49)),
+                verification_level_id=3, daily_message_count=40 - 1)),
             DefaultRateLimit.NONE,
         )
         self.assertEqual(
             get_default_rate_limit(make_row(
-                verification_level_id=3, daily_message_count=50)),
+                verification_level_id=3, daily_message_count=40)),
             DefaultRateLimit.PHOTOS,
         )
         self.assertEqual(
@@ -132,10 +132,10 @@ class TestRateLimit(unittest.TestCase):
                 verification_level_id=2, recent_manual_report_count=5)),
             DefaultRateLimit.PHOTOS,
         )
-        # PHOTOS: 50 // 2**7 = 0
+        # PHOTOS: 40 // 2**6 = 0
         self.assertEqual(
             get_default_rate_limit(make_row(
-                verification_level_id=3, recent_manual_report_count=7)),
+                verification_level_id=3, recent_manual_report_count=6)),
             DefaultRateLimit.PHOTOS,
         )
 
@@ -144,16 +144,16 @@ class TestRateLimit(unittest.TestCase):
     # ──────────────────────────────────────────────────────────────
     def test_rude_messages_reduce_limit(self):
         """
-        verification_level_id = 3 (PHOTOS, value 50)
+        verification_level_id = 3 (PHOTOS, value 40)
         recent_rude_message_count = 2 → adds ⌊2 / 2⌋ = 1 to the exponent
-        → limit = 50 // 2 = 25
+        → limit = 40 // 2 = 20
         """
         # One message below the new limit
         self.assertEqual(
             get_default_rate_limit(make_row(
                 verification_level_id=3,
                 recent_rude_message_count=2,
-                daily_message_count=24)),
+                daily_message_count=40 / 2 - 1)),
             DefaultRateLimit.NONE,
         )
         # At the limit (and beyond) we are rate-limited
@@ -161,7 +161,7 @@ class TestRateLimit(unittest.TestCase):
             get_default_rate_limit(make_row(
                 verification_level_id=3,
                 recent_rude_message_count=2,
-                daily_message_count=25)),
+                daily_message_count=40 / 2)),
             DefaultRateLimit.PHOTOS,
         )
 

--- a/test/functionality4/xmpp-rate-limit.sh
+++ b/test/functionality4/xmpp-rate-limit.sh
@@ -284,6 +284,6 @@ test_rate_limit \
 
 # Test base limit
 test_rate_limit \
-  50 \
+  40 \
   3 \
   '<duo_message_blocked id="id999" reason="rate-limited-1day"/>'


### PR DESCRIPTION
I'm hoping this improves the experience for most men and women by reducing the number of low quality messages women receive and therefore the number of replies men get. I might also try reducing this further, to just 30 messages.