### PR TITLE
Fancier feed ranking

### DIFF
--- a/service/search/sql/__init__.py
+++ b/service/search/sql/__init__.py
@@ -1159,22 +1159,7 @@ SELECT
         'is_verified', is_verified,
         'time', time,
         'type', type,
-        'match_percentage', match_percentage,
-
-        'costs', jsonb_build_object(
-            'verification_cost', verification_cost,
-            'incoming_message_cost', incoming_message_cost,
-            'age_gap_cost', age_gap_cost,
-            'match_cost', match_cost,
-            'prospect_gender_preference_cost', prospect_gender_preference_cost,
-            'searcher_gender_preference_cost', searcher_gender_preference_cost,
-            'mutual_club_cost', mutual_club_cost,
-            'club_cost', club_cost,
-            'about_length_cost', about_length_cost,
-            'photo_count_cost', photo_count_cost,
-            'animation_count_cost', animation_count_cost,
-            'distance_cost', distance_cost
-        )
+        'match_percentage', match_percentage
     ) || last_event_data AS j
 FROM
     ranked_person_data


### PR DESCRIPTION
The point of this PR is to promote content people want to see in the feed (and de-promote content users don't want to see, like bot accounts). The purpose of the feed skews more heavily toward engagement than the search and Q&A features do, which focus more on compatibility.