### PR TITLE
Sign in with Apple/Google

### DIFF
--- a/antiabuse/antispam/signupemail/__init__.py
+++ b/antiabuse/antispam/signupemail/__init__.py
@@ -49,8 +49,13 @@ def check_and_update_bad_domains(email):
     else:
         raise Exception('Unhandled domain status')
 
+
+def normalize_email_case(email: str) -> str:
+    return email.lower()
+
+
 def normalize_email_dots(email: str) -> str:
-    name, domain = email.lower().split('@')
+    name, domain = email.split('@')
 
     if domain not in dot_insignificant_email_domains:
         return email
@@ -59,8 +64,9 @@ def normalize_email_dots(email: str) -> str:
 
     return f'{name}@{domain}'
 
+
 def normalize_email_pluses(email: str) -> str:
-    name, domain = email.lower().split('@')
+    name, domain = email.split('@')
 
     if domain not in plus_address_domains:
         return email
@@ -70,7 +76,7 @@ def normalize_email_pluses(email: str) -> str:
     return f'{name}@{domain}'
 
 def normalize_email_domain(email: str) -> str:
-    name, domain = email.lower().split('@')
+    name, domain = email.split('@')
 
     if domain != 'googlemail.com':
         return email
@@ -79,6 +85,10 @@ def normalize_email_domain(email: str) -> str:
 
 
 def normalize_email(email: str) -> str:
+    if not email:
+        return ''
+
+    email = normalize_email_case(email)
     email = normalize_email_dots(email)
     email = normalize_email_pluses(email)
     email = normalize_email_domain(email)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -67,6 +67,11 @@ services:
       # which is fine because the functional tests use the OTP flow.
       DUO_GOOGLE_CLIENT_IDS: test-dummy.apps.googleusercontent.com
       DUO_APPLE_CLIENT_IDS: app.duolicious,app.duolicious.web
+      # Where /auth/apple/callback redirects the user after a web/Android
+      # Apple sign-in. Test values can be any URL — the callback test
+      # only asserts on the redirect Location header.
+      DUO_APPLE_WEB_REDIRECT_URL: http://test-web.example/
+      DUO_APPLE_ANDROID_REDIRECT_URL: http://test-android.example/
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
       interval: 30s

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -61,6 +61,12 @@ services:
       DUO_R2_ACCESS_KEY_SECRET: s3-mock-secret-access-key-secret
 
       DUO_BOTO_ENDPOINT_URL: http://s3mock:9090
+
+      # Social-login OAuth audiences. Dummy values let the API boot;
+      # any real /sign-in-with-* call will fail token verification,
+      # which is fine because the functional tests use the OTP flow.
+      DUO_GOOGLE_CLIENT_IDS: test-dummy.apps.googleusercontent.com
+      DUO_APPLE_CLIENT_IDS: app.duolicious,app.duolicious.web
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,11 +70,11 @@ services:
       # Console / Apple Developer Portal in production; dummy values let
       # the API boot in dev without crashing on missing config. Any
       # actual /sign-in-with-* call will fail token verification.
-      DUO_GOOGLE_CLIENT_IDS: dev-dummy.apps.googleusercontent.com
+      DUO_GOOGLE_CLIENT_IDS: 443037492722-n1lcbdqe2u49ev56b1tv6m087a9muhsd.apps.googleusercontent.com
       DUO_APPLE_CLIENT_IDS: app.duolicious,app.duolicious.web
       # Where /auth/apple/callback redirects the user after a web/Android
       # Apple sign-in. See service/auth/apple_oauth.py.
-      DUO_APPLE_WEB_REDIRECT_URL: http://localhost:19006/
+      DUO_APPLE_WEB_REDIRECT_URL: http://localhost:8081/
       DUO_APPLE_ANDROID_REDIRECT_URL: https://get.duolicious.app/
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       DUO_APPLE_CLIENT_IDS: app.duolicious,app.duolicious.web
       # Where /auth/apple/callback redirects the user after a web/Android
       # Apple sign-in. See service/auth/apple_oauth.py.
-      DUO_APPLE_WEB_REDIRECT_URL: http://localhost:8081/
+      DUO_APPLE_WEB_REDIRECT_URL: http://web.duolicious.app/
       DUO_APPLE_ANDROID_REDIRECT_URL: https://get.duolicious.app/
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,13 @@ services:
       DUO_R2_ACCESS_KEY_SECRET: s3-mock-secret-access-key-secret
 
       DUO_BOTO_ENDPOINT_URL: http://s3mock:9090
+
+      # Social-login OAuth audiences. Real values come from Google Cloud
+      # Console / Apple Developer Portal in production; dummy values let
+      # the API boot in dev without crashing on missing config. Any
+      # actual /sign-in-with-* call will fail token verification.
+      DUO_GOOGLE_CLIENT_IDS: dev-dummy.apps.googleusercontent.com
+      DUO_APPLE_CLIENT_IDS: app.duolicious,app.duolicious.web
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,10 @@ services:
       # actual /sign-in-with-* call will fail token verification.
       DUO_GOOGLE_CLIENT_IDS: dev-dummy.apps.googleusercontent.com
       DUO_APPLE_CLIENT_IDS: app.duolicious,app.duolicious.web
+      # Where /auth/apple/callback redirects the user after a web/Android
+      # Apple sign-in. See service/auth/apple_oauth.py.
+      DUO_APPLE_WEB_REDIRECT_URL: http://localhost:19006/
+      DUO_APPLE_ANDROID_REDIRECT_URL: https://get.duolicious.app/
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
       interval: 30s

--- a/duotypes/__init__.py
+++ b/duotypes/__init__.py
@@ -305,6 +305,11 @@ class PostSignInWithGoogle(BaseModel):
 class PostSignInWithApple(BaseModel):
     # Apple identity token (a JWT). Verified server-side against Apple's JWKS.
     identity_token: str = Field(min_length=1, max_length=4096)
+    # Random hex string the client passed to Apple as the `nonce` parameter
+    # (native `signInAsync({ nonce })` on iOS, `&nonce=` URL param on
+    # web/Android). Apple echoes it verbatim into the JWT's `nonce` claim;
+    # the backend compares the two to bind the token to this client session.
+    nonce: str = Field(min_length=16, max_length=128, pattern=r'^[a-zA-Z0-9_-]+$')
     pending_club_name: PendingClubName = Field(
         default=None,
         pattern=CLUB_PATTERN,

--- a/duotypes/__init__.py
+++ b/duotypes/__init__.py
@@ -11,6 +11,7 @@ from typing import (
 )
 from pydantic import (
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     EmailStr,
     Field,
@@ -44,6 +45,22 @@ register_heif_opener()
 
 CLUB_PATTERN = r"""^[a-zA-Z0-9/#'"_-]+( [a-zA-Z0-9/#'"_-]+)*$"""
 CLUB_MAX_LEN = 42
+
+
+def _normalize_pending_club_name(value):
+    if value is None:
+        return value
+    return value.lower().strip()
+
+
+# `pending_club_name` is sent by the client when the user is signing in
+# *into* a pending club invite. Used by /request-otp,
+# /sign-in-with-google, /sign-in-with-apple — all three normalize the
+# name the same way before pydantic's pattern/length validation runs.
+PendingClubName = Annotated[
+    Optional[str],
+    BeforeValidator(_normalize_pending_club_name),
+]
 
 HEX_COLOR_PATTERN = r"^#[0-9a-fA-F]{6}$"
 
@@ -258,7 +275,7 @@ class DeleteAnswer(BaseModel):
 
 class PostRequestOtp(BaseModel):
     email: EmailStr
-    pending_club_name: Optional[str] = Field(
+    pending_club_name: PendingClubName = Field(
         default=None,
         pattern=CLUB_PATTERN,
         min_length=1,
@@ -269,10 +286,6 @@ class PostRequestOtp(BaseModel):
     def validate_email(cls, value):
         return EmailStr._validate(value.lower().strip())
 
-    @field_validator('pending_club_name', mode='before')
-    def validate_pending_club_name(cls, value):
-        return value.lower().strip()
-
 
 class PostCheckOtp(BaseModel):
     otp: str = Field(pattern=r"^\d{6}$")
@@ -281,35 +294,23 @@ class PostCheckOtp(BaseModel):
 class PostSignInWithGoogle(BaseModel):
     # Google ID token (a JWT). Verified server-side against Google's JWKS.
     id_token: str = Field(min_length=1, max_length=4096)
-    pending_club_name: Optional[str] = Field(
+    pending_club_name: PendingClubName = Field(
         default=None,
         pattern=CLUB_PATTERN,
         min_length=1,
         max_length=CLUB_MAX_LEN,
     )
-
-    @field_validator('pending_club_name', mode='before')
-    def validate_pending_club_name(cls, value):
-        if value is None:
-            return value
-        return value.lower().strip()
 
 
 class PostSignInWithApple(BaseModel):
     # Apple identity token (a JWT). Verified server-side against Apple's JWKS.
     identity_token: str = Field(min_length=1, max_length=4096)
-    pending_club_name: Optional[str] = Field(
+    pending_club_name: PendingClubName = Field(
         default=None,
         pattern=CLUB_PATTERN,
         min_length=1,
         max_length=CLUB_MAX_LEN,
     )
-
-    @field_validator('pending_club_name', mode='before')
-    def validate_pending_club_name(cls, value):
-        if value is None:
-            return value
-        return value.lower().strip()
 
 
 class PatchOnboardeeInfo(BaseModel):

--- a/duotypes/__init__.py
+++ b/duotypes/__init__.py
@@ -278,6 +278,40 @@ class PostCheckOtp(BaseModel):
     otp: str = Field(pattern=r"^\d{6}$")
 
 
+class PostSignInWithGoogle(BaseModel):
+    # Google ID token (a JWT). Verified server-side against Google's JWKS.
+    id_token: str = Field(min_length=1, max_length=4096)
+    pending_club_name: Optional[str] = Field(
+        default=None,
+        pattern=CLUB_PATTERN,
+        min_length=1,
+        max_length=CLUB_MAX_LEN,
+    )
+
+    @field_validator('pending_club_name', mode='before')
+    def validate_pending_club_name(cls, value):
+        if value is None:
+            return value
+        return value.lower().strip()
+
+
+class PostSignInWithApple(BaseModel):
+    # Apple identity token (a JWT). Verified server-side against Apple's JWKS.
+    identity_token: str = Field(min_length=1, max_length=4096)
+    pending_club_name: Optional[str] = Field(
+        default=None,
+        pattern=CLUB_PATTERN,
+        min_length=1,
+        max_length=CLUB_MAX_LEN,
+    )
+
+    @field_validator('pending_club_name', mode='before')
+    def validate_pending_club_name(cls, value):
+        if value is None:
+            return value
+        return value.lower().strip()
+
+
 class PatchOnboardeeInfo(BaseModel):
     name: Optional[str] = Field(
         default=None,

--- a/duotypes/__init__.py
+++ b/duotypes/__init__.py
@@ -47,6 +47,10 @@ CLUB_PATTERN = r"""^[a-zA-Z0-9/#'"_-]+( [a-zA-Z0-9/#'"_-]+)*$"""
 CLUB_MAX_LEN = 42
 
 
+def _normalize_email_input(value: str) -> str:
+    return value.lower().strip() if value else ''
+
+
 def _normalize_pending_club_name(value):
     if value is None:
         return value
@@ -284,7 +288,7 @@ class PostRequestOtp(BaseModel):
 
     @field_validator('email', mode='before')
     def validate_email(cls, value):
-        return EmailStr._validate(value.lower().strip())
+        return EmailStr._validate(_normalize_email_input(value))
 
 
 class PostCheckOtp(BaseModel):
@@ -316,6 +320,16 @@ class PostSignInWithApple(BaseModel):
         min_length=1,
         max_length=CLUB_MAX_LEN,
     )
+
+
+class SocialClaims(BaseModel):
+    sub: str
+    email: str
+    email_verified: bool
+
+    @field_validator('email', mode='before')
+    def validate_email(cls, value):
+        return _normalize_email_input(value)
 
 
 class PatchOnboardeeInfo(BaseModel):

--- a/init-api.sql
+++ b/init-api.sql
@@ -394,13 +394,35 @@ CREATE TABLE IF NOT EXISTS duo_session (
     person_id INT REFERENCES person(id) ON DELETE CASCADE ON UPDATE CASCADE,
     email TEXT NOT NULL,
     pending_club_name TEXT,
-    otp TEXT NOT NULL,
+    otp TEXT,
     ip_address inet,
     signed_in BOOLEAN NOT NULL DEFAULT FALSE,
     session_expiry TIMESTAMP NOT NULL DEFAULT (NOW() + INTERVAL '6 months'),
     otp_expiry TIMESTAMP NOT NULL DEFAULT (NOW() + INTERVAL '10 minutes'),
+    -- For new-user social sign-ins (Google / Apple) where an `onboardee`
+    -- exists but no `person` yet. On `/finish-onboarding`, these get promoted
+    -- to a row in `social_identity` linked to the new person.
+    pending_social_provider TEXT,
+    pending_social_sub TEXT,
     PRIMARY KEY (session_token_hash)
 );
+
+CREATE TABLE IF NOT EXISTS social_identity (
+    -- 'google' | 'apple'
+    provider TEXT NOT NULL,
+    -- Stable, opaque user id from the provider (Google `sub`, Apple `sub`).
+    -- Source of truth for identity; emails can change (esp. Apple relay).
+    provider_sub TEXT NOT NULL,
+    person_id INT NOT NULL REFERENCES person(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    -- Whatever email the provider reported at link time, for diagnostics only.
+    -- May be a `@privaterelay.appleid.com` alias.
+    email TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (provider, provider_sub)
+);
+
+CREATE INDEX IF NOT EXISTS social_identity__person_id__idx
+    ON social_identity (person_id);
 
 CREATE TABLE IF NOT EXISTS photo (
     person_id INT NOT NULL REFERENCES person(id) ON DELETE CASCADE ON UPDATE CASCADE,

--- a/migrations.sql
+++ b/migrations.sql
@@ -13,3 +13,24 @@ $$;
 -- "Public Profile" entry in privacy settings.
 ALTER TABLE person
     ADD COLUMN IF NOT EXISTS public_profile BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Social login (Google / Apple) added alongside OTP. Social sessions have
+-- no OTP, so the column must be nullable. The pending_social_* columns
+-- carry the provider identity through onboarding for new users; on
+-- `/finish-onboarding` they get materialized into `social_identity`.
+ALTER TABLE duo_session ALTER COLUMN otp DROP NOT NULL;
+ALTER TABLE duo_session
+    ADD COLUMN IF NOT EXISTS pending_social_provider TEXT,
+    ADD COLUMN IF NOT EXISTS pending_social_sub TEXT;
+
+CREATE TABLE IF NOT EXISTS social_identity (
+    provider TEXT NOT NULL,
+    provider_sub TEXT NOT NULL,
+    person_id INT NOT NULL REFERENCES person(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    email TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (provider, provider_sub)
+);
+
+CREATE INDEX IF NOT EXISTS social_identity__person_id__idx
+    ON social_identity (person_id);

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,3 +13,12 @@ ignore_missing_imports = True
 
 [mypy-pytricia]
 ignore_missing_imports = True
+
+[mypy-jwt]
+ignore_missing_imports = True
+
+[mypy-jwt.*]
+ignore_missing_imports = True
+
+[mypy-google.*]
+ignore_missing_imports = True

--- a/mypy.requirements.txt
+++ b/mypy.requirements.txt
@@ -8,6 +8,7 @@ confusable-homoglyphs
 erlastic
 fastapi
 flask-cors
+google-auth
 gunicorn
 lxml
 lxml-stubs
@@ -20,6 +21,7 @@ openai
 pillow-heif
 psycopg[binary]
 pydantic[email]
+PyJWT[crypto]
 redis
 regex
 types-Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ fastapi
 Flask
 flask-cors
 Flask-Limiter
+google-auth
 gunicorn
 lxml
 nltk
@@ -17,6 +18,7 @@ Pillow
 pillow-heif
 psycopg[binary]
 pydantic[email]
+PyJWT[crypto]
 pytricia
 PyYAML
 redis

--- a/service/api/__init__.py
+++ b/service/api/__init__.py
@@ -218,8 +218,7 @@ def post_sign_in_with_google(req: t.PostSignInWithGoogle):
             scope=scope,
             exempt_when=disable_ip_rate_limit),
     ):
-        return person.post_sign_in_with_provider(
-            provider='google',
+        return person.post_sign_in_with_google(
             token=req.id_token,
             pending_club_name=req.pending_club_name,
         )
@@ -235,9 +234,9 @@ def post_sign_in_with_apple(req: t.PostSignInWithApple):
             scope=scope,
             exempt_when=disable_ip_rate_limit),
     ):
-        return person.post_sign_in_with_provider(
-            provider='apple',
+        return person.post_sign_in_with_apple(
             token=req.identity_token,
+            nonce=req.nonce,
             pending_club_name=req.pending_club_name,
         )
 

--- a/service/api/__init__.py
+++ b/service/api/__init__.py
@@ -207,6 +207,34 @@ def post_check_otp(req: t.PostCheckOtp, s: t.SessionInfo):
     ):
         return person.post_check_otp(req, s)
 
+@post('/sign-in-with-google')
+@validate(t.PostSignInWithGoogle)
+def post_sign_in_with_google(req: t.PostSignInWithGoogle):
+    limit = "40 per day"
+    scope = "social_sign_in"
+
+    with (
+        limiter.limit(
+            limit,
+            scope=scope,
+            exempt_when=disable_ip_rate_limit),
+    ):
+        return person.post_sign_in_with_google(req)
+
+@post('/sign-in-with-apple')
+@validate(t.PostSignInWithApple)
+def post_sign_in_with_apple(req: t.PostSignInWithApple):
+    limit = "40 per day"
+    scope = "social_sign_in"
+
+    with (
+        limiter.limit(
+            limit,
+            scope=scope,
+            exempt_when=disable_ip_rate_limit),
+    ):
+        return person.post_sign_in_with_apple(req)
+
 @apost('/sign-out', expected_onboarding_status=None)
 def post_sign_out(s: t.SessionInfo):
     return person.post_sign_out(s)

--- a/service/api/__init__.py
+++ b/service/api/__init__.py
@@ -218,7 +218,11 @@ def post_sign_in_with_google(req: t.PostSignInWithGoogle):
             scope=scope,
             exempt_when=disable_ip_rate_limit),
     ):
-        return person.post_sign_in_with_google(req)
+        return person.post_sign_in_with_provider(
+            provider='google',
+            token=req.id_token,
+            pending_club_name=req.pending_club_name,
+        )
 
 @post('/sign-in-with-apple')
 @validate(t.PostSignInWithApple)
@@ -231,7 +235,11 @@ def post_sign_in_with_apple(req: t.PostSignInWithApple):
             scope=scope,
             exempt_when=disable_ip_rate_limit),
     ):
-        return person.post_sign_in_with_apple(req)
+        return person.post_sign_in_with_provider(
+            provider='apple',
+            token=req.identity_token,
+            pending_club_name=req.pending_club_name,
+        )
 
 # Apple Sign-In web/Android OAuth callback. Must be a `@post` (not
 # `@apost`) — the request comes from Apple's authorize endpoint as an

--- a/service/api/__init__.py
+++ b/service/api/__init__.py
@@ -8,6 +8,7 @@ from service import (
     question,
     search,
 )
+from service.auth import apple_oauth
 from database import api_tx
 import psycopg
 from service.api.decorators import (
@@ -234,6 +235,27 @@ def post_sign_in_with_apple(req: t.PostSignInWithApple):
             exempt_when=disable_ip_rate_limit),
     ):
         return person.post_sign_in_with_apple(req)
+
+# Apple Sign-In web/Android OAuth callback. Must be a `@post` (not
+# `@apost`) — the request comes from Apple's authorize endpoint as an
+# unauthenticated form_post, with no bearer token. See
+# `service/auth/apple_oauth.py` for the rationale.
+@post('/auth/apple/callback')
+def post_auth_apple_callback():
+    limit = "40 per day"
+    scope = "social_sign_in"
+
+    with (
+        limiter.limit(
+            limit,
+            scope=scope,
+            exempt_when=disable_ip_rate_limit),
+    ):
+        return apple_oauth.handle_callback(
+            id_token=request.form.get('id_token', ''),
+            state=request.form.get('state', ''),
+            error=request.form.get('error'),
+        )
 
 @apost('/sign-out', expected_onboarding_status=None)
 def post_sign_out(s: t.SessionInfo):

--- a/service/api/__init__.py
+++ b/service/api/__init__.py
@@ -18,6 +18,7 @@ from service.api.decorators import (
     apatch,
     apost,
     aput,
+    auth_rate_limit,
     delete,
     get,
     patch,
@@ -160,16 +161,15 @@ def init_db():
 @post('/request-otp', limiter=shared_otp_limit)
 @validate(t.PostRequestOtp)
 def post_request_otp(req: t.PostRequestOtp):
-    limit = "40 per day"
     scope = "request_otp"
 
     with (
         limiter.limit(
-            limit,
+            auth_rate_limit,
             scope=scope,
             exempt_when=disable_ip_rate_limit),
         limiter.limit(
-            limit,
+            auth_rate_limit,
             scope=scope,
             key_func=limiter_account,
             exempt_when=disable_account_rate_limit)
@@ -192,16 +192,15 @@ def post_resend_otp(s: t.SessionInfo):
 )
 @validate(t.PostCheckOtp)
 def post_check_otp(req: t.PostCheckOtp, s: t.SessionInfo):
-    limit = "40 per day"
     scope = "check_otp"
 
     with (
         limiter.limit(
-            limit,
+            auth_rate_limit,
             scope=scope,
             exempt_when=disable_ip_rate_limit),
         limiter.limit(
-            limit,
+            auth_rate_limit,
             scope=scope,
             key_func=limiter_account,
             exempt_when=disable_account_rate_limit)
@@ -211,12 +210,11 @@ def post_check_otp(req: t.PostCheckOtp, s: t.SessionInfo):
 @post('/sign-in-with-google')
 @validate(t.PostSignInWithGoogle)
 def post_sign_in_with_google(req: t.PostSignInWithGoogle):
-    limit = "40 per day"
     scope = "social_sign_in"
 
     with (
         limiter.limit(
-            limit,
+            auth_rate_limit,
             scope=scope,
             exempt_when=disable_ip_rate_limit),
     ):
@@ -225,12 +223,11 @@ def post_sign_in_with_google(req: t.PostSignInWithGoogle):
 @post('/sign-in-with-apple')
 @validate(t.PostSignInWithApple)
 def post_sign_in_with_apple(req: t.PostSignInWithApple):
-    limit = "40 per day"
     scope = "social_sign_in"
 
     with (
         limiter.limit(
-            limit,
+            auth_rate_limit,
             scope=scope,
             exempt_when=disable_ip_rate_limit),
     ):
@@ -240,14 +237,18 @@ def post_sign_in_with_apple(req: t.PostSignInWithApple):
 # `@apost`) — the request comes from Apple's authorize endpoint as an
 # unauthenticated form_post, with no bearer token. See
 # `service/auth/apple_oauth.py` for the rationale.
+#
+# This is on its own scope so it doesn't double-bill against
+# `social_sign_in`: a single web/Android Apple sign-in hits this
+# callback *and* /sign-in-with-apple, and we want the per-day budget
+# to be "one sign-in = one slot" not "two slots".
 @post('/auth/apple/callback')
 def post_auth_apple_callback():
-    limit = "40 per day"
-    scope = "social_sign_in"
+    scope = "apple_oauth_callback"
 
     with (
         limiter.limit(
-            limit,
+            auth_rate_limit,
             scope=scope,
             exempt_when=disable_ip_rate_limit),
     ):

--- a/service/api/decorators.py
+++ b/service/api/decorators.py
@@ -123,6 +123,13 @@ app.config['MAX_CONTENT_LENGTH'] = constants.MAX_CONTENT_LENGTH;
 
 default_limits = "60 per minute; 12 per second"
 
+# Per-IP cap shared by every unauthenticated auth endpoint
+# (/request-otp, /check-otp, /sign-in-with-*, /auth/apple/callback).
+# Each endpoint scopes the bucket separately so they don't double-bill
+# against the same allowance — change this string to retune them all
+# at once.
+auth_rate_limit = "40 per day"
+
 limiter = Limiter(
     _get_remote_address,
     app=app,

--- a/service/auth/apple_oauth.py
+++ b/service/auth/apple_oauth.py
@@ -34,34 +34,30 @@ Env vars:
 
 import os
 from typing import Optional
-from urllib.parse import quote
 
 from flask import redirect
 
+from util import append_query
+
+
+APPLE_WEB_REDIRECT_URL = os.environ.get('DUO_APPLE_WEB_REDIRECT_URL', '').strip()
+APPLE_ANDROID_REDIRECT_URL = os.environ.get('DUO_APPLE_ANDROID_REDIRECT_URL', '').strip()
+
 
 _REDIRECT_TARGETS = {
-    'web': os.environ.get('DUO_APPLE_WEB_REDIRECT_URL', '').strip(),
-    'android': os.environ.get('DUO_APPLE_ANDROID_REDIRECT_URL', '').strip(),
+    'web': APPLE_WEB_REDIRECT_URL,
+    'android': APPLE_ANDROID_REDIRECT_URL,
 }
 
 
 def _resolve_target(state: str) -> Optional[str]:
     # `state` is `<csrf-nonce>.<target>`; we only care about the target
     # suffix. The nonce is verified client-side after the redirect.
-    if not state or '.' not in state:
+    try:
+        _, _, target = state.rpartition('.')
+    except:
         return None
-    target = state.rpartition('.')[2]
     return _REDIRECT_TARGETS.get(target) or None
-
-
-def _append_query(base: str, params: dict) -> str:
-    sep = '&' if '?' in base else '?'
-    encoded = '&'.join(
-        f'{quote(k, safe="")}={quote(v, safe="")}'
-        for k, v in params.items()
-        if v is not None
-    )
-    return f'{base}{sep}{encoded}' if encoded else base
 
 
 def handle_callback(
@@ -75,18 +71,18 @@ def handle_callback(
         return 'Invalid Apple sign-in state', 400
 
     if error:
-        return redirect(_append_query(target_url, dict(
+        return redirect(append_query(target_url, dict(
             apple_error=error,
             apple_state=state,
         )), code=302)
 
     if not id_token:
-        return redirect(_append_query(target_url, dict(
+        return redirect(append_query(target_url, dict(
             apple_error='missing_id_token',
             apple_state=state,
         )), code=302)
 
-    return redirect(_append_query(target_url, dict(
+    return redirect(append_query(target_url, dict(
         apple_id_token=id_token,
         apple_state=state,
     )), code=302)

--- a/service/auth/apple_oauth.py
+++ b/service/auth/apple_oauth.py
@@ -1,0 +1,92 @@
+"""
+Apple Sign In with Apple — web/Android OAuth callback.
+
+iOS uses the native Sign In with Apple API (expo-apple-authentication)
+and never hits this endpoint. Android and web have no native Apple SDK,
+so they use the OAuth web flow against a Services ID:
+
+    1. Client builds an authorize URL pointing at appleid.apple.com.
+    2. User signs in.
+    3. Apple POSTs the result (form-encoded) back to a Return URL
+       registered on the Services ID.
+    4. Browsers can't navigate to a POST response, so the Return URL has
+       to be a server endpoint that converts POST -> 302 redirect.
+
+This module is that converter. It pulls the `id_token` out of the form
+post and 302s back to a client-controlled URL with the token in a query
+parameter, so the originating client can hand it to /sign-in-with-apple.
+
+The redirect target is *not* picked by the client URL-side — that would
+be an open redirect. Instead, the client encodes a target name (`web`
+or `android`) inside the OAuth `state` parameter, which Apple echoes
+back unchanged. We resolve that name against an env-configured
+allow-list.
+
+Env vars:
+    DUO_APPLE_WEB_REDIRECT_URL      Final redirect target after a web
+                                    sign-in. Typically the SPA root.
+    DUO_APPLE_ANDROID_REDIRECT_URL  Final redirect target after an
+                                    Android sign-in. Must be the
+                                    Universal Link / App Link the
+                                    Android client passes to
+                                    expo-web-browser as `returnUrl`.
+"""
+
+import os
+from typing import Optional
+from urllib.parse import quote
+
+from flask import redirect
+
+
+_REDIRECT_TARGETS = {
+    'web': os.environ.get('DUO_APPLE_WEB_REDIRECT_URL', '').strip(),
+    'android': os.environ.get('DUO_APPLE_ANDROID_REDIRECT_URL', '').strip(),
+}
+
+
+def _resolve_target(state: str) -> Optional[str]:
+    # `state` is `<csrf-nonce>.<target>`; we only care about the target
+    # suffix. The nonce is verified client-side after the redirect.
+    if not state or '.' not in state:
+        return None
+    target = state.rpartition('.')[2]
+    return _REDIRECT_TARGETS.get(target) or None
+
+
+def _append_query(base: str, params: dict) -> str:
+    sep = '&' if '?' in base else '?'
+    encoded = '&'.join(
+        f'{quote(k, safe="")}={quote(v, safe="")}'
+        for k, v in params.items()
+        if v is not None
+    )
+    return f'{base}{sep}{encoded}' if encoded else base
+
+
+def handle_callback(
+    *,
+    id_token: str,
+    state: str,
+    error: Optional[str],
+):
+    target_url = _resolve_target(state)
+    if not target_url:
+        return 'Invalid Apple sign-in state', 400
+
+    if error:
+        return redirect(_append_query(target_url, dict(
+            apple_error=error,
+            apple_state=state,
+        )), code=302)
+
+    if not id_token:
+        return redirect(_append_query(target_url, dict(
+            apple_error='missing_id_token',
+            apple_state=state,
+        )), code=302)
+
+    return redirect(_append_query(target_url, dict(
+        apple_id_token=id_token,
+        apple_state=state,
+    )), code=302)

--- a/service/auth/social.py
+++ b/service/auth/social.py
@@ -19,6 +19,7 @@ import os
 import secrets
 import time
 from typing import TypedDict
+import duotypes as t
 
 import jwt
 from jwt import PyJWKClient
@@ -31,12 +32,6 @@ from service.api.decorators import enable_mocking
 # Bound on JWKS / certs HTTP fetches. Without this, a slow upstream pins
 # a gunicorn worker indefinitely on the cold-start fetch.
 _PROVIDER_HTTP_TIMEOUT_SECONDS = 5
-
-
-class SocialClaims(TypedDict):
-    sub: str
-    email: str
-    email_verified: bool
 
 
 class SocialAuthError(Exception):
@@ -126,7 +121,7 @@ def _decode_unverified(
     return claims
 
 
-def verify_google_id_token(id_token: str) -> SocialClaims:
+def verify_google_id_token(id_token: str) -> t.SocialClaims:
     """
     Validate a Google ID token. Returns the canonical claims we need.
 
@@ -164,7 +159,7 @@ def verify_google_id_token(id_token: str) -> SocialClaims:
         (isinstance(raw_verified, str) and raw_verified.lower() == 'true')
     )
 
-    return SocialClaims(
+    return t.SocialClaims(
         sub=sub,
         email=email,
         email_verified=email_verified,
@@ -175,7 +170,7 @@ def verify_apple_identity_token(
     identity_token: str,
     *,
     expected_nonce: str,
-) -> SocialClaims:
+) -> t.SocialClaims:
     """
     Validate an Apple `identity_token` (the JWT returned to the client by
     Sign In with Apple). Returns the canonical claims.
@@ -242,7 +237,7 @@ def verify_apple_identity_token(
         (isinstance(raw_verified, str) and raw_verified.lower() == 'true')
     )
 
-    return SocialClaims(
+    return t.SocialClaims(
         sub=sub,
         email=email,
         email_verified=email_verified,

--- a/service/auth/social.py
+++ b/service/auth/social.py
@@ -17,6 +17,7 @@ Env vars:
 
 import os
 import time
+from pathlib import Path
 from typing import TypedDict
 
 import jwt
@@ -43,6 +44,7 @@ def _split_csv(env_name: str) -> list[str]:
 _GOOGLE_CLIENT_IDS = _split_csv('DUO_GOOGLE_CLIENT_IDS')
 _APPLE_CLIENT_IDS = _split_csv('DUO_APPLE_CLIENT_IDS')
 
+_GOOGLE_ISSUERS = ('https://accounts.google.com', 'accounts.google.com')
 _APPLE_JWKS_URL = 'https://appleid.apple.com/auth/keys'
 _APPLE_ISSUER = 'https://appleid.apple.com'
 
@@ -52,6 +54,61 @@ _apple_jwks_client = PyJWKClient(_APPLE_JWKS_URL, cache_keys=True, lifespan=3600
 
 # `google-auth` caches its certs on the Request object.
 _google_request = _GoogleRequest()
+
+# Test-mode escape hatch. When the same flag the rest of the test suite
+# uses is set, we skip JWT signature verification and rely on the test
+# providing a structurally-valid, semantically-correct payload (right
+# `iss`, `aud`, `exp`). Lets `test/functionality1/social-login.sh` mint
+# tokens in pure bash without hitting Google's or Apple's JWKS.
+_enable_mocking_file = (
+    Path(__file__).parent.parent.parent / 'test' / 'input' / 'enable-mocking'
+)
+
+
+def _is_mocking_enabled() -> bool:
+    try:
+        return _enable_mocking_file.read_text().strip() == '1'
+    except (FileNotFoundError, NotADirectoryError):
+        return False
+
+
+def _decode_unverified(
+    token: str,
+    *,
+    allowed_issuers: tuple[str, ...],
+    allowed_audiences: list[str],
+) -> dict:
+    """
+    Decode a JWT *without* signature verification, then enforce the
+    same iss/aud/exp/required-claim checks that the real verifiers do.
+    Used only when `_is_mocking_enabled()` is True — in production this
+    path is never reached.
+    """
+    try:
+        claims = jwt.decode(
+            token,
+            options={
+                'verify_signature': False,
+                'require': ['sub', 'iss', 'aud', 'exp'],
+            },
+        )
+    except jwt.PyJWTError as e:
+        raise SocialAuthError(f'Mock token malformed: {e}')
+
+    iss = claims.get('iss')
+    if iss not in allowed_issuers:
+        raise SocialAuthError(f'Mock token has unexpected iss: {iss!r}')
+
+    aud_claim = claims.get('aud')
+    aud_list = [aud_claim] if isinstance(aud_claim, str) else list(aud_claim or [])
+    if not any(a in allowed_audiences for a in aud_list):
+        raise SocialAuthError(f'Mock token has unexpected aud: {aud_claim!r}')
+
+    exp = claims.get('exp')
+    if not isinstance(exp, (int, float)) or exp < time.time():
+        raise SocialAuthError('Mock token has expired or invalid exp')
+
+    return claims
 
 
 def verify_google_id_token(id_token: str) -> SocialClaims:
@@ -63,15 +120,22 @@ def verify_google_id_token(id_token: str) -> SocialClaims:
     if not _GOOGLE_CLIENT_IDS:
         raise SocialAuthError('DUO_GOOGLE_CLIENT_IDS is not configured')
 
-    try:
-        # `verify_oauth2_token` checks signature, exp, iss
-        # ('accounts.google.com' or 'https://accounts.google.com'), and
-        # `aud` against the supplied list.
-        claims = _google_id_token.verify_oauth2_token(
-            id_token, _google_request, audience=_GOOGLE_CLIENT_IDS,
+    if _is_mocking_enabled():
+        claims = _decode_unverified(
+            id_token,
+            allowed_issuers=_GOOGLE_ISSUERS,
+            allowed_audiences=_GOOGLE_CLIENT_IDS,
         )
-    except ValueError as e:
-        raise SocialAuthError(f'Invalid Google token: {e}')
+    else:
+        try:
+            # `verify_oauth2_token` checks signature, exp, iss
+            # ('accounts.google.com' or 'https://accounts.google.com'), and
+            # `aud` against the supplied list.
+            claims = _google_id_token.verify_oauth2_token(
+                id_token, _google_request, audience=_GOOGLE_CLIENT_IDS,
+            )
+        except ValueError as e:
+            raise SocialAuthError(f'Invalid Google token: {e}')
 
     sub = claims.get('sub')
     email = claims.get('email')
@@ -102,18 +166,25 @@ def verify_apple_identity_token(identity_token: str) -> SocialClaims:
     if not _APPLE_CLIENT_IDS:
         raise SocialAuthError('DUO_APPLE_CLIENT_IDS is not configured')
 
-    try:
-        signing_key = _apple_jwks_client.get_signing_key_from_jwt(identity_token)
-        claims = jwt.decode(
+    if _is_mocking_enabled():
+        claims = _decode_unverified(
             identity_token,
-            signing_key.key,
-            algorithms=['RS256'],
-            audience=_APPLE_CLIENT_IDS,
-            issuer=_APPLE_ISSUER,
-            options={'require': ['exp', 'iat', 'sub', 'iss', 'aud']},
+            allowed_issuers=(_APPLE_ISSUER,),
+            allowed_audiences=_APPLE_CLIENT_IDS,
         )
-    except (jwt.PyJWTError, jwt.exceptions.PyJWKClientError) as e:
-        raise SocialAuthError(f'Invalid Apple token: {e}')
+    else:
+        try:
+            signing_key = _apple_jwks_client.get_signing_key_from_jwt(identity_token)
+            claims = jwt.decode(
+                identity_token,
+                signing_key.key,
+                algorithms=['RS256'],
+                audience=_APPLE_CLIENT_IDS,
+                issuer=_APPLE_ISSUER,
+                options={'require': ['exp', 'iat', 'sub', 'iss', 'aud']},
+            )
+        except (jwt.PyJWTError, jwt.exceptions.PyJWKClientError) as e:
+            raise SocialAuthError(f'Invalid Apple token: {e}')
 
     sub = claims.get('sub')
     email = claims.get('email')

--- a/service/auth/social.py
+++ b/service/auth/social.py
@@ -17,13 +17,19 @@ Env vars:
 
 import os
 import time
-from pathlib import Path
 from typing import TypedDict
 
 import jwt
 from jwt import PyJWKClient
 from google.auth.transport.requests import Request as _GoogleRequest
 from google.oauth2 import id_token as _google_id_token
+
+from service.api.decorators import enable_mocking
+
+
+# Bound on JWKS / certs HTTP fetches. Without this, a slow upstream pins
+# a gunicorn worker indefinitely on the cold-start fetch.
+_PROVIDER_HTTP_TIMEOUT_SECONDS = 5
 
 
 class SocialClaims(TypedDict):
@@ -50,26 +56,33 @@ _APPLE_ISSUER = 'https://appleid.apple.com'
 
 # `PyJWKClient` does its own in-process caching with a 1-hour TTL, so a
 # module-level singleton is fine.
-_apple_jwks_client = PyJWKClient(_APPLE_JWKS_URL, cache_keys=True, lifespan=3600)
-
-# `google-auth` caches its certs on the Request object.
-_google_request = _GoogleRequest()
-
-# Test-mode escape hatch. When the same flag the rest of the test suite
-# uses is set, we skip JWT signature verification and rely on the test
-# providing a structurally-valid, semantically-correct payload (right
-# `iss`, `aud`, `exp`). Lets `test/functionality1/social-login.sh` mint
-# tokens in pure bash without hitting Google's or Apple's JWKS.
-_enable_mocking_file = (
-    Path(__file__).parent.parent.parent / 'test' / 'input' / 'enable-mocking'
+_apple_jwks_client = PyJWKClient(
+    _APPLE_JWKS_URL,
+    cache_keys=True,
+    lifespan=3600,
+    timeout=_PROVIDER_HTTP_TIMEOUT_SECONDS,
 )
 
 
-def _is_mocking_enabled() -> bool:
-    try:
-        return _enable_mocking_file.read_text().strip() == '1'
-    except (FileNotFoundError, NotADirectoryError):
-        return False
+# `google-auth`'s `Request` accepts a per-call timeout via __call__, but
+# `verify_oauth2_token` doesn't expose that. Subclass to set a default.
+class _BoundedTimeoutGoogleRequest(_GoogleRequest):
+    def __call__(
+        self,
+        url,
+        method='GET',
+        body=None,
+        headers=None,
+        timeout=_PROVIDER_HTTP_TIMEOUT_SECONDS,
+        **kwargs,
+    ):
+        return super().__call__(
+            url, method, body, headers, timeout=timeout, **kwargs
+        )
+
+
+# `google-auth` caches its certs on the Request object.
+_google_request = _BoundedTimeoutGoogleRequest()
 
 
 def _decode_unverified(
@@ -81,8 +94,9 @@ def _decode_unverified(
     """
     Decode a JWT *without* signature verification, then enforce the
     same iss/aud/exp/required-claim checks that the real verifiers do.
-    Used only when `_is_mocking_enabled()` is True — in production this
-    path is never reached.
+    Used only when `enable_mocking()` is True — in production this path
+    is never reached because the mocking flag file isn't shipped in the
+    Docker image (`api.Dockerfile` excludes the `test/` directory).
     """
     try:
         claims = jwt.decode(
@@ -120,7 +134,7 @@ def verify_google_id_token(id_token: str) -> SocialClaims:
     if not _GOOGLE_CLIENT_IDS:
         raise SocialAuthError('DUO_GOOGLE_CLIENT_IDS is not configured')
 
-    if _is_mocking_enabled():
+    if enable_mocking():
         claims = _decode_unverified(
             id_token,
             allowed_issuers=_GOOGLE_ISSUERS,
@@ -166,7 +180,7 @@ def verify_apple_identity_token(identity_token: str) -> SocialClaims:
     if not _APPLE_CLIENT_IDS:
         raise SocialAuthError('DUO_APPLE_CLIENT_IDS is not configured')
 
-    if _is_mocking_enabled():
+    if enable_mocking():
         claims = _decode_unverified(
             identity_token,
             allowed_issuers=(_APPLE_ISSUER,),
@@ -198,10 +212,13 @@ def verify_apple_identity_token(identity_token: str) -> SocialClaims:
         email = ''
 
     # Apple's `email_verified` is a string ("true"/"false") and is always
-    # "true" when the field is present (relay or real). Treat absence as
-    # not-verified for safety.
+    # "true" when the field is present (relay or real). When the claim is
+    # absent we trust the issuer: Apple wouldn't include an email it hasn't
+    # verified, so an unset claim alongside a present `email` is treated as
+    # verified. The only false case is an explicit "false" / False.
     raw_verified = claims.get('email_verified')
     email_verified = (
+        raw_verified is None or
         raw_verified is True or
         (isinstance(raw_verified, str) and raw_verified.lower() == 'true')
     )

--- a/service/auth/social.py
+++ b/service/auth/social.py
@@ -16,6 +16,7 @@ Env vars:
 """
 
 import os
+import secrets
 import time
 from typing import TypedDict
 
@@ -170,10 +171,19 @@ def verify_google_id_token(id_token: str) -> SocialClaims:
     )
 
 
-def verify_apple_identity_token(identity_token: str) -> SocialClaims:
+def verify_apple_identity_token(
+    identity_token: str,
+    *,
+    expected_nonce: str,
+) -> SocialClaims:
     """
     Validate an Apple `identity_token` (the JWT returned to the client by
     Sign In with Apple). Returns the canonical claims.
+
+    `expected_nonce` is the random string the client passed to Apple as the
+    `nonce` (native `signInAsync({ nonce })` on iOS, `&nonce=` URL param on
+    web/Android). Apple echoes it verbatim into the JWT's `nonce` claim; we
+    compare the two to bind the token to the originating client session.
 
     Raises SocialAuthError on any verification failure.
     """
@@ -195,10 +205,19 @@ def verify_apple_identity_token(identity_token: str) -> SocialClaims:
                 algorithms=['RS256'],
                 audience=_APPLE_CLIENT_IDS,
                 issuer=_APPLE_ISSUER,
-                options={'require': ['exp', 'iat', 'sub', 'iss', 'aud']},
+                options={'require': ['exp', 'iat', 'sub', 'iss', 'aud', 'nonce']},
             )
         except (jwt.PyJWTError, jwt.exceptions.PyJWKClientError) as e:
             raise SocialAuthError(f'Invalid Apple token: {e}')
+
+    # Constant-time nonce comparison. An attacker who controls neither the
+    # client nor Apple can't forge a JWT with a known nonce, but failing
+    # closed here protects against bug-class issues if a nonce ever leaks.
+    token_nonce = claims.get('nonce')
+    if not isinstance(token_nonce, str) or not secrets.compare_digest(
+        token_nonce, expected_nonce
+    ):
+        raise SocialAuthError('Apple token nonce did not match the expected value')
 
     sub = claims.get('sub')
     email = claims.get('email')

--- a/service/auth/social.py
+++ b/service/auth/social.py
@@ -1,0 +1,142 @@
+"""
+Verify ID tokens from Google and Apple.
+
+Both providers issue signed JWTs after a successful sign-in. Rather than
+calling each provider's `/userinfo` endpoint (extra round-trip, possible
+rate limits), we verify the JWT signature locally against the provider's
+JWKS — same trust model, $0 cost, and no external dependency at request
+time after the JWKS is cached.
+
+Env vars:
+    DUO_GOOGLE_CLIENT_IDS  Comma-separated allowed `aud` values for Google.
+                           Include every OAuth client ID that ships in a
+                           client (Web, iOS, Android).
+    DUO_APPLE_CLIENT_IDS   Comma-separated allowed `aud` values for Apple.
+                           Bundle ID for native iOS, Services ID for web.
+"""
+
+import os
+import time
+from typing import TypedDict
+
+import jwt
+from jwt import PyJWKClient
+from google.auth.transport.requests import Request as _GoogleRequest
+from google.oauth2 import id_token as _google_id_token
+
+
+class SocialClaims(TypedDict):
+    sub: str
+    email: str
+    email_verified: bool
+
+
+class SocialAuthError(Exception):
+    """Raised when a provider token fails verification."""
+
+
+def _split_csv(env_name: str) -> list[str]:
+    raw = os.environ.get(env_name, '')
+    return [s.strip() for s in raw.split(',') if s.strip()]
+
+
+_GOOGLE_CLIENT_IDS = _split_csv('DUO_GOOGLE_CLIENT_IDS')
+_APPLE_CLIENT_IDS = _split_csv('DUO_APPLE_CLIENT_IDS')
+
+_APPLE_JWKS_URL = 'https://appleid.apple.com/auth/keys'
+_APPLE_ISSUER = 'https://appleid.apple.com'
+
+# `PyJWKClient` does its own in-process caching with a 1-hour TTL, so a
+# module-level singleton is fine.
+_apple_jwks_client = PyJWKClient(_APPLE_JWKS_URL, cache_keys=True, lifespan=3600)
+
+# `google-auth` caches its certs on the Request object.
+_google_request = _GoogleRequest()
+
+
+def verify_google_id_token(id_token: str) -> SocialClaims:
+    """
+    Validate a Google ID token. Returns the canonical claims we need.
+
+    Raises SocialAuthError on any verification failure.
+    """
+    if not _GOOGLE_CLIENT_IDS:
+        raise SocialAuthError('DUO_GOOGLE_CLIENT_IDS is not configured')
+
+    try:
+        # `verify_oauth2_token` checks signature, exp, iss
+        # ('accounts.google.com' or 'https://accounts.google.com'), and
+        # `aud` against the supplied list.
+        claims = _google_id_token.verify_oauth2_token(
+            id_token, _google_request, audience=_GOOGLE_CLIENT_IDS,
+        )
+    except ValueError as e:
+        raise SocialAuthError(f'Invalid Google token: {e}')
+
+    sub = claims.get('sub')
+    email = claims.get('email')
+    if not sub or not email:
+        raise SocialAuthError('Google token missing sub or email')
+
+    # Google sometimes returns email_verified as bool, sometimes as string
+    raw_verified = claims.get('email_verified', False)
+    email_verified = (
+        raw_verified is True or
+        (isinstance(raw_verified, str) and raw_verified.lower() == 'true')
+    )
+
+    return SocialClaims(
+        sub=sub,
+        email=email,
+        email_verified=email_verified,
+    )
+
+
+def verify_apple_identity_token(identity_token: str) -> SocialClaims:
+    """
+    Validate an Apple `identity_token` (the JWT returned to the client by
+    Sign In with Apple). Returns the canonical claims.
+
+    Raises SocialAuthError on any verification failure.
+    """
+    if not _APPLE_CLIENT_IDS:
+        raise SocialAuthError('DUO_APPLE_CLIENT_IDS is not configured')
+
+    try:
+        signing_key = _apple_jwks_client.get_signing_key_from_jwt(identity_token)
+        claims = jwt.decode(
+            identity_token,
+            signing_key.key,
+            algorithms=['RS256'],
+            audience=_APPLE_CLIENT_IDS,
+            issuer=_APPLE_ISSUER,
+            options={'require': ['exp', 'iat', 'sub', 'iss', 'aud']},
+        )
+    except (jwt.PyJWTError, jwt.exceptions.PyJWKClientError) as e:
+        raise SocialAuthError(f'Invalid Apple token: {e}')
+
+    sub = claims.get('sub')
+    email = claims.get('email')
+    if not sub:
+        raise SocialAuthError('Apple token missing sub')
+    if not email:
+        # Apple usually includes `email` in every identity token, but if it
+        # ever omits it (e.g. token from a re-auth path) we cannot link a
+        # new account from email — only an existing `social_identity` row
+        # via sub will work. Caller handles that case.
+        email = ''
+
+    # Apple's `email_verified` is a string ("true"/"false") and is always
+    # "true" when the field is present (relay or real). Treat absence as
+    # not-verified for safety.
+    raw_verified = claims.get('email_verified')
+    email_verified = (
+        raw_verified is True or
+        (isinstance(raw_verified, str) and raw_verified.lower() == 'true')
+    )
+
+    return SocialClaims(
+        sub=sub,
+        email=email,
+        email_verified=email_verified,
+    )

--- a/service/person/__init__.py
+++ b/service/person/__init__.py
@@ -34,6 +34,11 @@ import erlastic
 from datetime import datetime, timezone
 from duoaudio import put_audio_in_object_store
 from service.person.aboutdiff import diff_addition_with_context
+from service.auth.social import (
+    SocialAuthError,
+    verify_apple_identity_token,
+    verify_google_id_token,
+)
 from verification.messages import (
     V_QUEUED,
     V_REUSED_SELFIE,
@@ -408,19 +413,19 @@ def _sign_in_with_social(
                 return 'Banned', 461
 
         # 1. Resolve to an existing person via (provider, sub) first; on
-        #    miss, fall back to a verified-email match against `person`.
+        #    miss, fall back to an email match against `person`.
         row = tx.execute(Q_LOOKUP_SOCIAL_IDENTITY, dict(
             provider=provider,
             provider_sub=sub,
         )).fetchone()
         person_id = row['person_id'] if row else None
 
-        if person_id is None and email_verified and email:
+        if person_id is None and email:
             row = tx.execute(Q_LOOKUP_PERSON_BY_EMAIL, dict(
                 normalized_email=normalized,
                 email=email,
             )).fetchone()
-            if row:
+            if row and email_verified:
                 person_id = row['person_id']
                 # Auto-link: record the social identity so future sign-ins
                 # hit Q_LOOKUP_SOCIAL_IDENTITY directly.
@@ -430,6 +435,18 @@ def _sign_in_with_social(
                     person_id=person_id,
                     email=email,
                 ))
+            elif row:
+                # Existing person with this email but the provider hasn't
+                # marked the email verified, so we can't safely auto-link.
+                # Letting the user proceed would create an onboardee row
+                # and then crash on the `person.email` UNIQUE constraint
+                # at /finish-onboarding. Reject up front instead.
+                return (
+                    'An account already exists for this email. Sign in '
+                    'with the email link to confirm ownership, then try '
+                    'social sign-in again.',
+                    401,
+                )
 
         # 2. New user with no email? We can't proceed — Apple should always
         #    include `email` in the identity token, but if it doesn't and
@@ -502,10 +519,6 @@ def _sign_in_with_social(
     )
 
 def post_sign_in_with_google(req: 't.PostSignInWithGoogle'):
-    from service.auth.social import (
-        SocialAuthError,
-        verify_google_id_token,
-    )
     try:
         claims = verify_google_id_token(req.id_token)
     except SocialAuthError as e:
@@ -520,10 +533,6 @@ def post_sign_in_with_google(req: 't.PostSignInWithGoogle'):
     )
 
 def post_sign_in_with_apple(req: 't.PostSignInWithApple'):
-    from service.auth.social import (
-        SocialAuthError,
-        verify_apple_identity_token,
-    )
     try:
         claims = verify_apple_identity_token(req.identity_token)
     except SocialAuthError as e:

--- a/service/person/__init__.py
+++ b/service/person/__init__.py
@@ -527,32 +527,33 @@ def _sign_in_with_social(
         **clubs,
     )
 
-def post_sign_in_with_google(req: 't.PostSignInWithGoogle'):
+# (provider name, human-readable label, JWT verifier).
+# Adding a new social provider means adding a row here, a Pydantic
+# request type, and a route in `service/api/__init__.py` that dispatches
+# to `post_sign_in_with_provider` — no new business-logic function.
+_SOCIAL_PROVIDERS = {
+    'google': ('Google', verify_google_id_token),
+    'apple':  ('Apple',  verify_apple_identity_token),
+}
+
+def post_sign_in_with_provider(
+    *,
+    provider: str,
+    token: str,
+    pending_club_name: Optional[str],
+):
+    label, verifier = _SOCIAL_PROVIDERS[provider]
     try:
-        claims = verify_google_id_token(req.id_token)
+        claims = verifier(token)
     except SocialAuthError as e:
-        return f'Invalid Google token: {e}', 401
+        return f'Invalid {label} token: {e}', 401
 
     return _sign_in_with_social(
-        provider='google',
+        provider=provider,
         sub=claims['sub'],
         email=claims['email'],
         email_verified=claims['email_verified'],
-        pending_club_name=req.pending_club_name,
-    )
-
-def post_sign_in_with_apple(req: 't.PostSignInWithApple'):
-    try:
-        claims = verify_apple_identity_token(req.identity_token)
-    except SocialAuthError as e:
-        return f'Invalid Apple token: {e}', 401
-
-    return _sign_in_with_social(
-        provider='apple',
-        sub=claims['sub'],
-        email=claims['email'],
-        email_verified=claims['email_verified'],
-        pending_club_name=req.pending_club_name,
+        pending_club_name=pending_club_name,
     )
 
 def post_check_session_token(s: t.SessionInfo):

--- a/service/person/__init__.py
+++ b/service/person/__init__.py
@@ -286,10 +286,11 @@ def post_request_otp(req: t.PostRequestOtp):
 
     session_token = secrets.token_hex(64)
     session_token_hash = sha512(session_token)
+    normalized = normalize_email(req.email)
 
     params = dict(
         email=req.email,
-        normalized_email=normalize_email(req.email),
+        normalized_email=normalized,
         pending_club_name=req.pending_club_name,
         is_dev=DUO_ENV == 'dev',
         session_token_hash=session_token_hash,
@@ -297,8 +298,13 @@ def post_request_otp(req: t.PostRequestOtp):
     )
 
     with api_tx() as tx:
-        if tx.execute(Q_IS_BANNED, params).fetchone():
+        banned = tx.execute(Q_IS_BANNED, dict(
+            normalized_email=normalized,
+            ip_address=request.remote_addr,
+        )).fetchone()
+        if banned:
             return 'Banned', 461
+
         rows = tx.execute(Q_INSERT_DUO_SESSION, params).fetchall()
 
     try:
@@ -403,23 +409,18 @@ def _sign_in_with_social(
     if not request.remote_addr or firehol.matches(request.remote_addr):
         return 'IP address blocked', 460
 
-    # Match the OTP path: store emails lowercased; the rest of the system
-    # treats `person.email` as already-lowercased.
-    email = email.lower().strip() if email else ''
-
     session_token = secrets.token_hex(64)
     session_token_hash = sha512(session_token)
-    normalized = normalize_email(email) if email else ''
+    normalized = normalize_email(email)
 
     with api_tx() as tx:
         # 0. Banned-person guard (mirrors `_OTP_CTE`).
-        if normalized:
-            banned = tx.execute(Q_IS_BANNED, dict(
-                normalized_email=normalized,
-                ip_address=request.remote_addr,
-            )).fetchone()
-            if banned:
-                return 'Banned', 461
+        banned = tx.execute(Q_IS_BANNED, dict(
+            normalized_email=normalized,
+            ip_address=request.remote_addr,
+        )).fetchone()
+        if banned:
+            return 'Banned', 461
 
         # 1. Resolve to an existing person via (provider, sub) first; on
         #    miss, fall back to an email match against `person`.
@@ -552,9 +553,9 @@ def post_sign_in_with_google(
 
     return _sign_in_with_social(
         provider='google',
-        sub=claims['sub'],
-        email=claims['email'],
-        email_verified=claims['email_verified'],
+        sub=claims.sub,
+        email=claims.email,
+        email_verified=claims.email_verified,
         pending_club_name=pending_club_name,
     )
 
@@ -571,9 +572,9 @@ def post_sign_in_with_apple(
 
     return _sign_in_with_social(
         provider='apple',
-        sub=claims['sub'],
-        email=claims['email'],
-        email_verified=claims['email_verified'],
+        sub=claims.sub,
+        email=claims.email,
+        email_verified=claims.email_verified,
         pending_club_name=pending_club_name,
     )
 

--- a/service/person/__init__.py
+++ b/service/person/__init__.py
@@ -430,11 +430,36 @@ def _sign_in_with_social(
         person_id = row['person_id'] if row else None
 
         if person_id is None and email:
+            # Auto-link / collision check requires a verified email — without
+            # it we'd risk creating an onboardee that later crashes on
+            # `person.email`'s UNIQUE constraint at /finish-onboarding, and
+            # we'd risk handing someone else's account to an unverified
+            # claimant. Reject the whole sign-in up front. 409 (Conflict)
+            # lets the client distinguish this from a bad-token 401 and
+            # surface a clear "verify your email first" message.
+            if not email_verified:
+                row = tx.execute(Q_LOOKUP_PERSON_BY_EMAIL, dict(
+                    normalized_email=normalized,
+                    email=email,
+                )).fetchone()
+                if row:
+                    return (
+                        'An account already exists for this email. Sign in '
+                        'with the email link to confirm ownership, then try '
+                        'social sign-in again.',
+                        409,
+                    )
+                return (
+                    'Your email address is not verified with the sign-in '
+                    'provider. Verify it and try again.',
+                    409,
+                )
+
             row = tx.execute(Q_LOOKUP_PERSON_BY_EMAIL, dict(
                 normalized_email=normalized,
                 email=email,
             )).fetchone()
-            if row and email_verified:
+            if row:
                 person_id = row['person_id']
                 # Auto-link: record the social identity so future sign-ins
                 # hit Q_LOOKUP_SOCIAL_IDENTITY directly.
@@ -444,18 +469,6 @@ def _sign_in_with_social(
                     person_id=person_id,
                     email=email,
                 ))
-            elif row:
-                # Existing person with this email but the provider hasn't
-                # marked the email verified, so we can't safely auto-link.
-                # Letting the user proceed would create an onboardee row
-                # and then crash on the `person.email` UNIQUE constraint
-                # at /finish-onboarding. Reject up front instead.
-                return (
-                    'An account already exists for this email. Sign in '
-                    'with the email link to confirm ownership, then try '
-                    'social sign-in again.',
-                    401,
-                )
 
         # 2. New user with no email? We can't proceed — Apple should always
         #    include `email` in the identity token, but if it doesn't and
@@ -527,29 +540,37 @@ def _sign_in_with_social(
         **clubs,
     )
 
-# (provider name, human-readable label, JWT verifier).
-# Adding a new social provider means adding a row here, a Pydantic
-# request type, and a route in `service/api/__init__.py` that dispatches
-# to `post_sign_in_with_provider` — no new business-logic function.
-_SOCIAL_PROVIDERS = {
-    'google': ('Google', verify_google_id_token),
-    'apple':  ('Apple',  verify_apple_identity_token),
-}
-
-def post_sign_in_with_provider(
+def post_sign_in_with_google(
     *,
-    provider: str,
     token: str,
     pending_club_name: Optional[str],
 ):
-    label, verifier = _SOCIAL_PROVIDERS[provider]
     try:
-        claims = verifier(token)
+        claims = verify_google_id_token(token)
     except SocialAuthError as e:
-        return f'Invalid {label} token: {e}', 401
+        return f'Invalid Google token: {e}', 401
 
     return _sign_in_with_social(
-        provider=provider,
+        provider='google',
+        sub=claims['sub'],
+        email=claims['email'],
+        email_verified=claims['email_verified'],
+        pending_club_name=pending_club_name,
+    )
+
+def post_sign_in_with_apple(
+    *,
+    token: str,
+    nonce: str,
+    pending_club_name: Optional[str],
+):
+    try:
+        claims = verify_apple_identity_token(token, expected_nonce=nonce)
+    except SocialAuthError as e:
+        return f'Invalid Apple token: {e}', 401
+
+    return _sign_in_with_social(
+        provider='apple',
         sub=claims['sub'],
         email=claims['email'],
         email_verified=claims['email_verified'],

--- a/service/person/__init__.py
+++ b/service/person/__init__.py
@@ -297,12 +297,19 @@ def post_request_otp(req: t.PostRequestOtp):
     )
 
     with api_tx() as tx:
+        if tx.execute(Q_IS_BANNED, params).fetchone():
+            return 'Banned', 461
         rows = tx.execute(Q_INSERT_DUO_SESSION, params).fetchall()
 
     try:
         row, *_ = rows
         otp = row['otp']
     except:
+        # The ban path is handled above; reaching here means the OTP
+        # CTE returned no rows for some other reason (e.g. the
+        # `bad_email_domain` filter on a new sign-up). Surfacing
+        # 'Banned' is a deliberate vagueness — we don't tell the
+        # caller which guardrail tripped.
         return 'Banned', 461
 
     _send_otp(req.email, otp)
@@ -322,6 +329,8 @@ def post_resend_otp(s: t.SessionInfo):
     )
 
     with api_tx() as tx:
+        if tx.execute(Q_IS_BANNED, params).fetchone():
+            return 'Banned', 461
         rows = tx.execute(Q_UPDATE_OTP, params).fetchall()
 
     try:

--- a/service/person/__init__.py
+++ b/service/person/__init__.py
@@ -277,15 +277,51 @@ def _send_otp(email: str, otp: str):
         from_addr='noreply-otp@duolicious.app',
     )
 
-def post_request_otp(req: t.PostRequestOtp):
+def _check_ip_blocked():
     if not request.remote_addr or firehol.matches(request.remote_addr):
         return 'IP address blocked', 460
+    return None
+
+def _check_banned(tx, normalized_email: str):
+    banned = tx.execute(Q_IS_BANNED, dict(
+        normalized_email=normalized_email,
+        ip_address=request.remote_addr,
+    )).fetchone()
+    if banned:
+        return 'Banned', 461
+    return None
+
+def _new_session_token():
+    session_token = secrets.token_hex(64)
+    return session_token, sha512(session_token)
+
+def _otp_from_rows(rows):
+    try:
+        row, *_ = rows
+        return row['otp']
+    except:
+        return None
+
+def _handle_pending_club(tx, person_id, pending_club_name):
+    club_params = dict(
+        person_id=person_id,
+        club_name=pending_club_name,
+        pending_club_name=pending_club_name,
+        do_modify=True,
+    )
+    if person_id is not None and pending_club_name is not None:
+        tx.execute(Q_JOIN_CLUB, club_params)
+        tx.execute(Q_UPSERT_SEARCH_PREFERENCE_CLUB, club_params)
+    return tx.execute(Q_GET_SESSION_CLUBS, club_params).fetchone()
+
+def post_request_otp(req: t.PostRequestOtp):
+    if blocked := _check_ip_blocked():
+        return blocked
 
     if not check_and_update_bad_domains(req.email):
         return 'Disposable email', 400
 
-    session_token = secrets.token_hex(64)
-    session_token_hash = sha512(session_token)
+    session_token, session_token_hash = _new_session_token()
     normalized = normalize_email(req.email)
 
     params = dict(
@@ -298,19 +334,13 @@ def post_request_otp(req: t.PostRequestOtp):
     )
 
     with api_tx() as tx:
-        banned = tx.execute(Q_IS_BANNED, dict(
-            normalized_email=normalized,
-            ip_address=request.remote_addr,
-        )).fetchone()
-        if banned:
-            return 'Banned', 461
+        if banned := _check_banned(tx, normalized):
+            return banned
 
         rows = tx.execute(Q_INSERT_DUO_SESSION, params).fetchall()
 
-    try:
-        row, *_ = rows
-        otp = row['otp']
-    except:
+    otp = _otp_from_rows(rows)
+    if otp is None:
         # The ban path is handled above; reaching here means the OTP
         # CTE returned no rows for some other reason (e.g. the
         # `bad_email_domain` filter on a new sign-up). Surfacing
@@ -323,33 +353,32 @@ def post_request_otp(req: t.PostRequestOtp):
     return dict(session_token=session_token)
 
 def post_resend_otp(s: t.SessionInfo):
-    if not request.remote_addr or firehol.matches(request.remote_addr):
-        return 'IP address blocked', 460
+    if blocked := _check_ip_blocked():
+        return blocked
 
+    normalized = normalize_email(s.email)
     params = dict(
         email=s.email,
-        normalized_email=normalize_email(s.email),
+        normalized_email=normalized,
         is_dev=DUO_ENV == 'dev',
         session_token_hash=s.session_token_hash,
         ip_address=request.remote_addr,
     )
 
     with api_tx() as tx:
-        if tx.execute(Q_IS_BANNED, params).fetchone():
-            return 'Banned', 461
+        if banned := _check_banned(tx, normalized):
+            return banned
         rows = tx.execute(Q_UPDATE_OTP, params).fetchall()
 
-    try:
-        row, *_ = rows
-        otp = row['otp']
-    except:
+    otp = _otp_from_rows(rows)
+    if otp is None:
         return 'Banned', 461
 
     _send_otp(s.email, otp)
 
 def post_check_otp(req: t.PostCheckOtp, s: t.SessionInfo):
-    if not request.remote_addr or firehol.matches(request.remote_addr):
-        return 'IP address blocked', 460
+    if blocked := _check_ip_blocked():
+        return blocked
 
     params = dict(
         otp=req.otp,
@@ -365,20 +394,7 @@ def post_check_otp(req: t.PostCheckOtp, s: t.SessionInfo):
         if not row:
             return 'Invalid OTP', 401
 
-        club_params = dict(
-            person_id=s.person_id,
-            club_name=s.pending_club_name,
-            pending_club_name=s.pending_club_name,
-            do_modify=True,
-        )
-
-        if \
-                club_params['person_id'] is not None and \
-                club_params['club_name'] is not None:
-            tx.execute(Q_JOIN_CLUB, club_params)
-            tx.execute(Q_UPSERT_SEARCH_PREFERENCE_CLUB, club_params)
-
-        clubs = tx.execute(Q_GET_SESSION_CLUBS, club_params).fetchone()
+        clubs = _handle_pending_club(tx, s.person_id, s.pending_club_name)
 
         tx.execute(Q_UPDATE_LAST, dict(person_uuid=row['person_uuid']))
 
@@ -406,21 +422,16 @@ def _sign_in_with_social(
     caller is responsible for verifying the provider's JWT and passing
     canonical claim values.
     """
-    if not request.remote_addr or firehol.matches(request.remote_addr):
-        return 'IP address blocked', 460
+    if blocked := _check_ip_blocked():
+        return blocked
 
-    session_token = secrets.token_hex(64)
-    session_token_hash = sha512(session_token)
+    session_token, session_token_hash = _new_session_token()
     normalized = normalize_email(email)
 
     with api_tx() as tx:
         # 0. Banned-person guard (mirrors `_OTP_CTE`).
-        banned = tx.execute(Q_IS_BANNED, dict(
-            normalized_email=normalized,
-            ip_address=request.remote_addr,
-        )).fetchone()
-        if banned:
-            return 'Banned', 461
+        if banned := _check_banned(tx, normalized):
+            return banned
 
         # 1. Resolve to an existing person via (provider, sub) first; on
         #    miss, fall back to an email match against `person`.
@@ -519,17 +530,7 @@ def _sign_in_with_social(
             )
 
         # 6. Same pending-club-join handling as the OTP path.
-        club_params = dict(
-            person_id=person_id,
-            club_name=pending_club_name,
-            pending_club_name=pending_club_name,
-            do_modify=True,
-        )
-        if person_id is not None and pending_club_name is not None:
-            tx.execute(Q_JOIN_CLUB, club_params)
-            tx.execute(Q_UPSERT_SEARCH_PREFERENCE_CLUB, club_params)
-
-        clubs = tx.execute(Q_GET_SESSION_CLUBS, club_params).fetchone()
+        clubs = _handle_pending_club(tx, person_id, pending_club_name)
 
         if profile.get('person_uuid'):
             tx.execute(Q_UPDATE_LAST, dict(person_uuid=profile['person_uuid']))
@@ -801,25 +802,7 @@ def post_finish_onboarding(s: t.SessionInfo):
             person_id=row['person_id'],
         ))
 
-        club_params = dict(
-            person_id=row['person_id'],
-            club_name=s.pending_club_name,
-            pending_club_name=s.pending_club_name,
-            do_modify=True,
-        )
-
-        if \
-                club_params['person_id'] is not None and \
-                club_params['club_name'] is not None:
-            tx.execute(Q_JOIN_CLUB, club_params)
-            tx.execute(Q_UPSERT_SEARCH_PREFERENCE_CLUB, club_params)
-
-        clubs = tx.execute(Q_GET_SESSION_CLUBS, club_params).fetchone()
-
-    chat_params = dict(
-        person_id=row['person_id'],
-        person_uuid=row['person_uuid'],
-    )
+        clubs = _handle_pending_club(tx, row['person_id'], s.pending_club_name)
 
     return dict(**row, **clubs)
 

--- a/service/person/__init__.py
+++ b/service/person/__init__.py
@@ -374,6 +374,169 @@ def post_sign_out(s: t.SessionInfo):
     with api_tx('READ COMMITTED') as tx:
         tx.execute(Q_DELETE_DUO_SESSION, params)
 
+def _sign_in_with_social(
+    provider: str,
+    sub: str,
+    email: str,
+    email_verified: bool,
+    pending_club_name: Optional[str],
+):
+    """
+    Shared logic for /sign-in-with-google and /sign-in-with-apple. The
+    caller is responsible for verifying the provider's JWT and passing
+    canonical claim values.
+    """
+    if not request.remote_addr or firehol.matches(request.remote_addr):
+        return 'IP address blocked', 460
+
+    # Match the OTP path: store emails lowercased; the rest of the system
+    # treats `person.email` as already-lowercased.
+    email = email.lower().strip() if email else ''
+
+    session_token = secrets.token_hex(64)
+    session_token_hash = sha512(session_token)
+    normalized = normalize_email(email) if email else ''
+
+    with api_tx() as tx:
+        # 0. Banned-person guard (mirrors `_OTP_CTE`).
+        if normalized:
+            banned = tx.execute(Q_IS_BANNED, dict(
+                normalized_email=normalized,
+                ip_address=request.remote_addr,
+            )).fetchone()
+            if banned:
+                return 'Banned', 461
+
+        # 1. Resolve to an existing person via (provider, sub) first; on
+        #    miss, fall back to a verified-email match against `person`.
+        row = tx.execute(Q_LOOKUP_SOCIAL_IDENTITY, dict(
+            provider=provider,
+            provider_sub=sub,
+        )).fetchone()
+        person_id = row['person_id'] if row else None
+
+        if person_id is None and email_verified and email:
+            row = tx.execute(Q_LOOKUP_PERSON_BY_EMAIL, dict(
+                normalized_email=normalized,
+                email=email,
+            )).fetchone()
+            if row:
+                person_id = row['person_id']
+                # Auto-link: record the social identity so future sign-ins
+                # hit Q_LOOKUP_SOCIAL_IDENTITY directly.
+                tx.execute(Q_INSERT_SOCIAL_IDENTITY, dict(
+                    provider=provider,
+                    provider_sub=sub,
+                    person_id=person_id,
+                    email=email,
+                ))
+
+        # 2. New user with no email? We can't proceed — Apple should always
+        #    include `email` in the identity token, but if it doesn't and
+        #    there's no existing link, we can't create an onboardee row
+        #    (the table is keyed by email).
+        if person_id is None and not email:
+            return 'Provider did not return an email', 400
+
+        # 3. New user: ensure an onboardee row, then carry the pending
+        #    social identity on the session so /finish-onboarding can
+        #    promote it to `social_identity` once the person row exists.
+        # The user picks their display name in the onboarding wizard;
+        # we deliberately don't seed it from the provider's `name` claim.
+        pending_provider = None
+        pending_sub = None
+        if person_id is None:
+            tx.execute(Q_UPSERT_ONBOARDEE_FOR_SOCIAL, dict(email=email))
+            pending_provider = provider
+            pending_sub = sub
+
+        # 4. Mint the session — already signed in.
+        tx.execute(Q_INSERT_DUO_SESSION_SOCIAL, dict(
+            session_token_hash=session_token_hash,
+            person_id=person_id,
+            email=email,
+            pending_club_name=pending_club_name,
+            ip_address=request.remote_addr,
+            pending_social_provider=pending_provider,
+            pending_social_sub=pending_sub,
+        ))
+
+        # 5. For existing users, bump sign-in metadata + reactivation
+        #    club counts; for new users, return a stub profile.
+        if person_id is not None:
+            profile = tx.execute(Q_AFTER_SOCIAL_SIGN_IN, dict(
+                person_id=person_id,
+            )).fetchone()
+        else:
+            profile = dict(
+                person_id=None,
+                person_uuid=None,
+                has_gold=False,
+                units=None,
+                do_show_donation_nag=False,
+                estimated_end_date=None,
+                name=None,
+            )
+
+        # 6. Same pending-club-join handling as the OTP path.
+        club_params = dict(
+            person_id=person_id,
+            club_name=pending_club_name,
+            pending_club_name=pending_club_name,
+            do_modify=True,
+        )
+        if person_id is not None and pending_club_name is not None:
+            tx.execute(Q_JOIN_CLUB, club_params)
+            tx.execute(Q_UPSERT_SEARCH_PREFERENCE_CLUB, club_params)
+
+        clubs = tx.execute(Q_GET_SESSION_CLUBS, club_params).fetchone()
+
+        if profile.get('person_uuid'):
+            tx.execute(Q_UPDATE_LAST, dict(person_uuid=profile['person_uuid']))
+
+    return dict(
+        session_token=session_token,
+        onboarded=person_id is not None,
+        **profile,
+        **clubs,
+    )
+
+def post_sign_in_with_google(req: 't.PostSignInWithGoogle'):
+    from service.auth.social import (
+        SocialAuthError,
+        verify_google_id_token,
+    )
+    try:
+        claims = verify_google_id_token(req.id_token)
+    except SocialAuthError as e:
+        return f'Invalid Google token: {e}', 401
+
+    return _sign_in_with_social(
+        provider='google',
+        sub=claims['sub'],
+        email=claims['email'],
+        email_verified=claims['email_verified'],
+        pending_club_name=req.pending_club_name,
+    )
+
+def post_sign_in_with_apple(req: 't.PostSignInWithApple'):
+    from service.auth.social import (
+        SocialAuthError,
+        verify_apple_identity_token,
+    )
+    try:
+        claims = verify_apple_identity_token(req.identity_token)
+    except SocialAuthError as e:
+        return f'Invalid Apple token: {e}', 401
+
+    return _sign_in_with_social(
+        provider='apple',
+        sub=claims['sub'],
+        email=claims['email'],
+        email_verified=claims['email_verified'],
+        pending_club_name=req.pending_club_name,
+    )
+
 def post_check_session_token(s: t.SessionInfo):
     params = dict(
         person_id=s.person_id,
@@ -588,6 +751,14 @@ def post_finish_onboarding(s: t.SessionInfo):
         tx.execute('SET LOCAL statement_timeout = 15000') # 15 seconds
         tx.execute(Q_FINISH_ONBOARDING, params=api_params)
         row = tx.fetchone()
+
+        # If this user signed up via Google/Apple, drain the pending
+        # provider identity from `duo_session` into `social_identity` now
+        # that the new `person` row exists.
+        tx.execute(Q_PROMOTE_PENDING_SOCIAL_IDENTITY, dict(
+            session_token_hash=s.session_token_hash,
+            person_id=row['person_id'],
+        ))
 
         club_params = dict(
             person_id=row['person_id'],

--- a/service/person/__init__.py
+++ b/service/person/__init__.py
@@ -441,46 +441,46 @@ def _sign_in_with_social(
         )).fetchone()
         person_id = row['person_id'] if row else None
 
-        if person_id is None and email:
-            # Auto-link / collision check requires a verified email — without
-            # it we'd risk creating an onboardee that later crashes on
-            # `person.email`'s UNIQUE constraint at /finish-onboarding, and
-            # we'd risk handing someone else's account to an unverified
-            # claimant. Reject the whole sign-in up front. 409 (Conflict)
-            # lets the client distinguish this from a bad-token 401 and
-            # surface a clear "verify your email first" message.
-            if not email_verified:
-                row = tx.execute(Q_LOOKUP_PERSON_BY_EMAIL, dict(
-                    normalized_email=normalized,
-                    email=email,
-                )).fetchone()
-                if row:
-                    return (
-                        'An account already exists for this email. Sign in '
-                        'with the email link to confirm ownership, then try '
-                        'social sign-in again.',
-                        409,
-                    )
-                return (
-                    'Your email address is not verified with the sign-in '
-                    'provider. Verify it and try again.',
-                    409,
-                )
+        # Auto-link / collision check requires a verified email — without
+        # it we'd risk creating an onboardee that later crashes on
+        # `person.email`'s UNIQUE constraint at /finish-onboarding, and
+        # we'd risk handing someone else's account to an unverified
+        # claimant. Reject the whole sign-in up front. 409 (Conflict)
+        # lets the client distinguish this from a bad-token 401 and
+        # surface a clear "verify your email first" message.
+        needs_email_match = person_id is None and email
 
-            row = tx.execute(Q_LOOKUP_PERSON_BY_EMAIL, dict(
+        if needs_email_match and not email_verified:
+            existing = tx.execute(Q_LOOKUP_PERSON_BY_EMAIL, dict(
                 normalized_email=normalized,
                 email=email,
             )).fetchone()
-            if row:
-                person_id = row['person_id']
-                # Auto-link: record the social identity so future sign-ins
-                # hit Q_LOOKUP_SOCIAL_IDENTITY directly.
-                tx.execute(Q_INSERT_SOCIAL_IDENTITY, dict(
-                    provider=provider,
-                    provider_sub=sub,
-                    person_id=person_id,
-                    email=email,
-                ))
+            return (
+                'An account already exists for this email. Sign in '
+                'with the email link to confirm ownership, then try '
+                'social sign-in again.'
+                if existing else
+                'Your email address is not verified with the sign-in '
+                'provider. Verify it and try again.',
+                409,
+            )
+
+        # Auto-link: a verified social email matches an existing person.
+        # Record the social identity so future sign-ins hit
+        # Q_LOOKUP_SOCIAL_IDENTITY directly.
+        existing = tx.execute(Q_LOOKUP_PERSON_BY_EMAIL, dict(
+            normalized_email=normalized,
+            email=email,
+        )).fetchone() if needs_email_match else None
+
+        if existing:
+            person_id = existing['person_id']
+            tx.execute(Q_INSERT_SOCIAL_IDENTITY, dict(
+                provider=provider,
+                provider_sub=sub,
+                person_id=person_id,
+                email=email,
+            ))
 
         # 2. New user with no email? We can't proceed — Apple should always
         #    include `email` in the identity token, but if it doesn't and

--- a/service/person/sql/__init__.py
+++ b/service/person/sql/__init__.py
@@ -180,21 +180,6 @@ ORDER BY
     trait_name ASC
 """
 
-# True when the caller is currently banned, by either normalized email or
-# IP. Shared by the OTP path (where it gates the OTP-issuing CTE) and the
-# social-login path (which checks it explicitly before issuing a session).
-# Requires `%(normalized_email)s` and `%(ip_address)s` query params.
-_BANNED_PERSON_PREDICATE = """
-EXISTS (
-    SELECT 1
-    FROM banned_person
-    WHERE
-        (normalized_email = %(normalized_email)s OR ip_address = %(ip_address)s)
-    AND
-        expires_at > NOW()
-)
-"""
-
 # Reactivation/sign-in metadata bumps shared by `/check-otp` and the
 # social sign-in flow: marks the user activated, bumps `sign_in_count` /
 # `sign_in_time`, and (only when the user was previously deactivated)
@@ -249,7 +234,11 @@ existing_person AS (
 )
 """
 
-_OTP_CTE = f"""
+# OTP-issuing CTE chain. The ban check is intentionally NOT here: the
+# OTP and social paths share `Q_IS_BANNED` for that and run it as an
+# explicit step in the same transaction, which keeps both endpoints
+# following the same control flow.
+_OTP_CTE = """
 WITH random_otp AS (
     SELECT LPAD(FLOOR(RANDOM() * (10e5 + 1))::TEXT, 6, '0') AS otp
 ), zero_otp AS (
@@ -278,8 +267,6 @@ WITH random_otp AS (
             (SELECT otp FROM random_otp)
         END AS otp
     WHERE
-        NOT {_BANNED_PERSON_PREDICATE}
-    AND
         NOT EXISTS (
             SELECT
                 1
@@ -3350,12 +3337,25 @@ WHERE
 # Social login (Google / Apple)
 # ---------------------------------------------------------------------------
 
-# Reuses the same predicate as `_OTP_CTE`'s ban guard. We don't repeat the
-# bad_email_domain check here because Apple/Google already gate disposable
-# providers, and Apple's @privaterelay.appleid.com would otherwise trip an
-# overzealous filter.
-Q_IS_BANNED = f"""
-SELECT 1 WHERE {_BANNED_PERSON_PREDICATE}
+# True when the caller is currently banned, by either normalized email
+# or IP. Used by both /request-otp and the social sign-in path as the
+# first statement inside their api_tx() block; the OTP-issuing /
+# session-issuing query then runs against the same snapshot.
+#
+# We don't repeat the bad_email_domain check here because Apple/Google
+# already gate disposable providers, and Apple's
+# @privaterelay.appleid.com would otherwise trip an overzealous filter.
+# The OTP path keeps that filter inside `_OTP_CTE` for new sign-ups.
+Q_IS_BANNED = """
+SELECT 1
+WHERE EXISTS (
+    SELECT 1
+    FROM banned_person
+    WHERE
+        (normalized_email = %(normalized_email)s OR ip_address = %(ip_address)s)
+    AND
+        expires_at > NOW()
+)
 """
 
 # Look up a linked person by provider sub. Excludes bots — a bot account

--- a/service/person/sql/__init__.py
+++ b/service/person/sql/__init__.py
@@ -180,7 +180,22 @@ ORDER BY
     trait_name ASC
 """
 
-_OTP_CTE = """
+# True when the caller is currently banned, by either normalized email or
+# IP. Shared by the OTP path (where it gates the OTP-issuing CTE) and the
+# social-login path (which checks it explicitly before issuing a session).
+# Requires `%(normalized_email)s` and `%(ip_address)s` query params.
+_BANNED_PERSON_PREDICATE = """
+EXISTS (
+    SELECT 1
+    FROM banned_person
+    WHERE
+        (normalized_email = %(normalized_email)s OR ip_address = %(ip_address)s)
+    AND
+        expires_at > NOW()
+)
+"""
+
+_OTP_CTE = f"""
 WITH random_otp AS (
     SELECT LPAD(FLOOR(RANDOM() * (10e5 + 1))::TEXT, 6, '0') AS otp
 ), zero_otp AS (
@@ -209,20 +224,7 @@ WITH random_otp AS (
             (SELECT otp FROM random_otp)
         END AS otp
     WHERE
-        NOT EXISTS (
-            SELECT
-                1
-            FROM
-                banned_person
-            WHERE
-                normalized_email = %(normalized_email)s
-            AND
-                expires_at > NOW()
-            OR
-                ip_address = %(ip_address)s
-            AND
-                expires_at > NOW()
-        )
+        NOT {_BANNED_PERSON_PREDICATE}
     AND
         NOT EXISTS (
             SELECT
@@ -3324,4 +3326,182 @@ SET
     )
 WHERE
     id = %(person_id)s
+"""
+
+# ---------------------------------------------------------------------------
+# Social login (Google / Apple)
+# ---------------------------------------------------------------------------
+
+# Reuses the same predicate as `_OTP_CTE`'s ban guard. We don't repeat the
+# bad_email_domain check here because Apple/Google already gate disposable
+# providers, and Apple's @privaterelay.appleid.com would otherwise trip an
+# overzealous filter.
+Q_IS_BANNED = f"""
+SELECT 1 WHERE {_BANNED_PERSON_PREDICATE}
+"""
+
+# Look up a linked person by provider sub. Excludes bots — a bot account
+# returning here would bypass the bot check that the OTP path performs.
+Q_LOOKUP_SOCIAL_IDENTITY = """
+SELECT
+    person.id AS person_id
+FROM
+    social_identity
+JOIN
+    person ON person.id = social_identity.person_id
+WHERE
+    social_identity.provider = %(provider)s
+AND
+    social_identity.provider_sub = %(provider_sub)s
+AND
+    NOT 'bot' = ANY(person.roles)
+"""
+
+# Auto-link path: find a person by normalized_email so a verified social
+# email can claim an existing OTP-only account without an OTP round-trip.
+# Matches `Q_INSERT_DUO_SESSION`'s tiebreaker (prefer exact-case email).
+Q_LOOKUP_PERSON_BY_EMAIL = """
+SELECT
+    id AS person_id
+FROM
+    person
+WHERE
+    normalized_email = %(normalized_email)s
+AND
+    NOT 'bot' = ANY(roles)
+ORDER BY
+    email = %(email)s DESC,
+    email
+LIMIT 1
+"""
+
+Q_INSERT_SOCIAL_IDENTITY = """
+INSERT INTO social_identity (
+    provider,
+    provider_sub,
+    person_id,
+    email
+) VALUES (
+    %(provider)s,
+    %(provider_sub)s,
+    %(person_id)s,
+    %(email)s
+)
+ON CONFLICT (provider, provider_sub) DO NOTHING
+"""
+
+# Create the onboardee row for a brand-new social sign-up. The user picks
+# their display name later in the onboarding wizard — we deliberately
+# don't seed it from the provider.
+Q_UPSERT_ONBOARDEE_FOR_SOCIAL = """
+INSERT INTO onboardee (email)
+VALUES (%(email)s)
+ON CONFLICT (email) DO NOTHING
+"""
+
+# Insert an already-signed-in session. `pending_social_*` are non-null only
+# when this session belongs to a brand-new user who still has to complete
+# onboarding — `Q_FINISH_ONBOARDING` drains them into `social_identity`.
+Q_INSERT_DUO_SESSION_SOCIAL = """
+INSERT INTO duo_session (
+    session_token_hash,
+    person_id,
+    email,
+    pending_club_name,
+    ip_address,
+    signed_in,
+    pending_social_provider,
+    pending_social_sub
+) VALUES (
+    %(session_token_hash)s,
+    %(person_id)s,
+    %(email)s,
+    %(pending_club_name)s,
+    %(ip_address)s,
+    TRUE,
+    %(pending_social_provider)s,
+    %(pending_social_sub)s
+)
+"""
+
+# Mirrors the `existing_person` + club-count CTEs from `Q_MAYBE_SIGN_IN` so
+# that a social sign-in to an existing person bumps the same metadata as
+# OTP would, including reactivation-driven club counts.
+Q_AFTER_SOCIAL_SIGN_IN = f"""
+WITH existing_person_before_update AS (
+    SELECT id, activated FROM person WHERE id = %(person_id)s
+), existing_person AS (
+    UPDATE
+        person
+    SET
+        activated = TRUE,
+        sign_in_count = sign_in_count + 1,
+        sign_in_time = NOW()
+    WHERE
+        id = %(person_id)s
+    RETURNING
+        person.id,
+        person.uuid AS person_uuid,
+        person.unit_id,
+        person.name,
+        person.last_nag_time,
+        person.sign_up_time,
+        person.count_answers,
+        person.has_gold
+), club_to_increment AS (
+    SELECT
+        person_club.club_name
+    FROM
+        existing_person
+    LEFT JOIN
+        person_club
+    ON
+        person_club.person_id = existing_person.id
+    JOIN
+        existing_person_before_update
+    ON
+        existing_person_before_update.id = existing_person.id
+    WHERE
+        NOT existing_person_before_update.activated
+), increment_club_count_if_not_activated AS (
+    UPDATE
+        club
+    SET
+        count_members = count_members + 1
+    FROM
+        club_to_increment
+    WHERE
+        club_to_increment.club_name = club.name
+)
+SELECT
+    existing_person.id AS person_id,
+    existing_person.person_uuid::TEXT AS person_uuid,
+    existing_person.has_gold,
+    (SELECT name FROM unit WHERE id = existing_person.unit_id) AS units,
+    {_Q_DO_SHOW_DONATION_NAG.format(table='existing_person')},
+    {_Q_ESTIMATED_END_DATE},
+    existing_person.name AS name
+FROM
+    existing_person
+"""
+
+# After a brand-new user finishes onboarding, drain the pending social
+# identity from `duo_session` into `social_identity`. Run inside the same
+# transaction as `Q_FINISH_ONBOARDING`, after the new `person` row exists.
+Q_PROMOTE_PENDING_SOCIAL_IDENTITY = """
+INSERT INTO social_identity (provider, provider_sub, person_id, email)
+SELECT
+    duo_session.pending_social_provider,
+    duo_session.pending_social_sub,
+    %(person_id)s,
+    duo_session.email
+FROM
+    duo_session
+WHERE
+    duo_session.session_token_hash = %(session_token_hash)s
+AND
+    duo_session.pending_social_provider IS NOT NULL
+AND
+    duo_session.pending_social_sub IS NOT NULL
+ON CONFLICT (provider, provider_sub) DO NOTHING
 """

--- a/service/person/sql/__init__.py
+++ b/service/person/sql/__init__.py
@@ -195,6 +195,60 @@ EXISTS (
 )
 """
 
+# Reactivation/sign-in metadata bumps shared by `/check-otp` and the
+# social sign-in flow: marks the user activated, bumps `sign_in_count` /
+# `sign_in_time`, and (only when the user was previously deactivated)
+# increments their clubs' `count_members`.
+#
+# Caller must define `existing_person_before_update` first as a CTE
+# yielding `(id, activated)` with zero or one rows — that anchor lets the
+# club-count branch read the user's *pre-update* activated state.
+_Q_POST_SIGN_IN_CTES = """
+existing_person AS (
+    UPDATE
+        person
+    SET
+        activated = TRUE,
+        sign_in_count = sign_in_count + 1,
+        sign_in_time = NOW()
+    WHERE
+        id = (SELECT id FROM existing_person_before_update)
+    RETURNING
+        person.id,
+        person.uuid AS person_uuid,
+        person.unit_id,
+        person.name,
+        person.last_nag_time,
+        person.sign_up_time,
+        person.count_answers,
+        person.has_gold
+), club_to_increment AS (
+    SELECT
+        person_club.club_name
+    FROM
+        existing_person
+    LEFT JOIN
+        person_club
+    ON
+        person_club.person_id = existing_person.id
+    JOIN
+        existing_person_before_update
+    ON
+        existing_person_before_update.id = existing_person.id
+    WHERE
+        NOT existing_person_before_update.activated
+), increment_club_count_if_not_activated AS (
+    UPDATE
+        club
+    SET
+        count_members = count_members + 1
+    FROM
+        club_to_increment
+    WHERE
+        club_to_increment.club_name = club.name
+)
+"""
+
 _OTP_CTE = f"""
 WITH random_otp AS (
     SELECT LPAD(FLOOR(RANDOM() * (10e5 + 1))::TEXT, 6, '0') AS otp
@@ -332,27 +386,15 @@ WITH valid_session AS (
     RETURNING
         person_id,
         email
-), existing_person AS (
-    UPDATE
-        person
-    SET
-        activated = TRUE,
-        sign_in_count = sign_in_count + 1,
-        sign_in_time = NOW()
+), existing_person_before_update AS (
+    SELECT
+        id,
+        activated
     FROM
-        valid_session
+        person
     WHERE
-        person.id = person_id
-    RETURNING
-        person.id,
-        person.uuid AS person_uuid,
-        person.unit_id,
-        person.name,
-        person.last_nag_time,
-        person.sign_up_time,
-        person.count_answers,
-        person.has_gold
-), new_onboardee AS (
+        id = (SELECT person_id FROM valid_session)
+), {_Q_POST_SIGN_IN_CTES}, new_onboardee AS (
     INSERT INTO onboardee (
         email
     )
@@ -361,30 +403,6 @@ WITH valid_session AS (
     FROM
         valid_session
     WHERE NOT EXISTS (SELECT 1 FROM existing_person)
-), club_to_increment AS (
-    SELECT
-        person_club.club_name
-    FROM
-        existing_person
-    LEFT JOIN
-        person_club
-    ON
-        person_club.person_id = existing_person.id
-    LEFT JOIN
-        person AS existing_person_before_update
-    ON
-        existing_person_before_update.id = existing_person.id
-    WHERE
-        NOT existing_person_before_update.activated
-), increment_club_count_if_not_activated AS (
-    UPDATE
-        club
-    SET
-        count_members = count_members + 1
-    FROM
-        club_to_increment
-    WHERE
-        club_to_increment.club_name = club.name
 )
 SELECT
     person_id,
@@ -3424,58 +3442,19 @@ INSERT INTO duo_session (
 )
 """
 
-# Mirrors the `existing_person` + club-count CTEs from `Q_MAYBE_SIGN_IN` so
-# that a social sign-in to an existing person bumps the same metadata as
-# OTP would, including reactivation-driven club counts.
 Q_AFTER_SOCIAL_SIGN_IN = f"""
 WITH existing_person_before_update AS (
-    SELECT id, activated FROM person WHERE id = %(person_id)s
-), existing_person AS (
-    UPDATE
+    SELECT
+        id,
+        activated
+    FROM
         person
-    SET
-        activated = TRUE,
-        sign_in_count = sign_in_count + 1,
-        sign_in_time = NOW()
     WHERE
         id = %(person_id)s
-    RETURNING
-        person.id,
-        person.uuid AS person_uuid,
-        person.unit_id,
-        person.name,
-        person.last_nag_time,
-        person.sign_up_time,
-        person.count_answers,
-        person.has_gold
-), club_to_increment AS (
-    SELECT
-        person_club.club_name
-    FROM
-        existing_person
-    LEFT JOIN
-        person_club
-    ON
-        person_club.person_id = existing_person.id
-    JOIN
-        existing_person_before_update
-    ON
-        existing_person_before_update.id = existing_person.id
-    WHERE
-        NOT existing_person_before_update.activated
-), increment_club_count_if_not_activated AS (
-    UPDATE
-        club
-    SET
-        count_members = count_members + 1
-    FROM
-        club_to_increment
-    WHERE
-        club_to_increment.club_name = club.name
-)
+), {_Q_POST_SIGN_IN_CTES}
 SELECT
     existing_person.id AS person_id,
-    existing_person.person_uuid::TEXT AS person_uuid,
+    existing_person.person_uuid,
     existing_person.has_gold,
     (SELECT name FROM unit WHERE id = existing_person.unit_id) AS units,
     {_Q_DO_SHOW_DONATION_NAG.format(table='existing_person')},

--- a/service/person/sql/__init__.py
+++ b/service/person/sql/__init__.py
@@ -3325,3 +3325,187 @@ SET
 WHERE
     id = %(person_id)s
 """
+
+# ---------------------------------------------------------------------------
+# Social login (Google / Apple)
+# ---------------------------------------------------------------------------
+
+# Mirrors the banned_person check inside `_OTP_CTE`. We don't repeat the
+# bad_email_domain check here because Apple/Google already gate disposable
+# providers, and Apple's @privaterelay.appleid.com would otherwise trip an
+# overzealous filter.
+Q_IS_BANNED = """
+SELECT 1
+FROM banned_person
+WHERE
+    (normalized_email = %(normalized_email)s OR ip_address = %(ip_address)s)
+AND
+    expires_at > NOW()
+LIMIT 1
+"""
+
+# Look up a linked person by provider sub. Excludes bots — a bot account
+# returning here would bypass the bot check that the OTP path performs.
+Q_LOOKUP_SOCIAL_IDENTITY = """
+SELECT
+    person.id AS person_id
+FROM
+    social_identity
+JOIN
+    person ON person.id = social_identity.person_id
+WHERE
+    social_identity.provider = %(provider)s
+AND
+    social_identity.provider_sub = %(provider_sub)s
+AND
+    NOT 'bot' = ANY(person.roles)
+"""
+
+# Auto-link path: find a person by normalized_email so a verified social
+# email can claim an existing OTP-only account without an OTP round-trip.
+# Matches `Q_INSERT_DUO_SESSION`'s tiebreaker (prefer exact-case email).
+Q_LOOKUP_PERSON_BY_EMAIL = """
+SELECT
+    id AS person_id
+FROM
+    person
+WHERE
+    normalized_email = %(normalized_email)s
+AND
+    NOT 'bot' = ANY(roles)
+ORDER BY
+    email = %(email)s DESC,
+    email
+LIMIT 1
+"""
+
+Q_INSERT_SOCIAL_IDENTITY = """
+INSERT INTO social_identity (
+    provider,
+    provider_sub,
+    person_id,
+    email
+) VALUES (
+    %(provider)s,
+    %(provider_sub)s,
+    %(person_id)s,
+    %(email)s
+)
+ON CONFLICT (provider, provider_sub) DO NOTHING
+"""
+
+# Create the onboardee row for a brand-new social sign-up. The user picks
+# their display name later in the onboarding wizard — we deliberately
+# don't seed it from the provider.
+Q_UPSERT_ONBOARDEE_FOR_SOCIAL = """
+INSERT INTO onboardee (email)
+VALUES (%(email)s)
+ON CONFLICT (email) DO NOTHING
+"""
+
+# Insert an already-signed-in session. `pending_social_*` are non-null only
+# when this session belongs to a brand-new user who still has to complete
+# onboarding — `Q_FINISH_ONBOARDING` drains them into `social_identity`.
+Q_INSERT_DUO_SESSION_SOCIAL = """
+INSERT INTO duo_session (
+    session_token_hash,
+    person_id,
+    email,
+    pending_club_name,
+    ip_address,
+    signed_in,
+    pending_social_provider,
+    pending_social_sub
+) VALUES (
+    %(session_token_hash)s,
+    %(person_id)s,
+    %(email)s,
+    %(pending_club_name)s,
+    %(ip_address)s,
+    TRUE,
+    %(pending_social_provider)s,
+    %(pending_social_sub)s
+)
+"""
+
+# Mirrors the `existing_person` + club-count CTEs from `Q_MAYBE_SIGN_IN` so
+# that a social sign-in to an existing person bumps the same metadata as
+# OTP would, including reactivation-driven club counts.
+Q_AFTER_SOCIAL_SIGN_IN = f"""
+WITH existing_person_before_update AS (
+    SELECT id, activated FROM person WHERE id = %(person_id)s
+), existing_person AS (
+    UPDATE
+        person
+    SET
+        activated = TRUE,
+        sign_in_count = sign_in_count + 1,
+        sign_in_time = NOW()
+    WHERE
+        id = %(person_id)s
+    RETURNING
+        person.id,
+        person.uuid AS person_uuid,
+        person.unit_id,
+        person.name,
+        person.last_nag_time,
+        person.sign_up_time,
+        person.count_answers,
+        person.has_gold
+), club_to_increment AS (
+    SELECT
+        person_club.club_name
+    FROM
+        existing_person
+    LEFT JOIN
+        person_club
+    ON
+        person_club.person_id = existing_person.id
+    JOIN
+        existing_person_before_update
+    ON
+        existing_person_before_update.id = existing_person.id
+    WHERE
+        NOT existing_person_before_update.activated
+), increment_club_count_if_not_activated AS (
+    UPDATE
+        club
+    SET
+        count_members = count_members + 1
+    FROM
+        club_to_increment
+    WHERE
+        club_to_increment.club_name = club.name
+)
+SELECT
+    existing_person.id AS person_id,
+    existing_person.person_uuid::TEXT AS person_uuid,
+    existing_person.has_gold,
+    (SELECT name FROM unit WHERE id = existing_person.unit_id) AS units,
+    {_Q_DO_SHOW_DONATION_NAG.format(table='existing_person')},
+    {_Q_ESTIMATED_END_DATE},
+    existing_person.name AS name
+FROM
+    existing_person
+"""
+
+# After a brand-new user finishes onboarding, drain the pending social
+# identity from `duo_session` into `social_identity`. Run inside the same
+# transaction as `Q_FINISH_ONBOARDING`, after the new `person` row exists.
+Q_PROMOTE_PENDING_SOCIAL_IDENTITY = """
+INSERT INTO social_identity (provider, provider_sub, person_id, email)
+SELECT
+    duo_session.pending_social_provider,
+    duo_session.pending_social_sub,
+    %(person_id)s,
+    duo_session.email
+FROM
+    duo_session
+WHERE
+    duo_session.session_token_hash = %(session_token_hash)s
+AND
+    duo_session.pending_social_provider IS NOT NULL
+AND
+    duo_session.pending_social_sub IS NOT NULL
+ON CONFLICT (provider, provider_sub) DO NOTHING
+"""

--- a/test/functionality1/social-login.sh
+++ b/test/functionality1/social-login.sh
@@ -56,7 +56,10 @@ SESSION_TOKEN=$(jq -r .session_token <<< "$response")
 [[ "$(q "select name is null from onboardee where email = 'new1@example.com'")" = t ]]
 
 # Session is already signed-in and carries the pending social link.
-[[ "$(q "select signed_in from duo_session where session_token_hash = encode(digest('$SESSION_TOKEN'::bytea, 'sha512'), 'hex')")" = t ]]
+# Hash in shell rather than via pgcrypto's `digest()` — the test DB doesn't
+# load that extension. Matches the pattern used in `revenuecat.sh`.
+session_token_hash=$(printf '%s' "$SESSION_TOKEN" | sha512sum | cut -d' ' -f1)
+[[ "$(q "select signed_in from duo_session where session_token_hash = '$session_token_hash'")" = t ]]
 [[ "$(q "select pending_social_provider from duo_session where pending_social_provider is not null")" = google ]]
 [[ "$(q "select pending_social_sub      from duo_session where pending_social_sub is not null")"      = google-sub-1 ]]
 
@@ -124,12 +127,17 @@ SESSION_TOKEN=$(jq -r .session_token <<< "$response")
 [[ "$(q "select count(*) from social_identity where provider = 'google' and provider_sub = 'google-sub-2' and person_id = $linkme_id")" -eq 1 ]]
 
 # ---------------------------------------------------------------------------
-# 4. email_verified:false must NOT auto-link — even if email matches.
+# 4. email_verified:false collides with an existing person → 401. Without
+#    this short-circuit the user would proceed through onboarding and crash
+#    on `person.email`'s UNIQUE constraint at /finish-onboarding.
 # ---------------------------------------------------------------------------
 g_token=$(mint_google_token --sub google-sub-3 --email linkme@example.com --verified false)
-response=$(jc POST /sign-in-with-google -d "{ \"id_token\": \"${g_token}\" }")
-# Treated as a brand-new user: onboarded false, no link inserted.
-[[ "$(jq -r .onboarded <<< "$response")" = false ]]
+status=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST http://localhost:5000/sign-in-with-google \
+  -H "Content-Type: application/json" \
+  -d "{ \"id_token\": \"${g_token}\" }")
+[[ "$status" = "401" ]]
+# No onboardee or social_identity row created for the unverified attempt.
 [[ "$(q "select count(*) from social_identity where provider_sub = 'google-sub-3'")" -eq 0 ]]
 
 # ---------------------------------------------------------------------------

--- a/test/functionality1/social-login.sh
+++ b/test/functionality1/social-login.sh
@@ -236,4 +236,49 @@ complete_onboarding_for_current_session
 club_id=$(get_id 'club@example.com')
 [[ "$(q "select count(*) from person_club where person_id = $club_id and club_name = 'some-club'")" -eq 1 ]]
 
+# ---------------------------------------------------------------------------
+# 11. Apple OAuth callback (web/Android flow). The backend converts
+#     Apple's POST into a 302 carrying the id_token in a query param.
+#     `DUO_APPLE_*_REDIRECT_URL` in docker-compose.test.yml define the
+#     allowed targets.
+# ---------------------------------------------------------------------------
+expected_web_redirect="http://test-web.example/"
+expected_android_redirect="http://test-android.example/"
+
+# 11a. Web target: state = "<nonce>.web" → redirects to web URL with
+# id_token + state preserved. We don't trust curl's URL re-encoding for
+# the assertion, so just check the prefix and that both params are present.
+location=$(curl -s -o /dev/null -w "%{redirect_url}" \
+  -X POST http://localhost:5000/auth/apple/callback \
+  -d 'id_token=fake.id.token&state=abc123.web')
+[[ "$location" == "${expected_web_redirect}"* ]]
+[[ "$location" == *apple_id_token=fake.id.token* ]]
+[[ "$location" == *apple_state=abc123.web* ]]
+
+# 11b. Android target.
+location=$(curl -s -o /dev/null -w "%{redirect_url}" \
+  -X POST http://localhost:5000/auth/apple/callback \
+  -d 'id_token=fake.id.token&state=xyz789.android')
+[[ "$location" == "${expected_android_redirect}"* ]]
+[[ "$location" == *apple_id_token=fake.id.token* ]]
+
+# 11c. Unknown target in state → 400 (no open redirect).
+status=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST http://localhost:5000/auth/apple/callback \
+  -d 'id_token=fake.id.token&state=abc123.evil')
+[[ "$status" = "400" ]]
+
+# 11d. Apple-reported error is forwarded to the client as a query param.
+location=$(curl -s -o /dev/null -w "%{redirect_url}" \
+  -X POST http://localhost:5000/auth/apple/callback \
+  -d 'state=abc123.web&error=user_cancelled_authorize')
+[[ "$location" == "${expected_web_redirect}"* ]]
+[[ "$location" == *apple_error=user_cancelled_authorize* ]]
+
+# 11e. Missing id_token (and no error) → forwarded as a generic error.
+location=$(curl -s -o /dev/null -w "%{redirect_url}" \
+  -X POST http://localhost:5000/auth/apple/callback \
+  -d 'state=abc123.web')
+[[ "$location" == *apple_error=missing_id_token* ]]
+
 echo "social-login.sh OK"

--- a/test/functionality1/social-login.sh
+++ b/test/functionality1/social-login.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+# Tests for /sign-in-with-google and /sign-in-with-apple. Relies on the
+# mocking-mode branch in service/auth/social.py — when
+# test/input/enable-mocking is '1' the API skips JWT signature checks
+# but still enforces iss/aud/exp, so we mint structurally-valid fake
+# tokens with `mint_google_token` / `mint_apple_token` from setup.sh.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "$script_dir"
+
+source ../util/setup.sh
+
+set -xe
+
+reset_db () {
+  local future
+  future=$(q "select iso8601_utc((now() + interval '20 days')::timestamp)")
+  q "delete from duo_session"
+  q "delete from social_identity"
+  q "delete from person"
+  q "delete from onboardee"
+  q "delete from banned_person"
+  q "update funding set estimated_end_date = '$future'"
+}
+
+complete_onboarding_for_current_session () {
+  jc PATCH /onboardee-info -d '{ "name": "Pat" }'
+  jc PATCH /onboardee-info -d '{ "date_of_birth": "1997-05-30" }'
+  c GET /search-locations?q=Syd
+  jc PATCH /onboardee-info -d '{ "location": "Sydney, New South Wales, Australia" }'
+  jc PATCH /onboardee-info -d '{ "gender": "Man" }'
+  jc PATCH /onboardee-info -d '{ "other_peoples_genders": ["Woman"] }'
+  c POST /finish-onboarding
+}
+
+# ---------------------------------------------------------------------------
+# 1. Brand-new sign-up via Google → onboardee created, session signed-in,
+#    pending_social_* set, social_identity row appears after
+#    /finish-onboarding.
+# ---------------------------------------------------------------------------
+reset_db
+SESSION_TOKEN=""
+
+g_token=$(mint_google_token --sub google-sub-1 --email new1@example.com)
+response=$(jc POST /sign-in-with-google -d "{ \"id_token\": \"${g_token}\" }")
+
+[[ "$(jq -r .onboarded         <<< "$response")" = false ]]
+[[ "$(jq -r .person_id         <<< "$response")" = null ]]
+[[ "$(jq -r .session_token     <<< "$response")" != null ]]
+
+SESSION_TOKEN=$(jq -r .session_token <<< "$response")
+
+# Onboardee created with no name (we deliberately don't seed from provider).
+[[ "$(q "select count(*) from onboardee where email = 'new1@example.com'")" -eq 1 ]]
+[[ "$(q "select name is null from onboardee where email = 'new1@example.com'")" = t ]]
+
+# Session is already signed-in and carries the pending social link.
+[[ "$(q "select signed_in from duo_session where session_token_hash = encode(digest('$SESSION_TOKEN'::bytea, 'sha512'), 'hex')")" = t ]]
+[[ "$(q "select pending_social_provider from duo_session where pending_social_provider is not null")" = google ]]
+[[ "$(q "select pending_social_sub      from duo_session where pending_social_sub is not null")"      = google-sub-1 ]]
+
+# No social_identity row yet — that only happens after onboarding completes.
+[[ "$(q "select count(*) from social_identity")" -eq 0 ]]
+
+complete_onboarding_for_current_session
+
+# Now there's a person row and a matching social_identity link.
+new1_id=$(get_id 'new1@example.com')
+[[ "$(q "select count(*) from social_identity where provider = 'google' and provider_sub = 'google-sub-1' and person_id = $new1_id")" -eq 1 ]]
+
+# ---------------------------------------------------------------------------
+# 2. Returning sign-in: same Google sub → onboarded:true, no new
+#    onboardee, sign_in_count increments, social_identity unchanged.
+# ---------------------------------------------------------------------------
+sign_in_count_before=$(q "select sign_in_count from person where id = $new1_id")
+si_count_before=$(q "select count(*) from social_identity")
+
+g_token=$(mint_google_token --sub google-sub-1 --email new1@example.com)
+response=$(jc POST /sign-in-with-google -d "{ \"id_token\": \"${g_token}\" }")
+
+[[ "$(jq -r .onboarded <<< "$response")" = true ]]
+[[ "$(jq -r .person_id <<< "$response")" = "$new1_id" ]]
+SESSION_TOKEN=$(jq -r .session_token <<< "$response")
+
+# Sign-in metadata bumped exactly once.
+sign_in_count_after=$(q "select sign_in_count from person where id = $new1_id")
+[[ $((sign_in_count_after - sign_in_count_before)) -eq 1 ]]
+
+# No duplicate onboardee, no duplicate social_identity.
+[[ "$(q "select count(*) from onboardee where email = 'new1@example.com'")" -eq 0 ]]
+[[ "$(q "select count(*) from social_identity")" -eq "$si_count_before" ]]
+
+c POST /check-session-token > /dev/null
+
+# ---------------------------------------------------------------------------
+# 3. Auto-link: existing OTP user signs in with Google for the first
+#    time. Verified email should match by normalized_email; backend
+#    inserts a social_identity row and returns onboarded:true.
+# ---------------------------------------------------------------------------
+reset_db
+SESSION_TOKEN=""
+
+# Build an existing OTP-only user.
+response=$(jc POST /request-otp -d '{ "email": "linkme@example.com" }')
+SESSION_TOKEN=$(jq -r .session_token <<< "$response")
+jc POST /check-otp -d '{ "otp": "000000" }'
+complete_onboarding_for_current_session
+linkme_id=$(get_id 'linkme@example.com')
+
+# No social_identity link yet.
+[[ "$(q "select count(*) from social_identity where person_id = $linkme_id")" -eq 0 ]]
+
+SESSION_TOKEN=""
+# Google sign-in for the same email (different case to exercise normalize_email).
+g_token=$(mint_google_token --sub google-sub-2 --email LINKME@example.com)
+response=$(jc POST /sign-in-with-google -d "{ \"id_token\": \"${g_token}\" }")
+
+[[ "$(jq -r .onboarded <<< "$response")" = true ]]
+[[ "$(jq -r .person_id <<< "$response")" = "$linkme_id" ]]
+SESSION_TOKEN=$(jq -r .session_token <<< "$response")
+
+# Auto-link inserted exactly one row.
+[[ "$(q "select count(*) from social_identity where provider = 'google' and provider_sub = 'google-sub-2' and person_id = $linkme_id")" -eq 1 ]]
+
+# ---------------------------------------------------------------------------
+# 4. email_verified:false must NOT auto-link — even if email matches.
+# ---------------------------------------------------------------------------
+g_token=$(mint_google_token --sub google-sub-3 --email linkme@example.com --verified false)
+response=$(jc POST /sign-in-with-google -d "{ \"id_token\": \"${g_token}\" }")
+# Treated as a brand-new user: onboarded false, no link inserted.
+[[ "$(jq -r .onboarded <<< "$response")" = false ]]
+[[ "$(q "select count(*) from social_identity where provider_sub = 'google-sub-3'")" -eq 0 ]]
+
+# ---------------------------------------------------------------------------
+# 5. Apple basic sign-up.
+# ---------------------------------------------------------------------------
+reset_db
+SESSION_TOKEN=""
+
+a_token=$(mint_apple_token --sub apple-sub-1 --email apple1@example.com)
+response=$(jc POST /sign-in-with-apple -d "{ \"identity_token\": \"${a_token}\" }")
+
+[[ "$(jq -r .onboarded         <<< "$response")" = false ]]
+[[ "$(jq -r .session_token     <<< "$response")" != null ]]
+SESSION_TOKEN=$(jq -r .session_token <<< "$response")
+
+[[ "$(q "select pending_social_provider from duo_session where pending_social_provider is not null")" = apple ]]
+
+complete_onboarding_for_current_session
+apple1_id=$(get_id 'apple1@example.com')
+[[ "$(q "select count(*) from social_identity where provider = 'apple' and provider_sub = 'apple-sub-1' and person_id = $apple1_id")" -eq 1 ]]
+
+# ---------------------------------------------------------------------------
+# 6. Apple Hide-My-Email: privaterelay address never matches an existing
+#    OTP account, so the user goes through onboarding as new.
+# ---------------------------------------------------------------------------
+# Pre-existing OTP user at a "real" address.
+SESSION_TOKEN=""
+response=$(jc POST /request-otp -d '{ "email": "real@example.com" }')
+SESSION_TOKEN=$(jq -r .session_token <<< "$response")
+jc POST /check-otp -d '{ "otp": "000000" }'
+complete_onboarding_for_current_session
+real_id=$(get_id 'real@example.com')
+
+SESSION_TOKEN=""
+relay_token=$(mint_apple_token --sub apple-sub-relay --email abc.def@privaterelay.appleid.com)
+response=$(jc POST /sign-in-with-apple -d "{ \"identity_token\": \"${relay_token}\" }")
+
+# Did NOT auto-link to real@example.com.
+[[ "$(jq -r .onboarded <<< "$response")" = false ]]
+[[ "$(q "select count(*) from social_identity where person_id = $real_id")" -eq 0 ]]
+SESSION_TOKEN=$(jq -r .session_token <<< "$response")
+complete_onboarding_for_current_session
+relay_id=$(get_id 'abc.def@privaterelay.appleid.com')
+[[ "$relay_id" -ne "$real_id" ]]
+
+# ---------------------------------------------------------------------------
+# 7. Banned user (by email) → 461.
+# ---------------------------------------------------------------------------
+reset_db
+q "insert into banned_person (normalized_email, expires_at) values ('banned@example.com', now() + interval '1 month')"
+
+g_token=$(mint_google_token --sub google-banned --email banned@example.com)
+response_file=/tmp/social-banned.$$
+status=$(curl -s -o "$response_file" -w "%{http_code}" \
+  -X POST http://localhost:5000/sign-in-with-google \
+  -H "Content-Type: application/json" \
+  -d "{ \"id_token\": \"${g_token}\" }")
+[[ "$status" = "461" ]]
+rm -f "$response_file"
+
+# ---------------------------------------------------------------------------
+# 8. Bad audience → 401.
+# ---------------------------------------------------------------------------
+bad_aud=$(mint_google_token --sub x --email a@b.com --aud not-our-client-id)
+status=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST http://localhost:5000/sign-in-with-google \
+  -H "Content-Type: application/json" \
+  -d "{ \"id_token\": \"${bad_aud}\" }")
+[[ "$status" = "401" ]]
+
+# ---------------------------------------------------------------------------
+# 9. Bad issuer (Apple-shaped token to /sign-in-with-google) → 401.
+# ---------------------------------------------------------------------------
+mismatched=$(mint_apple_token --sub x --email a@b.com)
+status=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST http://localhost:5000/sign-in-with-google \
+  -H "Content-Type: application/json" \
+  -d "{ \"id_token\": \"${mismatched}\" }")
+[[ "$status" = "401" ]]
+
+# ---------------------------------------------------------------------------
+# 10. Pending club join works on social sign-up.
+# ---------------------------------------------------------------------------
+reset_db
+SESSION_TOKEN=""
+
+g_token=$(mint_google_token --sub google-club --email club@example.com)
+response=$(jc POST /sign-in-with-google \
+  -d "{ \"id_token\": \"${g_token}\", \"pending_club_name\": \"some-club\" }")
+SESSION_TOKEN=$(jq -r .session_token <<< "$response")
+
+# Pending club is recorded on the session and surfaces after onboarding.
+[[ "$(q "select pending_club_name from duo_session where pending_club_name is not null")" = some-club ]]
+
+complete_onboarding_for_current_session
+club_id=$(get_id 'club@example.com')
+[[ "$(q "select count(*) from person_club where person_id = $club_id and club_name = 'some-club'")" -eq 1 ]]
+
+echo "social-login.sh OK"

--- a/test/functionality1/social-login.sh
+++ b/test/functionality1/social-login.sh
@@ -13,6 +13,11 @@ source ../util/setup.sh
 
 set -xe
 
+# Default nonce shared by mint_apple_token and the /sign-in-with-apple
+# request bodies. The backend rejects an Apple sign-in whose JWT.nonce
+# doesn't match the nonce supplied alongside the token.
+NONCE="test-nonce-0000000000000000"
+
 reset_db () {
   local future
   future=$(q "select iso8601_utc((now() + interval '20 days')::timestamp)")
@@ -127,18 +132,35 @@ SESSION_TOKEN=$(jq -r .session_token <<< "$response")
 [[ "$(q "select count(*) from social_identity where provider = 'google' and provider_sub = 'google-sub-2' and person_id = $linkme_id")" -eq 1 ]]
 
 # ---------------------------------------------------------------------------
-# 4. email_verified:false collides with an existing person → 401. Without
-#    this short-circuit the user would proceed through onboarding and crash
-#    on `person.email`'s UNIQUE constraint at /finish-onboarding.
+# 4a. email_verified:false collides with an existing person → 409. Without
+#     this short-circuit the user would proceed through onboarding and crash
+#     on `person.email`'s UNIQUE constraint at /finish-onboarding. The 409
+#     status (vs 401) is what tells the client to show the "use email to
+#     confirm ownership" hint rather than a generic auth-failure message.
 # ---------------------------------------------------------------------------
 g_token=$(mint_google_token --sub google-sub-3 --email linkme@example.com --verified false)
 status=$(curl -s -o /dev/null -w "%{http_code}" \
   -X POST http://localhost:5000/sign-in-with-google \
   -H "Content-Type: application/json" \
   -d "{ \"id_token\": \"${g_token}\" }")
-[[ "$status" = "401" ]]
+[[ "$status" = "409" ]]
 # No onboardee or social_identity row created for the unverified attempt.
 [[ "$(q "select count(*) from social_identity where provider_sub = 'google-sub-3'")" -eq 0 ]]
+
+# ---------------------------------------------------------------------------
+# 4b. email_verified:false with no existing person → also 409. Allowing the
+#     sign-up would create an account at an email the provider hasn't
+#     attested to, blocking the rightful owner from later registering via
+#     OTP. Reject up front to keep email ownership in step with verification.
+# ---------------------------------------------------------------------------
+g_token=$(mint_google_token --sub google-sub-4 --email unverified@example.com --verified false)
+status=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST http://localhost:5000/sign-in-with-google \
+  -H "Content-Type: application/json" \
+  -d "{ \"id_token\": \"${g_token}\" }")
+[[ "$status" = "409" ]]
+[[ "$(q "select count(*) from onboardee where email = 'unverified@example.com'")" -eq 0 ]]
+[[ "$(q "select count(*) from social_identity where provider_sub = 'google-sub-4'")" -eq 0 ]]
 
 # ---------------------------------------------------------------------------
 # 5. Apple basic sign-up.
@@ -147,7 +169,8 @@ reset_db
 SESSION_TOKEN=""
 
 a_token=$(mint_apple_token --sub apple-sub-1 --email apple1@example.com)
-response=$(jc POST /sign-in-with-apple -d "{ \"identity_token\": \"${a_token}\" }")
+response=$(jc POST /sign-in-with-apple \
+  -d "{ \"identity_token\": \"${a_token}\", \"nonce\": \"${NONCE}\" }")
 
 [[ "$(jq -r .onboarded         <<< "$response")" = false ]]
 [[ "$(jq -r .session_token     <<< "$response")" != null ]]
@@ -173,7 +196,8 @@ real_id=$(get_id 'real@example.com')
 
 SESSION_TOKEN=""
 relay_token=$(mint_apple_token --sub apple-sub-relay --email abc.def@privaterelay.appleid.com)
-response=$(jc POST /sign-in-with-apple -d "{ \"identity_token\": \"${relay_token}\" }")
+response=$(jc POST /sign-in-with-apple \
+  -d "{ \"identity_token\": \"${relay_token}\", \"nonce\": \"${NONCE}\" }")
 
 # Did NOT auto-link to real@example.com.
 [[ "$(jq -r .onboarded <<< "$response")" = false ]]
@@ -217,6 +241,20 @@ status=$(curl -s -o /dev/null -w "%{http_code}" \
   -H "Content-Type: application/json" \
   -d "{ \"id_token\": \"${mismatched}\" }")
 [[ "$status" = "401" ]]
+
+# ---------------------------------------------------------------------------
+# 9b. Apple token whose JWT.nonce doesn't match the nonce the client says
+#     it asked for → 401. Protects against an attacker replaying a stolen
+#     id_token: even with a valid signature, the nonce binding fails.
+# ---------------------------------------------------------------------------
+reset_db
+a_token=$(mint_apple_token --sub apple-nonce-bad --email a@b.com --nonce someone-elses-nonce-aaaaaaaaa)
+status=$(curl -s -o /dev/null -w "%{http_code}" \
+  -X POST http://localhost:5000/sign-in-with-apple \
+  -H "Content-Type: application/json" \
+  -d "{ \"identity_token\": \"${a_token}\", \"nonce\": \"${NONCE}\" }")
+[[ "$status" = "401" ]]
+[[ "$(q "select count(*) from social_identity where provider_sub = 'apple-nonce-bad'")" -eq 0 ]]
 
 # ---------------------------------------------------------------------------
 # 10. Pending club join works on social sign-up.

--- a/test/util/setup.sh
+++ b/test/util/setup.sh
@@ -292,20 +292,25 @@ mint_google_token () {
 #   --email <e>        email (use a privaterelay address to simulate Hide My Email)
 #   --verified <b>     email_verified, defaults true
 #   --aud <a>          audience, defaults to the iOS bundle id
+#   --nonce <n>        nonce echoed into the JWT's nonce claim (defaults to
+#                      "test-nonce-0000000000000000" — matches the nonce
+#                      tests pass in /sign-in-with-apple request bodies)
 # Example:
 #   t=$(mint_apple_token --sub a-1 --email user1@example.com)
 mint_apple_token () {
-  local sub email aud verified
+  local sub email aud verified nonce
   sub=""
   email=""
   aud="app.duolicious"
   verified="true"
+  nonce="test-nonce-0000000000000000"
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --sub)      sub="$2"; shift 2 ;;
       --email)    email="$2"; shift 2 ;;
       --aud)      aud="$2"; shift 2 ;;
       --verified) verified="$2"; shift 2 ;;
+      --nonce)    nonce="$2"; shift 2 ;;
       *) echo "mint_apple_token: unknown arg $1" >&2; return 1 ;;
     esac
   done
@@ -314,8 +319,9 @@ mint_apple_token () {
     --arg sub "$sub" \
     --arg email "$email" \
     --arg aud "$aud" \
+    --arg nonce "$nonce" \
     --argjson verified "$verified" \
-    '{iss:"https://appleid.apple.com",aud:$aud,sub:$sub,email:$email,email_verified:$verified,exp:9999999999,iat:1700000000}')
+    '{iss:"https://appleid.apple.com",aud:$aud,sub:$sub,email:$email,email_verified:$verified,nonce:$nonce,exp:9999999999,iat:1700000000}')
   mint_fake_jwt "$payload"
 }
 

--- a/test/util/setup.sh
+++ b/test/util/setup.sh
@@ -228,6 +228,97 @@ get_uuid () {
   q "select uuid::text from person where email = '$1'"
 }
 
+# Base64URL-encode stdin (no padding). Used by jwt_b64.
+b64url () {
+  base64 -w 0 | tr '+/' '-_' | tr -d '='
+}
+
+# Mint a fake JWT for the social-login mocking path.
+# Args: $1 = JSON payload string. The header is fixed (HS256/JWT) and the
+# signature is a constant garbage value — when test/input/enable-mocking
+# is '1', service/auth/social.py decodes payloads without verifying the
+# signature, so any non-empty signature works. Issuer / audience / exp
+# are still enforced, so the JSON payload must include them.
+# Example:
+#   t=$(mint_fake_jwt '{"iss":"https://accounts.google.com","aud":"test-dummy.apps.googleusercontent.com","sub":"g-1","email":"a@example.com","email_verified":true,"exp":9999999999}')
+mint_fake_jwt () {
+  local payload="$1"
+  local header_b64
+  local payload_b64
+  local sig_b64
+  header_b64=$(printf '{"alg":"HS256","typ":"JWT"}' | b64url)
+  payload_b64=$(printf '%s' "$payload" | b64url)
+  sig_b64=$(printf 'fake-signature' | b64url)
+  printf '%s.%s.%s' "$header_b64" "$payload_b64" "$sig_b64"
+}
+
+# Mint a fake Google ID token. Defaults match the test docker-compose
+# config and an expiry far in the future.
+# Args:
+#   --sub <s>       Google sub (required)
+#   --email <e>     email (required)
+#   --verified <b>  email_verified, defaults true
+#   --aud <a>       audience, defaults to the test client id
+# Example:
+#   t=$(mint_google_token --sub g-1 --email user1@example.com)
+mint_google_token () {
+  local sub email aud verified
+  sub=""
+  email=""
+  aud="test-dummy.apps.googleusercontent.com"
+  verified="true"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --sub)      sub="$2"; shift 2 ;;
+      --email)    email="$2"; shift 2 ;;
+      --aud)      aud="$2"; shift 2 ;;
+      --verified) verified="$2"; shift 2 ;;
+      *) echo "mint_google_token: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  local payload
+  payload=$(jq -nc \
+    --arg sub "$sub" \
+    --arg email "$email" \
+    --arg aud "$aud" \
+    --argjson verified "$verified" \
+    '{iss:"https://accounts.google.com",aud:$aud,sub:$sub,email:$email,email_verified:$verified,exp:9999999999,iat:1700000000}')
+  mint_fake_jwt "$payload"
+}
+
+# Mint a fake Apple identity token.
+# Args:
+#   --sub <s>          Apple sub (required)
+#   --email <e>        email (use a privaterelay address to simulate Hide My Email)
+#   --verified <b>     email_verified, defaults true
+#   --aud <a>          audience, defaults to the iOS bundle id
+# Example:
+#   t=$(mint_apple_token --sub a-1 --email user1@example.com)
+mint_apple_token () {
+  local sub email aud verified
+  sub=""
+  email=""
+  aud="app.duolicious"
+  verified="true"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --sub)      sub="$2"; shift 2 ;;
+      --email)    email="$2"; shift 2 ;;
+      --aud)      aud="$2"; shift 2 ;;
+      --verified) verified="$2"; shift 2 ;;
+      *) echo "mint_apple_token: unknown arg $1" >&2; return 1 ;;
+    esac
+  done
+  local payload
+  payload=$(jq -nc \
+    --arg sub "$sub" \
+    --arg email "$email" \
+    --arg aud "$aud" \
+    --argjson verified "$verified" \
+    '{iss:"https://appleid.apple.com",aud:$aud,sub:$sub,email:$email,email_verified:$verified,exp:9999999999,iat:1700000000}')
+  mint_fake_jwt "$payload"
+}
+
 # Delete all messages from the test SMTP server (MailHog).
 # Example: delete_emails
 delete_emails () {

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -1,3 +1,14 @@
+def append_query(base: str, params: dict) -> str:
+    from urllib.parse import quote
+    sep = '&' if '?' in base else '?'
+    encoded = '&'.join(
+        f'{quote(k, safe="")}={quote(v, safe="")}'
+        for k, v in params.items()
+        if v is not None
+    )
+    return f'{base}{sep}{encoded}' if encoded else base
+
+
 def human_readable_size_metric(size_bytes):
     # Define suffixes for metric prefixes
     suffixes = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB']

--- a/vm/docker/.env
+++ b/vm/docker/.env
@@ -18,3 +18,16 @@ DUO_SMTP_HOST=replace-me
 DUO_SMTP_PASS=replace-me
 DUO_SMTP_PORT=587
 DUO_SMTP_USER=replace-me
+
+# Social-login OAuth audiences. Comma-separated.
+# Google: every OAuth client ID that ships in a client (iOS, Android, Web).
+# Apple: bundle ID for native iOS, plus the Services ID for web/Android.
+DUO_GOOGLE_CLIENT_IDS=replace-me
+DUO_APPLE_CLIENT_IDS=replace-me
+
+# Where /auth/apple/callback redirects users after web/Android Apple
+# sign-in. The web URL is typically the SPA root. The Android URL must
+# be the Universal Link / App Link the Android app passes to
+# expo-web-browser as `returnUrl`.
+DUO_APPLE_WEB_REDIRECT_URL=replace-me
+DUO_APPLE_ANDROID_REDIRECT_URL=replace-me


### PR DESCRIPTION
TODO - Fix AI slop:

- [ ] Handle sign-up, not just sign-in
- [ ] Add env vars to docker-compose yaml files
- [ ] Tests
- [ ] Make the entire login flow DRYer, particularly checking for "banned" status
- [ ] Not allowed: if statements within if statements
- [ ] Users should be able to log in the old way even after account linking

---

Frontend PR: https://github.com/duolicious/duolicious-frontend/pull/972