### PR TITLE
Account for days per month in kofi donation logic

### DIFF
--- a/service/person/sql/__init__.py
+++ b/service/person/sql/__init__.py
@@ -2775,12 +2775,18 @@ FROM
 """
 
 Q_KOFI_DONATION = """
+WITH days_per_month AS (
+    SELECT (date_trunc('month', current_date) + interval '1 month')
+         -  date_trunc('month', current_date) AS dpm
+)
 UPDATE
     funding
 SET
     estimated_end_date
         = estimated_end_date
-        + interval '28 days' * %(amount)s / cost_per_month_usd
+        + dpm * %(amount)s / cost_per_month_usd
+FROM
+    days_per_month
 WHERE
     token_hash = %(token_hash)s
 """

--- a/test/functionality1/kofi-donation.sh
+++ b/test/functionality1/kofi-donation.sh
@@ -48,6 +48,6 @@ SESSION_TOKEN="" c \
   --data-urlencode 'data={"verification_token":"valid-token","message_id":"8d737342-2311-429f-b920-f6e98cde402e","timestamp":"2024-12-26T12:32:57Z","type":"Donation","is_public":true,"from_name":"Jo Example","message":"Good luck with the integration!","amount":"50.00","url":"https://ko-fi.com/Home/CoffeeShop?txid=00000000-1111-2222-3333-444444444444","email":"jo.example@example.com","currency":"USD","is_subscription_payment":false,"is_first_subscription_payment":false,"kofi_transaction_id":"00000000-1111-2222-3333-444444444444","shop_items":null,"tier_name":null,"shipping":null}'
 
 actual=$(q "select estimated_end_date from funding")
-expected='2024-10-01 15:02:10.866'
+expected='2024-10-03 03:02:10.866'
 
 diff <(echo "$actual") <(echo "$expected")


### PR DESCRIPTION
This PR makes the countdown timer in Duolicious more accurately match the goal as stated on Ko-fi. There's a trade-off here: The logic won't reflect the funds needed if some of Duolicious' providers bill by calendar month and others bill on a 28-day cycle.