### PR TITLE
Fix FireHOL list download

### DIFF
--- a/antiabuse/firehol/__init__.py
+++ b/antiabuse/firehol/__init__.py
@@ -26,7 +26,7 @@ import traceback
 from datetime import timedelta
 from pathlib import Path
 from typing import Dict, Iterable, Tuple, Union
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 import threading
 
 # ---------------------------------------------------------------------------
@@ -155,7 +155,8 @@ def _download_or_load(name: ListName, update_interval: timedelta) -> str:
         # Cache miss or stale – download
         url = _blocklist_url(name)
         print(f'Downloading {url}')
-        with urlopen(url, timeout=30) as resp:
+        request = Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urlopen(request, timeout=30) as resp:
             raw_bytes = resp.read()
         print(f'Finished downloading {url}')
         text = raw_bytes.decode("utf-8", errors="ignore")

--- a/antiabuse/firehol/__init__.py
+++ b/antiabuse/firehol/__init__.py
@@ -7,11 +7,10 @@ multiprocessing-based implementation, we can set a timeout for those pauses, and
 have them only occur for only some HTTP endpoints. With the threading-based
 alternative, *all* HTTP endpoints freeze while the definitions update.
 
-This module was was mostly vibe-coded. (Highly self-contained modules with very
-small public-facing interfaces like this one are fun to write with LLMs.) Tbh,
-I didn't check the correctness of the trie implementation but the logic LGTM
-otherwise.
-
+Prefix lookups are backed by `pytricia`, a C-implemented Patricia trie. Each
+prefix in the trie maps to a `frozenset` of FireHOL list names that contain it,
+and `matches()` walks the parent chain so that *every* covering prefix
+contributes its list names (not just the longest match).
 """
 
 import contextlib
@@ -29,13 +28,14 @@ from typing import Dict, Iterable, Tuple, Union
 from urllib.request import Request, urlopen
 import threading
 
+import pytricia
+
 # ---------------------------------------------------------------------------
 # Type aliases
 # ---------------------------------------------------------------------------
 
 ListName = str
 IPAddress = Union[str, ipaddress.IPv4Address, ipaddress.IPv6Address]
-IPvXNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 IPvXAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 
 # ---------------------------------------------------------------------------
@@ -55,12 +55,10 @@ def _blocklist_url(name: ListName) -> str:
     return f"https://iplists.firehol.org/files/{name}"
 
 
-def _parse_blocklist(
-    text: str,
-) -> Tuple[list[ipaddress.IPv4Network], list[ipaddress.IPv6Network]]:
-    """Convert raw *netset* text to IPv4 and IPv6 network lists."""
-    v4: list[ipaddress.IPv4Network] = []
-    v6: list[ipaddress.IPv6Network] = []
+def _parse_blocklist(text: str) -> Tuple[list[str], list[str]]:
+    """Convert raw *netset* text to IPv4 and IPv6 prefix-string lists."""
+    v4: list[str] = []
+    v6: list[str] = []
 
     for line in text.splitlines():
         # Skip comments / blank lines quickly
@@ -75,9 +73,9 @@ def _parse_blocklist(
             continue
 
         if isinstance(net, ipaddress.IPv4Network):
-            v4.append(net)
+            v4.append(net.with_prefixlen)
         elif isinstance(net, ipaddress.IPv6Network):
-            v6.append(net)
+            v6.append(net.with_prefixlen)
 
     return v4, v6
 
@@ -95,43 +93,43 @@ def _exclusive_lock(path: Path):
 
 
 # --------------------------------------------------------------------------
-# Tiny radix-trie for IPv4/IPv6 prefixes
+# Patricia-trie wrapper around `pytricia`
 # --------------------------------------------------------------------------
 
-class _TrieNode:
-    __slots__ = ("child", "lists")
+class _PrefixTrie:
+    """Thin wrapper that maps IP prefixes -> {list_name, ...}.
 
-    def __init__(self) -> None:
-        self.child: list[_TrieNode | None] = [None, None]  # bit 0 / bit 1
-        self.lists: set[ListName] = set()
+    pytricia stores at most one value per prefix, so when several FireHOL lists
+    contain the same prefix we stash the union in a `frozenset`. `search()`
+    walks the longest-match parent chain so every covering prefix contributes
+    its list names (matching the previous radix-trie behaviour).
+    """
 
+    def __init__(self, max_prefixlen: int) -> None:
+        self._pyt = pytricia.PyTricia(max_prefixlen)
 
-class _Trie:
-    def __init__(self):
-        self.root = _TrieNode()
+    def insert(self, prefix: str, list_name: ListName) -> None:
+        existing = self._pyt.get(prefix)
+        if existing is None:
+            self._pyt[prefix] = frozenset((list_name,))
+        elif list_name not in existing:
+            self._pyt[prefix] = existing | {list_name}
 
-    # insert a network and remember which list it came from
-    def insert(self, net: IPvXNetwork, list_name: ListName) -> None:
-        node = self.root
-        for bit in range(net.prefixlen):
-            b = (int(net.network_address) >> (net.max_prefixlen - 1 - bit)) & 1
-            if node.child[b] is None:
-                node.child[b] = _TrieNode()
-            node = node.child[b]
-        node.lists.add(list_name)
-
-    # walk the bits of an address, collecting all matching lists
     def search(self, addr: IPvXAddress) -> list[ListName]:
-        node, found = self.root, set()
-        for bit in range(addr.max_prefixlen):
-            if node.lists:
-                found.update(node.lists)
-            b = (int(addr) >> (addr.max_prefixlen - 1 - bit)) & 1
-            node = node.child[b]
-            if node is None:
-                break
-        if node and node.lists:
-            found.update(node.lists)
+        addr_str = str(addr)
+        try:
+            key = self._pyt.get_key(addr_str)
+        except (KeyError, ValueError):
+            return []
+        if key is None:
+            return []
+
+        found: set[ListName] = set()
+        while key is not None:
+            value = self._pyt.get(key)
+            if value:
+                found.update(value)
+            key = self._pyt.parent(key)
         return list(found)
 
 
@@ -169,15 +167,12 @@ def _download_or_load(name: ListName, update_interval: timedelta) -> str:
         return text
 
 
-def _collect_all(lists: Iterable[ListName],
-                 update_interval: timedelta
-                 ) -> Dict[ListName, Tuple[
-                     list[ipaddress.IPv4Network], list[ipaddress.IPv6Network]
-                 ]]:
-    """Download / load every configured list, return dict(name → nets)."""
-    fresh: Dict[ListName, Tuple[
-        list[ipaddress.IPv4Network], list[ipaddress.IPv6Network]
-    ]] = {}
+def _collect_all(
+    lists: Iterable[ListName],
+    update_interval: timedelta,
+) -> Dict[ListName, Tuple[list[str], list[str]]]:
+    """Download / load every configured list, return dict(name → prefixes)."""
+    fresh: Dict[ListName, Tuple[list[str], list[str]]] = {}
 
     for name in lists:
         raw = _download_or_load(name, update_interval)
@@ -189,16 +184,16 @@ def _collect_all(lists: Iterable[ListName],
     return fresh
 
 
-def _build_tries(data: Dict[ListName, Tuple[
-        list[ipaddress.IPv4Network], list[ipaddress.IPv6Network]
-        ]]) -> tuple[_Trie, _Trie]:
-    v4_trie = _Trie()
-    v6_trie = _Trie()
+def _build_tries(
+    data: Dict[ListName, Tuple[list[str], list[str]]],
+) -> tuple[_PrefixTrie, _PrefixTrie]:
+    v4_trie = _PrefixTrie(32)
+    v6_trie = _PrefixTrie(128)
     for name, (v4, v6) in data.items():
-        for v4net in v4:
-            v4_trie.insert(v4net, name)
-        for v6net in v6:
-            v6_trie.insert(v6net, name)
+        for prefix in v4:
+            v4_trie.insert(prefix, name)
+        for prefix in v6:
+            v6_trie.insert(prefix, name)
     return v4_trie, v6_trie
 
 
@@ -212,7 +207,7 @@ def _worker_main(conn: mp.connection.Connection,
     """Run in a dedicated process: refresh lists & answer match queries."""
     jitter = random.uniform(0.0, 10.0)
     next_refresh = 0.0
-    tries: tuple[_Trie, _Trie] | None = None
+    tries: tuple[_PrefixTrie, _PrefixTrie] | None = None
     refreshing = False # at most one refresh at a time
 
     def _async_refresh():

--- a/antiabuse/firehol/test_init.py
+++ b/antiabuse/firehol/test_init.py
@@ -1,24 +1,26 @@
 """
-Tests for antiabuse.firehol – updated for the 2025 refactor that moved all
-download / cache helpers out of the Firehol class and into module-level
-functions.
+Tests for antiabuse.firehol – updated for the pytricia-backed refactor.
+
+The radix-trie implementation has been replaced by `pytricia.PyTricia`, wrapped
+by `_PrefixTrie`. `_parse_blocklist` now yields CIDR-string prefixes (e.g.
+"1.2.3.0/24") rather than `ipaddress.IPvXNetwork` objects, since pytricia
+accepts string keys directly.
 """
 
 import ipaddress
-import multiprocessing as mp
 import random
-import time
 import unittest
 from datetime import timedelta
-from typing import Iterable, Tuple
+from typing import Iterable, Tuple, Union
 from unittest.mock import patch
 
 from antiabuse.firehol import (
     Firehol,
     _parse_blocklist,
-    _Trie,
-    IPvXNetwork,
+    _PrefixTrie,
 )
+
+IPvXNetwork = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
 
 # ---------------------------------------------------------------------------
 # Fixture data & helpers
@@ -32,7 +34,7 @@ _SAMPLE_NETSET = """
 bad_line_should_be_ignored
 """
 
-def _fake_download(name: str, _update_interval: timedelta) -> str:   # NEW SIG
+def _fake_download(name: str, _update_interval: timedelta) -> str:
     """Stub that replaces antiabuse.firehol._download_or_load – never hits disk."""
     return _SAMPLE_NETSET
 
@@ -90,9 +92,9 @@ class PatchedFireholMixin(unittest.TestCase):
 class ParseBlocklistTests(unittest.TestCase):
     def test_split_v4_and_v6(self):
         v4, v6 = _parse_blocklist(_SAMPLE_NETSET)
-        self.assertIn(ipaddress.ip_network("1.2.3.0/24"), v4)
-        self.assertIn(ipaddress.ip_network("4.4.4.4/32"), v4)
-        self.assertIn(ipaddress.ip_network("2001:db8::/32"), v6)
+        self.assertIn("1.2.3.0/24", v4)
+        self.assertIn("4.4.4.4/32", v4)
+        self.assertIn("2001:db8::/32", v6)
         self.assertEqual((len(v4), len(v6)), (2, 1))
 
 
@@ -127,41 +129,71 @@ class ConstructorGuardTests(unittest.TestCase):
             Firehol([])
 
 
-class TrieTests(unittest.TestCase):
-    trie: _Trie
+class PrefixTrieTests(unittest.TestCase):
+    """Random-network sanity checks for the pytricia-backed `_PrefixTrie`."""
+
+    v4_trie: _PrefixTrie
+    v6_trie: _PrefixTrie
     lookup_table: dict[IPvXNetwork, str]
 
     @classmethod
     def setUpClass(cls):
         random.seed(0xF1EE)
-        cls.trie = _Trie()
+        cls.v4_trie = _PrefixTrie(32)
+        cls.v6_trie = _PrefixTrie(128)
         cls.lookup_table = {}
         for family, count in (("v4", 1000), ("v6", 1000)):
             for _ in range(count):
                 net, name = cls._make_random_network(family)
-                cls.trie.insert(net, name)
+                trie = cls.v4_trie if family == "v4" else cls.v6_trie
+                trie.insert(net.with_prefixlen, name)
                 cls.lookup_table[net] = name
 
     @staticmethod
     def _make_random_network(family: str) -> Tuple[IPvXNetwork, str]:
-        addr: ipaddress.IPv4Address | ipaddress.IPv6Address
         if family == "v4":
-            addr = ipaddress.IPv4Address(random.getrandbits(32))
+            addr_v4 = ipaddress.IPv4Address(random.getrandbits(32))
             prefix = random.randint(8, 32)
+            net: IPvXNetwork = ipaddress.ip_network(
+                (addr_v4, prefix), strict=False
+            )
+            return net, f"list_v4_{addr_v4}_{prefix}"
         else:
-            addr = ipaddress.IPv6Address(random.getrandbits(128))
+            addr_v6 = ipaddress.IPv6Address(random.getrandbits(128))
             prefix = random.randint(16, 128)
-        net = ipaddress.ip_network((addr, prefix), strict=False)
-        return net, f"list_{family}_{addr}_{prefix}"
+            net = ipaddress.ip_network((addr_v6, prefix), strict=False)
+            return net, f"list_v6_{addr_v6}_{prefix}"
+
+    def _trie_for(self, net: IPvXNetwork) -> _PrefixTrie:
+        return self.v4_trie if isinstance(net, ipaddress.IPv4Network) else self.v6_trie
 
     def test_all_positive_matches(self):
         for net, expected in self.lookup_table.items():
+            trie = self._trie_for(net)
             for addr in _sample_addresses(net):
                 with self.subTest(addr=str(addr), net=str(net)):
-                    self.assertIn(expected, self.trie.search(addr))
+                    self.assertIn(expected, trie.search(addr))
 
     def test_no_false_positives(self):
         for net, list_name in self.lookup_table.items():
+            trie = self._trie_for(net)
             addr = _address_outside(net)
             with self.subTest(addr=str(addr), net=str(net)):
-                self.assertNotIn(list_name, self.trie.search(addr))
+                self.assertNotIn(list_name, trie.search(addr))
+
+    def test_multiple_lists_per_prefix(self):
+        """A prefix shared by several lists returns *all* of them."""
+        trie = _PrefixTrie(32)
+        trie.insert("10.0.0.0/8", "list_a")
+        trie.insert("10.0.0.0/8", "list_b")
+        trie.insert("10.1.0.0/16", "list_c")
+        result = sorted(trie.search(ipaddress.IPv4Address("10.1.2.3")))
+        self.assertEqual(result, ["list_a", "list_b", "list_c"])
+
+    def test_empty_trie_returns_empty_list(self):
+        trie = _PrefixTrie(32)
+        self.assertEqual(trie.search(ipaddress.IPv4Address("8.8.8.8")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -170,16 +170,6 @@ services:
       - "1025:1025"
       - "8025:8025"
 
-  pgadmin:
-    image: dpage/pgadmin4:7.3
-
-    ports:
-      - "8090:80"
-
-    environment:
-      PGADMIN_DEFAULT_EMAIL: user@example.com
-      PGADMIN_DEFAULT_PASSWORD: password
-
   chattest:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,16 +176,6 @@ services:
       - "1025:1025"
       - "8025:8025"
 
-  pgadmin:
-    image: dpage/pgadmin4:7.3
-
-    ports:
-      - "8090:80"
-
-    environment:
-      PGADMIN_DEFAULT_EMAIL: user@example.com
-      PGADMIN_DEFAULT_PASSWORD: password
-
   chattest:
     build:
       context: .

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,3 +10,6 @@ ignore_missing_imports = True
 
 [mypy-pillow_heif]
 ignore_missing_imports = True
+
+[mypy-pytricia]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ Pillow
 pillow-heif
 psycopg[binary]
 pydantic[email]
+pytricia
 PyYAML
 redis
 regex


### PR DESCRIPTION
FireHOL has started attempting to block scripted downloads. I don't know why. That's their main use case.

```
api-1       | Downloading https://iplists.firehol.org/files/firehol_abusers_30d.netset
api-1       | Exception in thread Thread-140 (_async_refresh):
api-1       | Traceback (most recent call last):
api-1       |   File "/usr/local/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
api-1       |     self.run()
api-1       |   File "/usr/local/lib/python3.11/threading.py", line 982, in run
api-1       |     self._target(*self._args, **self._kwargs)
api-1       |   File "/app/antiabuse/firehol/__init__.py", line 224, in _async_refresh
api-1       |     try:
api-1       |          
api-1       |   File "/app/antiabuse/firehol/__init__.py", line 182, in _collect_all
api-1       |     for name in lists:
api-1       |               ^^^^^^^^^
api-1       |   File "/app/antiabuse/firehol/__init__.py", line 158, in _download_or_load
api-1       |     request = Request(url, headers={"User-Agent": "Mozilla/5.0"})
api-1       |          ^^^^^^^^^^^^^^^^^^^^^^^^
api-1       |   File "/usr/local/lib/python3.11/urllib/request.py", line 216, in urlopen
api-1       |     return opener.open(url, data, timeout)
api-1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
api-1       |   File "/usr/local/lib/python3.11/urllib/request.py", line 525, in open
api-1       |     response = meth(req, response)
api-1       |                ^^^^^^^^^^^^^^^^^^^
api-1       |   File "/usr/local/lib/python3.11/urllib/request.py", line 634, in http_response
api-1       |     response = self.parent.error(
api-1       |                ^^^^^^^^^^^^^^^^^^
api-1       |   File "/usr/local/lib/python3.11/urllib/request.py", line 563, in error
api-1       |     return self._call_chain(*args)
api-1       |            ^^^^^^^^^^^^^^^^^^^^^^^
api-1       |   File "/usr/local/lib/python3.11/urllib/request.py", line 496, in _call_chain
api-1       |     result = func(*args)
api-1       |              ^^^^^^^^^^^
api-1       |   File "/usr/local/lib/python3.11/urllib/request.py", line 643, in http_error_default
api-1       |     raise HTTPError(req.full_url, code, msg, hdrs, fp)
api-1       | urllib.error.HTTPError: HTTP Error 403: Forbidden
```

I also had to reduce the memory usage of the app in this PR. It was running out of memory and killing GitHub's agents/runners. Most the savings are by switching from a pure Python trie to pytricia. Removing pgadmin helped a little too.