### PR TITLE
Make bus deserialization ignore unknown fields

### DIFF
--- a/backend/chatprotocol/outbound.py
+++ b/backend/chatprotocol/outbound.py
@@ -105,8 +105,10 @@ def to_bus(obj: Outbound) -> str:
 
 def from_bus(serialized: str) -> Outbound:
     payload = json.loads(serialized)
-    kind = payload.pop('kind')
-    return _REGISTRY[kind](**payload)
+    cls = _REGISTRY[payload.pop('kind')]
+    field_names = {field.name for field in dataclasses.fields(cls)}
+    kwargs = {k: v for k, v in payload.items() if k in field_names}
+    return cls(**kwargs)
 
 
 def _jid(username: str) -> str:

--- a/backend/chatprotocol/test_init.py
+++ b/backend/chatprotocol/test_init.py
@@ -152,6 +152,14 @@ class TestOutboundInvariant(unittest.TestCase):
             with self.subTest(stanza=type(sample).__name__):
                 self.assertEqual(from_bus(to_bus(sample)), sample)
 
+    def test_bus_ignores_unknown_fields(self) -> None:
+        serialized = json.dumps({
+            'kind': 'ServerError',
+            'stanza_id': 'id1',
+            'field_from_the_future': 'ignored',
+        })
+        self.assertEqual(from_bus(serialized), ServerError(stanza_id='id1'))
+
 
 class TestInboundParsing(unittest.TestCase):
     def _both(self, xml: str, js: str) -> tuple[object, object]:


### PR DESCRIPTION
Phase 1 of the chat-reactions rollout: a forward-compatibility release to deploy across all chat workers before any worker emits the new reaction fields. `from_bus` now drops fields the running worker doesn't recognize instead of crashing (which the bus consumer would silently swallow, dropping otherwise-valid messages).

Related: https://github.com/duolicious/duolicious/pull/1175, https://github.com/duolicious/duolicious/pull/1176, https://github.com/duolicious/duolicious/issues/1040