### PR TITLE
Deprecate `/inbox-info`

### DIFF
--- a/backend/chatprotocol/__init__.py
+++ b/backend/chatprotocol/__init__.py
@@ -14,6 +14,7 @@ so the live-push and snapshot paths share one source of truth.
 from chatprotocol.element import Element
 from chatprotocol.inbound import (
     InboxQuery,
+    InboxSnapshotQuery,
     IqBind,
     IqSession,
     MamQuery,

--- a/backend/chatprotocol/inbound.py
+++ b/backend/chatprotocol/inbound.py
@@ -89,6 +89,16 @@ class InboxQuery:
 
 
 @dataclass(frozen=True)
+class InboxSnapshotQuery:
+    """
+    The modern inbox query (`duo_query_inbox`). Unlike the legacy `InboxQuery`,
+    the response carries complete conversations (person info included), so
+    clients don't have to join the inbox against the `/inbox-info` endpoint.
+    """
+    pass
+
+
+@dataclass(frozen=True)
 class MarkDisplayed:
     to_username: str
 
@@ -113,6 +123,7 @@ Inbound = (
     | RegisterPushToken
     | MamQuery
     | InboxQuery
+    | InboxSnapshotQuery
     | MarkDisplayed
     | VisitorsQuery
     | MarkVisitorsChecked
@@ -331,6 +342,9 @@ def _interpret(el: Element) -> Inbound | None:
 
     if el.tag == 'duo_query_visitors':
         return VisitorsQuery()
+
+    if el.tag == 'duo_query_inbox':
+        return InboxSnapshotQuery()
 
     if el.tag == 'duo_mark_visitors_checked':
         return MarkVisitorsChecked(when=el.get('when'))

--- a/backend/chatprotocol/outbound.py
+++ b/backend/chatprotocol/outbound.py
@@ -478,15 +478,15 @@ class InboxFin(Outbound):
 @dataclass(frozen=True)
 class InboxSnapshot(Outbound):
     """
-    The response to `duo_query_inbox`: a JSON payload of the form
+    The response to `duo_query_inbox`: a JSON object of the form
     `{"conversations": [...]}` where each conversation is complete (last
     message, unread state and person info), replacing the legacy
     `InboxResult`/`InboxFin` stream plus `/inbox-info` join.
     """
-    payload_json: str
+    payload: dict
 
     def canonical(self) -> dict:
-        return {'duo_inbox': self.payload_json}
+        return {'duo_inbox': self.payload}
 
 
 @_register
@@ -497,10 +497,10 @@ class InboxEntry(Outbound):
     pushed to the recipient when a message arrives so their client can update
     its inbox without any further requests.
     """
-    payload_json: str
+    payload: dict
 
     def canonical(self) -> dict:
-        return {'duo_inbox_entry': self.payload_json}
+        return {'duo_inbox_entry': self.payload}
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/chatprotocol/outbound.py
+++ b/backend/chatprotocol/outbound.py
@@ -474,6 +474,35 @@ class InboxFin(Outbound):
         }}
 
 
+@_register
+@dataclass(frozen=True)
+class InboxSnapshot(Outbound):
+    """
+    The response to `duo_query_inbox`: a JSON payload of the form
+    `{"conversations": [...]}` where each conversation is complete (last
+    message, unread state and person info), replacing the legacy
+    `InboxResult`/`InboxFin` stream plus `/inbox-info` join.
+    """
+    payload_json: str
+
+    def canonical(self) -> dict:
+        return {'duo_inbox': self.payload_json}
+
+
+@_register
+@dataclass(frozen=True)
+class InboxEntry(Outbound):
+    """
+    A single conversation in the same shape as `InboxSnapshot`'s entries,
+    pushed to the recipient when a message arrives so their client can update
+    its inbox without any further requests.
+    """
+    payload_json: str
+
+    def canonical(self) -> dict:
+        return {'duo_inbox_entry': self.payload_json}
+
+
 # --------------------------------------------------------------------------- #
 # Session / handshake stanzas                                                 #
 # --------------------------------------------------------------------------- #

--- a/backend/chatprotocol/outbound.py
+++ b/backend/chatprotocol/outbound.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import dataclasses
 import json
 from dataclasses import dataclass
+from typing import TypedDict
 
 from chatprotocol.jid import LSERVER
 from chatprotocol.element import (
@@ -474,6 +475,34 @@ class InboxFin(Outbound):
         }}
 
 
+@dataclass(frozen=True)
+class InboxConversation(TypedDict):
+    """
+    The wire shape of one inbox conversation: the whole of an `InboxEntry`
+    payload, and each element of an `InboxSnapshot` payload's `conversations`.
+    This is the single source of truth for that shape; the rows it's assembled
+    from come from `Q_INBOX_SNAPSHOT`/`Q_INBOX_ENTRY` in
+    `service.chat.messagestorage.inbox`.
+    """
+    person_uuid: str
+    url_slug: str | None
+    name: str | None
+    match_percentage: int | None
+    image_uuid: str | None
+    image_blurhash: str | None
+    is_verified: bool
+    is_available: bool
+    location: str
+    last_message: str
+    last_message_read: bool
+    last_message_timestamp: str
+
+
+@dataclass(frozen=True)
+class InboxSnapshotPayload(TypedDict):
+    conversations: list[InboxConversation]
+
+
 @_register
 @dataclass(frozen=True)
 class InboxSnapshot(Outbound):
@@ -483,7 +512,7 @@ class InboxSnapshot(Outbound):
     message, unread state and person info), replacing the legacy
     `InboxResult`/`InboxFin` stream plus `/inbox-info` join.
     """
-    payload: dict
+    payload: InboxSnapshotPayload
 
     def canonical(self) -> dict:
         return {'duo_inbox': self.payload}
@@ -497,7 +526,7 @@ class InboxEntry(Outbound):
     pushed to the recipient when a message arrives so their client can update
     its inbox without any further requests.
     """
-    payload: dict
+    payload: InboxConversation
 
     def canonical(self) -> dict:
         return {'duo_inbox_entry': self.payload}

--- a/backend/chatprotocol/test_init.py
+++ b/backend/chatprotocol/test_init.py
@@ -80,7 +80,7 @@ _VISITORS_PAYLOAD_JSON = json.dumps({
     'you_visited': [],
     'last_visited_at': None,
 })
-_INBOX_CONVERSATION_JSON = json.dumps({
+_INBOX_CONVERSATION = {
     'person_uuid': U2,
     'url_slug': 'some-slug',
     'name': 'Alé & <co>',
@@ -93,10 +93,10 @@ _INBOX_CONVERSATION_JSON = json.dumps({
     'last_message': 'hi',
     'last_message_read': False,
     'last_message_timestamp': '2020-01-01T00:00:00.000000Z',
-})
-_INBOX_PAYLOAD_JSON = json.dumps({
-    'conversations': [json.loads(_INBOX_CONVERSATION_JSON)],
-})
+}
+_INBOX_PAYLOAD = {
+    'conversations': [_INBOX_CONVERSATION],
+}
 
 # One representative instance of every outbound stanza.
 OUTBOUND_SAMPLES = [
@@ -159,8 +159,8 @@ OUTBOUND_SAMPLES = [
         inner_to_username=U1, body='hi', stamp='2020-01-01T00:00:00.000000Z',
         unread_count=2, box='inbox', query_id='q1', muted_until=0),
     InboxFin(query_id='q1'),
-    InboxSnapshot(payload_json=_INBOX_PAYLOAD_JSON),
-    InboxEntry(payload_json=_INBOX_CONVERSATION_JSON),
+    InboxSnapshot(payload=_INBOX_PAYLOAD),
+    InboxEntry(payload=_INBOX_CONVERSATION),
     StreamOpenResponse(version='1.0', id='oid', from_=LSERVER),
     StreamFeatures(authenticated=False),
     StreamFeatures(authenticated=True),

--- a/backend/chatprotocol/test_init.py
+++ b/backend/chatprotocol/test_init.py
@@ -31,10 +31,12 @@ from chatprotocol.outbound import (
     AuthFailure,
     AuthSuccess,
     BindResult,
+    InboxConversation,
     InboxEntry,
     InboxFin,
     InboxResult,
     InboxSnapshot,
+    InboxSnapshotPayload,
     IncomingChat,
     IncomingReaction,
     IncomingTyping,
@@ -80,7 +82,7 @@ _VISITORS_PAYLOAD_JSON = json.dumps({
     'you_visited': [],
     'last_visited_at': None,
 })
-_INBOX_CONVERSATION = {
+_INBOX_CONVERSATION: InboxConversation = {
     'person_uuid': U2,
     'url_slug': 'some-slug',
     'name': 'Alé & <co>',
@@ -94,7 +96,7 @@ _INBOX_CONVERSATION = {
     'last_message_read': False,
     'last_message_timestamp': '2020-01-01T00:00:00.000000Z',
 }
-_INBOX_PAYLOAD = {
+_INBOX_PAYLOAD: InboxSnapshotPayload = {
     'conversations': [_INBOX_CONVERSATION],
 }
 

--- a/backend/chatprotocol/test_init.py
+++ b/backend/chatprotocol/test_init.py
@@ -12,6 +12,7 @@ from chatprotocol.message import (
 from chatprotocol import outbound
 from chatprotocol.inbound import (
     InboxQuery,
+    InboxSnapshotQuery,
     IqBind,
     IqSession,
     MamQuery,
@@ -30,8 +31,10 @@ from chatprotocol.outbound import (
     AuthFailure,
     AuthSuccess,
     BindResult,
+    InboxEntry,
     InboxFin,
     InboxResult,
+    InboxSnapshot,
     IncomingChat,
     IncomingReaction,
     IncomingTyping,
@@ -76,6 +79,23 @@ _VISITORS_PAYLOAD_JSON = json.dumps({
     'visited_you': [],
     'you_visited': [],
     'last_visited_at': None,
+})
+_INBOX_CONVERSATION_JSON = json.dumps({
+    'person_uuid': U2,
+    'url_slug': 'some-slug',
+    'name': 'Alé & <co>',
+    'match_percentage': 50,
+    'image_uuid': None,
+    'image_blurhash': None,
+    'is_verified': False,
+    'is_available': True,
+    'location': 'intros',
+    'last_message': 'hi',
+    'last_message_read': False,
+    'last_message_timestamp': '2020-01-01T00:00:00.000000Z',
+})
+_INBOX_PAYLOAD_JSON = json.dumps({
+    'conversations': [json.loads(_INBOX_CONVERSATION_JSON)],
 })
 
 # One representative instance of every outbound stanza.
@@ -139,6 +159,8 @@ OUTBOUND_SAMPLES = [
         inner_to_username=U1, body='hi', stamp='2020-01-01T00:00:00.000000Z',
         unread_count=2, box='inbox', query_id='q1', muted_until=0),
     InboxFin(query_id='q1'),
+    InboxSnapshot(payload_json=_INBOX_PAYLOAD_JSON),
+    InboxEntry(payload_json=_INBOX_CONVERSATION_JSON),
     StreamOpenResponse(version='1.0', id='oid', from_=LSERVER),
     StreamFeatures(authenticated=False),
     StreamFeatures(authenticated=True),
@@ -314,6 +336,10 @@ class TestInboundParsing(unittest.TestCase):
         self.assertEqual(
             parse_incoming('{"duo_mark_visitors_checked": null}'),
             MarkVisitorsChecked(when=None))
+
+    def test_inbox_snapshot_query(self) -> None:
+        self.assertEqual(
+            parse_incoming('{"duo_query_inbox": null}'), InboxSnapshotQuery())
 
     def test_inbox_query(self) -> None:
         js = (

--- a/backend/init-api.sql
+++ b/backend/init-api.sql
@@ -49,13 +49,17 @@ $$ LANGUAGE plpgsql IMMUTABLE STRICT;
 
 
 CREATE OR REPLACE FUNCTION uuid_or_null(str text)
-RETURNS uuid AS $$
-BEGIN
-    RETURN str::uuid;
-EXCEPTION WHEN invalid_text_representation THEN
-    RETURN NULL;
-END;
-$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+  RETURNS uuid
+  LANGUAGE sql
+  IMMUTABLE
+  PARALLEL SAFE
+  STRICT
+AS $$
+    SELECT CASE
+        WHEN str ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        THEN str::uuid
+    END
+$$;
 
 
 CREATE OR REPLACE FUNCTION iso8601_utc(ts timestamp)

--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -1,23 +1,12 @@
-CREATE OR REPLACE FUNCTION
-    mark_club_stats_dirty()
-RETURNS TRIGGER AS $$
-BEGIN
-    IF TG_OP = 'DELETE' THEN
-        INSERT INTO club_stats_dirty (club_name)
-        SELECT OLD.club_name
-        WHERE EXISTS (SELECT 1 FROM club WHERE name = OLD.club_name)
-        ON CONFLICT DO NOTHING;
-        RETURN OLD;
-    ELSIF TG_OP = 'UPDATE' THEN
-        IF OLD.activated IS DISTINCT FROM NEW.activated THEN
-            INSERT INTO club_stats_dirty (club_name) VALUES (NEW.club_name)
-            ON CONFLICT DO NOTHING;
-        END IF;
-        RETURN NEW;
-    ELSE
-        INSERT INTO club_stats_dirty (club_name) VALUES (NEW.club_name)
-        ON CONFLICT DO NOTHING;
-        RETURN NEW;
-    END IF;
-END;
-$$ LANGUAGE plpgsql;
+CREATE OR REPLACE FUNCTION uuid_or_null(str text)
+  RETURNS uuid
+  LANGUAGE sql
+  IMMUTABLE
+  PARALLEL SAFE
+  STRICT
+AS $$
+    SELECT CASE
+        WHEN str ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        THEN str::uuid
+    END
+$$;

--- a/backend/service/chat/__init__.py
+++ b/backend/service/chat/__init__.py
@@ -56,6 +56,7 @@ from service.chat.chatutil import (
     format_timestamp,
     now_microseconds,
     fetch_id_from_username,
+    redis_has_subscribers,
 )
 from chatprotocol.message import (
     AudioMessage,
@@ -220,15 +221,6 @@ REPEATED_CHARACTERS_RE = regex.compile(r'(.)\1{1,}')
 
 async def redis_publish(channel: str, message: str) -> None:
     await REDIS_WORKER_CLIENT.publish(channel, message)
-
-
-async def redis_has_subscribers(channel: str) -> bool:
-    """
-    True when at least one websocket connection (on any chat worker; they all
-    share one Redis) is subscribed to `channel`.
-    """
-    [(_, count)] = await REDIS_WORKER_CLIENT.pubsub_numsub(channel)
-    return count > 0
 
 
 async def redis_publish_many(
@@ -780,7 +772,7 @@ async def process_text(
             # offline recipient gets the whole inbox via `duo_query_inbox` on
             # reconnect anyway. That reconnect snapshot also covers the race
             # where a recipient connects between this check and the publish.
-            if await redis_has_subscribers(to_username):
+            if await redis_has_subscribers(REDIS_WORKER_CLIENT, to_username):
                 await redis_publish_many(
                         to_username,
                         await get_inbox_entry(

--- a/backend/service/chat/__init__.py
+++ b/backend/service/chat/__init__.py
@@ -222,6 +222,15 @@ async def redis_publish(channel: str, message: str) -> None:
     await REDIS_WORKER_CLIENT.publish(channel, message)
 
 
+async def redis_has_subscribers(channel: str) -> bool:
+    """
+    True when at least one websocket connection (on any chat worker; they all
+    share one Redis) is subscribed to `channel`.
+    """
+    [(_, count)] = await REDIS_WORKER_CLIENT.pubsub_numsub(channel)
+    return count > 0
+
+
 async def redis_publish_many(
     channel: str,
     messages: Iterable[Outbound],
@@ -765,11 +774,18 @@ async def process_text(
             # its inbox already has the sender's info (which legacy clients
             # fetched from `/inbox-info` instead). This runs after the message
             # is stored, so the entry reflects the new message.
-            await redis_publish_many(
-                    to_username,
-                    await get_inbox_entry(
-                        viewer_username=to_username,
-                        prospect_username=from_username))
+            #
+            # Fetching the entry is skipped when nobody is subscribed to the
+            # recipient's channel: the publish would go nowhere, and an
+            # offline recipient gets the whole inbox via `duo_query_inbox` on
+            # reconnect anyway. That reconnect snapshot also covers the race
+            # where a recipient connects between this check and the publish.
+            if await redis_has_subscribers(to_username):
+                await redis_publish_many(
+                        to_username,
+                        await get_inbox_entry(
+                            viewer_username=to_username,
+                            prospect_username=from_username))
 
             await redis_publish_many(to_username, [delivery_message])
 

--- a/backend/service/chat/__init__.py
+++ b/backend/service/chat/__init__.py
@@ -21,6 +21,8 @@ from service.chat.spam import is_spam_message
 from service.chat.upsertlastnotification import upsert_last_notification
 from service.chat.messagestorage.inbox import (
     get_inbox,
+    get_inbox_entry,
+    get_inbox_snapshot,
     mark_displayed,
 )
 from service.chat.messagestorage.mam import (
@@ -64,6 +66,7 @@ from chatprotocol.message import (
 )
 from chatprotocol import (
     InboxQuery,
+    InboxSnapshotQuery,
     MamQuery,
     MarkDisplayed,
     MarkVisitorsChecked,
@@ -553,6 +556,11 @@ async def process_text(
                 connection_uuid,
                 await get_inbox(parsed.query_id, from_username))
 
+    if isinstance(parsed, InboxSnapshotQuery):
+        return await redis_publish_many(
+                connection_uuid,
+                await get_inbox_snapshot(from_username))
+
     if isinstance(parsed, VisitorsQuery):
         return await redis_publish_many(
                 connection_uuid,
@@ -752,6 +760,17 @@ async def process_text(
         # Don't deliver to the recipient when the sender is shadow-banned; the
         # sender still gets their delivery receipt below.
         if not is_shadow_banned:
+            # The complete inbox entry goes out before the message itself so
+            # that by the time the recipient's client reacts to the message,
+            # its inbox already has the sender's info (which legacy clients
+            # fetched from `/inbox-info` instead). This runs after the message
+            # is stored, so the entry reflects the new message.
+            await redis_publish_many(
+                    to_username,
+                    await get_inbox_entry(
+                        viewer_username=to_username,
+                        prospect_username=from_username))
+
             await redis_publish_many(to_username, [delivery_message])
 
         await redis_publish_many(connection_uuid, [response])

--- a/backend/service/chat/chatutil/__init__.py
+++ b/backend/service/chat/chatutil/__init__.py
@@ -1,3 +1,5 @@
+import redis.asyncio as redis
+
 from async_lru_cache import AsyncLruCache
 from database import api_tx
 
@@ -45,6 +47,18 @@ SELECT shadow_banned_at FROM person WHERE id = %(person_id)s
 Q_FETCH_IS_PUBLIC = """
 SELECT public_profile FROM person WHERE id = %(person_id)s
 """
+
+
+async def redis_has_subscribers(
+    redis_client: redis.Redis,
+    channel: str,
+) -> bool:
+    """
+    True when at least one websocket connection (on any chat worker; they all
+    share one Redis) is subscribed to `channel`.
+    """
+    [(_, count)] = await redis_client.pubsub_numsub(channel)
+    return count > 0
 
 
 @AsyncLruCache(ttl=5)  # 5 seconds

--- a/backend/service/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/chat/messagestorage/inbox/__init__.py
@@ -48,17 +48,17 @@ WITH viewer AS (
     FROM
         person
     WHERE
-        uuid = uuid_or_null(%(username)s)
+        uuid = %(username)s::uuid
 ), entry AS (
     SELECT
-        split_part(remote_bare_jid, '@', 1) AS prospect_uuid,
+        uuid_or_null(split_part(remote_bare_jid, '@', 1)) AS prospect_uuid,
         body,
         COALESCE(unread_count, 0) AS unread_count,
         timestamp
     FROM
         inbox
     WHERE
-        luser = %(username)s
+        luser = %(username)s::text
     {entry_predicate}
 ), conversation AS (
     SELECT
@@ -125,7 +125,7 @@ WITH viewer AS (
     LEFT JOIN
         person AS prospect
     ON
-        prospect.uuid = uuid_or_null(entry.prospect_uuid)
+        prospect.uuid = entry.prospect_uuid
     LEFT JOIN
         viewer
     ON
@@ -181,14 +181,8 @@ WITH viewer AS (
     FROM
         conversation
 )
--- One row per conversation, already gated. The rows are assembled into the
--- wire payload in Python (see `_conversation_from_row`): building the JSON here
--- would make Postgres serialize a document that psycopg immediately parses back
--- into dicts, and its per-row timestamp formatting (`to_char`) is markedly
--- slower than doing it in Python. `timestamp` stays raw microseconds and is
--- formatted by `format_timestamp` on the way out.
 SELECT
-    prospect_uuid AS person_uuid,
+    prospect_uuid::TEXT AS person_uuid,
     url_slug,
     CASE WHEN is_available THEN name END AS name,
     CASE WHEN is_available THEN match_percentage END AS match_percentage,
@@ -425,6 +419,7 @@ async def _fetch_inbox_conversations(
         # thresholds for users with large inboxes, so JIT spends ~1s compiling
         # for no benefit. (Same rationale as the legacy Q_INBOX_INFO.)
         await tx.execute('SET LOCAL jit = off')
+        await tx.execute('SET LOCAL statement_timeout = 15000')
         await tx.execute(query, params)
         rows = await tx.fetchall()
 

--- a/backend/service/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/chat/messagestorage/inbox/__init__.py
@@ -3,12 +3,12 @@ import traceback
 from batcher import Batcher
 from database import Row, Tx, api_tx
 from dataclasses import dataclass
-from typing import TypedDict
 from service.chat.chatutil import (
     LSERVER,
     format_timestamp,
 )
 from chatprotocol.outbound import (
+    InboxConversation,
     InboxEntry,
     InboxFin,
     InboxResult,
@@ -359,28 +359,10 @@ async def get_inbox(query_id: str, username: str) -> list[Outbound]:
     return messages
 
 
-class InboxConversation(TypedDict):
-    """
-    The wire shape of one inbox conversation: the whole of a `duo_inbox_entry`,
-    and each element of a `duo_inbox` snapshot's `conversations`. This is the
-    single source of truth for that shape; `Q_INBOX_SNAPSHOT`/`Q_INBOX_ENTRY`
-    return the underlying columns and the query gates the viewer-visible fields,
-    but the payload itself is assembled here.
-    """
-    person_uuid: str
-    url_slug: str | None
-    name: str | None
-    match_percentage: int | None
-    image_uuid: str | None
-    image_blurhash: str | None
-    is_verified: bool
-    is_available: bool
-    location: str
-    last_message: str
-    last_message_read: bool
-    last_message_timestamp: str
-
-
+# The wire shape itself is defined beside the stanzas that carry it
+# (`chatprotocol.outbound.InboxConversation`); `Q_INBOX_SNAPSHOT`/
+# `Q_INBOX_ENTRY` return the underlying columns and the query gates the
+# viewer-visible fields, but the payload is assembled here.
 def _conversation_from_row(row: Row) -> InboxConversation:
     return InboxConversation(
         person_uuid=row['person_uuid'],

--- a/backend/service/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/chat/messagestorage/inbox/__init__.py
@@ -1,3 +1,6 @@
+import json
+import traceback
+
 from batcher import Batcher
 from database import Tx, api_tx
 from dataclasses import dataclass
@@ -6,8 +9,10 @@ from service.chat.chatutil import (
     format_timestamp,
 )
 from chatprotocol.outbound import (
+    InboxEntry,
     InboxFin,
     InboxResult,
+    InboxSnapshot,
     Outbound,
 )
 
@@ -20,6 +25,189 @@ WHERE
     luser = %(username)s
 ORDER BY
     timestamp
+"""
+
+
+# The gating rules (which fields a viewer may see, and which box the
+# conversation belongs in) mirror Q_INBOX_INFO, which serves the legacy
+# `/inbox-info` endpoint. This query joins them against the viewer's `inbox`
+# rows so one websocket response carries complete conversations.
+Q_INBOX_SNAPSHOT = """
+WITH viewer AS (
+    SELECT
+        id,
+        personality
+    FROM
+        person
+    WHERE
+        uuid = uuid_or_null(%(username)s)
+), entry AS (
+    SELECT
+        split_part(remote_bare_jid, '@', 1) AS prospect_uuid,
+        body,
+        COALESCE(unread_count, 0) AS unread_count,
+        timestamp
+    FROM
+        inbox
+    WHERE
+        luser = %(username)s
+    AND
+        (
+            %(prospect_uuid)s::TEXT IS NULL
+        OR
+            split_part(remote_bare_jid, '@', 1) = %(prospect_uuid)s::TEXT
+        )
+), conversation AS (
+    SELECT
+        entry.prospect_uuid,
+        entry.body,
+        entry.unread_count,
+        entry.timestamp,
+        prospect.url_slug AS url_slug,
+        prospect.name AS name,
+        COALESCE(prospect.verification_level_id > 1, FALSE) AS verified,
+        photo.uuid AS image_uuid,
+        photo.blurhash AS image_blurhash,
+        CLAMP(
+            0,
+            99,
+            100 * (1 - (viewer.personality <#> prospect.personality)) / 2
+        )::SMALLINT AS match_percentage,
+        prospect.id IS NULL AS is_prospect_deleted,
+        COALESCE(
+            prospect.activated AND prospect.shadow_banned_at IS NULL, FALSE
+        ) AS is_prospect_activated,
+        EXISTS (
+            SELECT
+                1
+            FROM
+                messaged
+            WHERE
+                subject_person_id = viewer.id
+            AND
+                object_person_id = prospect.id
+        ) AS person_messaged_prospect,
+        EXISTS (
+            SELECT
+                1
+            FROM
+                messaged
+            WHERE
+                subject_person_id = prospect.id
+            AND
+                object_person_id = viewer.id
+        ) AS prospect_messaged_person,
+        EXISTS (
+            SELECT
+                1
+            FROM
+                skipped
+            WHERE
+                subject_person_id = viewer.id
+            AND
+                object_person_id = prospect.id
+        ) AS person_skipped_prospect,
+        EXISTS (
+            SELECT
+                1
+            FROM
+                skipped
+            WHERE
+                subject_person_id = prospect.id
+            AND
+                object_person_id = viewer.id
+        ) AS prospect_skipped_person
+    FROM
+        entry
+    LEFT JOIN
+        person AS prospect
+    ON
+        prospect.uuid = uuid_or_null(entry.prospect_uuid)
+    LEFT JOIN
+        viewer
+    ON
+        TRUE
+    LEFT JOIN LATERAL (
+        SELECT
+            uuid,
+            blurhash
+        FROM
+            photo
+        WHERE
+            person_id = prospect.id
+        ORDER BY
+            position
+        LIMIT 1
+    ) AS photo
+    ON
+        TRUE
+), gated AS (
+    SELECT
+        conversation.*,
+        is_prospect_activated AND NOT prospect_skipped_person AS is_available,
+        CASE
+            WHEN
+                    NOT is_prospect_deleted
+                AND
+                    NOT prospect_messaged_person
+            THEN 'nowhere'
+            WHEN
+                    is_prospect_activated
+                AND
+                    NOT prospect_skipped_person
+                AND
+                    NOT person_skipped_prospect
+                AND
+                    prospect_messaged_person
+                AND
+                    person_messaged_prospect
+            THEN 'chats'
+            WHEN
+                    is_prospect_activated
+                AND
+                    NOT prospect_skipped_person
+                AND
+                    NOT person_skipped_prospect
+                AND
+                    prospect_messaged_person
+                AND
+                    NOT person_messaged_prospect
+            THEN 'intros'
+            ELSE 'archive'
+        END AS location
+    FROM
+        conversation
+)
+SELECT
+    JSON_BUILD_OBJECT(
+        'conversations',
+        COALESCE(
+            JSON_AGG(
+                JSON_BUILD_OBJECT(
+                    'person_uuid', prospect_uuid,
+                    'url_slug', url_slug,
+                    'name', CASE WHEN is_available THEN name END,
+                    'match_percentage',
+                        CASE WHEN is_available THEN match_percentage END,
+                    'image_uuid', CASE WHEN is_available THEN image_uuid END,
+                    'image_blurhash',
+                        CASE WHEN is_available THEN image_blurhash END,
+                    'is_verified', is_available AND verified,
+                    'is_available', is_available,
+                    'location', location,
+                    'last_message', body,
+                    'last_message_read', unread_count = 0,
+                    'last_message_timestamp', iso8601_utc(
+                        (TO_TIMESTAMP(timestamp / 1e6) AT TIME ZONE 'UTC')
+                    )
+                )
+                ORDER BY timestamp
+            ),
+            '[]'::JSON
+        )
+    ) AS j
+FROM
+    gated
 """
 
 
@@ -170,6 +358,64 @@ async def get_inbox(query_id: str, username: str) -> list[Outbound]:
     messages.append(InboxFin(query_id=query_id))
 
     return messages
+
+
+async def _fetch_inbox_conversations(
+    username: str,
+    prospect_uuid: str | None = None,
+) -> dict:
+    params = dict(username=username, prospect_uuid=prospect_uuid)
+
+    async with api_tx('read committed') as tx:
+        # The query is cheap (index-only scans) but its estimated cost crosses
+        # the default jit thresholds for users with large inboxes, so JIT
+        # spends ~1s compiling for no benefit. (Same rationale as the legacy
+        # Q_INBOX_INFO.)
+        await tx.execute('SET LOCAL jit = off')
+        row = await tx.require_one(Q_INBOX_SNAPSHOT, params)
+
+    return row['j']
+
+
+async def get_inbox_snapshot(username: str) -> list[Outbound]:
+    """
+    The user's whole inbox, each conversation complete with person info, as a
+    single `InboxSnapshot`.
+    """
+    try:
+        payload = await _fetch_inbox_conversations(username)
+
+        return [InboxSnapshot(payload_json=json.dumps(payload))]
+    except Exception:
+        print(traceback.format_exc())
+        return []
+
+
+async def get_inbox_entry(
+    viewer_username: str,
+    prospect_username: str,
+) -> list[Outbound]:
+    """
+    The viewer's conversation with one prospect, in the same shape as an
+    `InboxSnapshot` entry, for pushing alongside a delivered message. Empty
+    when the viewer has no inbox row for the prospect (or on failure), so
+    callers can publish the result unconditionally.
+    """
+    try:
+        payload = await _fetch_inbox_conversations(
+            username=viewer_username,
+            prospect_uuid=prospect_username,
+        )
+
+        conversations = payload['conversations']
+
+        if not conversations:
+            return []
+
+        return [InboxEntry(payload_json=json.dumps(conversations[0]))]
+    except Exception:
+        print(traceback.format_exc())
+        return []
 
 
 async def process_upsert_conversation_batch(tx: Tx, batch: list[UpsertConversationJob]) -> None:

--- a/backend/service/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/chat/messagestorage/inbox/__init__.py
@@ -1,8 +1,9 @@
 import traceback
 
 from batcher import Batcher
-from database import Tx, api_tx
+from database import Row, Tx, api_tx
 from dataclasses import dataclass
+from typing import TypedDict
 from service.chat.chatutil import (
     LSERVER,
     format_timestamp,
@@ -180,38 +181,31 @@ WITH viewer AS (
     FROM
         conversation
 )
+-- One row per conversation, already gated. The rows are assembled into the
+-- wire payload in Python (see `_conversation_from_row`): building the JSON here
+-- would make Postgres serialize a document that psycopg immediately parses back
+-- into dicts, and its per-row timestamp formatting (`to_char`) is markedly
+-- slower than doing it in Python. `timestamp` stays raw microseconds and is
+-- formatted by `format_timestamp` on the way out.
 SELECT
-    JSON_BUILD_OBJECT(
-        'conversations',
-        COALESCE(
-            JSON_AGG(
-                JSON_BUILD_OBJECT(
-                    'person_uuid', prospect_uuid,
-                    'url_slug', url_slug,
-                    'name', CASE WHEN is_available THEN name END,
-                    'match_percentage',
-                        CASE WHEN is_available THEN match_percentage END,
-                    'image_uuid', CASE WHEN is_available THEN image_uuid END,
-                    'image_blurhash',
-                        CASE WHEN is_available THEN image_blurhash END,
-                    'is_verified', is_available AND verified,
-                    'is_available', is_available,
-                    'location', location,
-                    'last_message', body,
-                    'last_message_read', unread_count = 0,
-                    'last_message_timestamp', iso8601_utc(
-                        (TO_TIMESTAMP(timestamp / 1e6) AT TIME ZONE 'UTC')
-                    )
-                )
-                ORDER BY timestamp
-            ),
-            '[]'::JSON
-        )
-    ) AS j
+    prospect_uuid AS person_uuid,
+    url_slug,
+    CASE WHEN is_available THEN name END AS name,
+    CASE WHEN is_available THEN match_percentage END AS match_percentage,
+    CASE WHEN is_available THEN image_uuid END AS image_uuid,
+    CASE WHEN is_available THEN image_blurhash END AS image_blurhash,
+    is_available AND verified AS is_verified,
+    is_available,
+    location,
+    body AS last_message,
+    unread_count = 0 AS last_message_read,
+    timestamp AS last_message_timestamp
 FROM
     gated
 WHERE
     location <> 'nowhere'
+ORDER BY
+    timestamp
 """
 
 
@@ -371,10 +365,51 @@ async def get_inbox(query_id: str, username: str) -> list[Outbound]:
     return messages
 
 
+class InboxConversation(TypedDict):
+    """
+    The wire shape of one inbox conversation: the whole of a `duo_inbox_entry`,
+    and each element of a `duo_inbox` snapshot's `conversations`. This is the
+    single source of truth for that shape; `Q_INBOX_SNAPSHOT`/`Q_INBOX_ENTRY`
+    return the underlying columns and the query gates the viewer-visible fields,
+    but the payload itself is assembled here.
+    """
+    person_uuid: str
+    url_slug: str | None
+    name: str | None
+    match_percentage: int | None
+    image_uuid: str | None
+    image_blurhash: str | None
+    is_verified: bool
+    is_available: bool
+    location: str
+    last_message: str
+    last_message_read: bool
+    last_message_timestamp: str
+
+
+def _conversation_from_row(row: Row) -> InboxConversation:
+    return InboxConversation(
+        person_uuid=row['person_uuid'],
+        url_slug=row['url_slug'],
+        name=row['name'],
+        match_percentage=row['match_percentage'],
+        image_uuid=row['image_uuid'],
+        image_blurhash=row['image_blurhash'],
+        is_verified=row['is_verified'],
+        is_available=row['is_available'],
+        location=row['location'],
+        last_message=row['last_message'],
+        last_message_read=row['last_message_read'],
+        # The query returns raw microseconds; formatting here (rather than via
+        # `to_char` in SQL) keeps the per-row timestamp work off the shared DB.
+        last_message_timestamp=format_timestamp(row['last_message_timestamp']),
+    )
+
+
 async def _fetch_inbox_conversations(
     username: str,
     prospect_username: str | None = None,
-) -> dict:
+) -> list[InboxConversation]:
     if prospect_username is None:
         query = Q_INBOX_SNAPSHOT
         params = dict(username=username)
@@ -390,9 +425,10 @@ async def _fetch_inbox_conversations(
         # thresholds for users with large inboxes, so JIT spends ~1s compiling
         # for no benefit. (Same rationale as the legacy Q_INBOX_INFO.)
         await tx.execute('SET LOCAL jit = off')
-        row = await tx.require_one(query, params)
+        await tx.execute(query, params)
+        rows = await tx.fetchall()
 
-    return row['j']
+    return [_conversation_from_row(row) for row in rows]
 
 
 async def get_inbox_snapshot(username: str) -> list[Outbound]:
@@ -401,9 +437,9 @@ async def get_inbox_snapshot(username: str) -> list[Outbound]:
     single `InboxSnapshot`.
     """
     try:
-        payload = await _fetch_inbox_conversations(username)
+        conversations = await _fetch_inbox_conversations(username)
 
-        return [InboxSnapshot(payload=payload)]
+        return [InboxSnapshot(payload={'conversations': conversations})]
     except Exception:
         print(traceback.format_exc())
         return []
@@ -420,12 +456,10 @@ async def get_inbox_entry(
     callers can publish the result unconditionally.
     """
     try:
-        payload = await _fetch_inbox_conversations(
-            username=viewer_username,
-            prospect_username=prospect_username,
+        conversations = await _fetch_inbox_conversations(
+            viewer_username,
+            prospect_username,
         )
-
-        conversations = payload['conversations']
 
         if not conversations:
             return []

--- a/backend/service/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/chat/messagestorage/inbox/__init__.py
@@ -31,7 +31,15 @@ ORDER BY
 # conversation belongs in) mirror Q_INBOX_INFO, which serves the legacy
 # `/inbox-info` endpoint. This query joins them against the viewer's `inbox`
 # rows so one websocket response carries complete conversations.
-Q_INBOX_SNAPSHOT = """
+#
+# `entry_predicate` narrows the viewer's `inbox` rows: empty for the whole-inbox
+# snapshot, or an equality on `remote_bare_jid` (the primary key's second
+# column) for a single conversation. The predicate is kept a plain equality --
+# rather than an `%(x)s IS NULL OR ...` that serves both -- so the single-entry
+# query gets an index scan on `inbox_pkey` even under a generic plan, which a
+# parameterised `IS NULL` branch would defeat.
+def _q_inbox_snapshot(entry_predicate: str) -> str:
+    return f"""
 WITH viewer AS (
     SELECT
         id,
@@ -50,12 +58,7 @@ WITH viewer AS (
         inbox
     WHERE
         luser = %(username)s
-    AND
-        (
-            %(prospect_uuid)s::TEXT IS NULL
-        OR
-            split_part(remote_bare_jid, '@', 1) = %(prospect_uuid)s::TEXT
-        )
+    {entry_predicate}
 ), conversation AS (
     SELECT
         entry.prospect_uuid,
@@ -212,6 +215,13 @@ WHERE
 """
 
 
+# The whole inbox: no extra `entry` predicate beyond the viewer's `luser`.
+Q_INBOX_SNAPSHOT = _q_inbox_snapshot('')
+
+# A single conversation: a plain primary-key equality on `remote_bare_jid`.
+Q_INBOX_ENTRY = _q_inbox_snapshot('AND remote_bare_jid = %(remote_bare_jid)s')
+
+
 Q_UPSERT_CONVERSATION = f"""
 WITH upsert_sender AS (
     INSERT INTO inbox (
@@ -363,17 +373,24 @@ async def get_inbox(query_id: str, username: str) -> list[Outbound]:
 
 async def _fetch_inbox_conversations(
     username: str,
-    prospect_uuid: str | None = None,
+    prospect_username: str | None = None,
 ) -> dict:
-    params = dict(username=username, prospect_uuid=prospect_uuid)
+    if prospect_username is None:
+        query = Q_INBOX_SNAPSHOT
+        params = dict(username=username)
+    else:
+        query = Q_INBOX_ENTRY
+        params = dict(
+            username=username,
+            remote_bare_jid=f'{prospect_username}@{LSERVER}',
+        )
 
     async with api_tx('read committed') as tx:
-        # The query is cheap (index-only scans) but its estimated cost crosses
-        # the default jit thresholds for users with large inboxes, so JIT
-        # spends ~1s compiling for no benefit. (Same rationale as the legacy
-        # Q_INBOX_INFO.)
+        # The whole-inbox query's estimated cost crosses the default jit
+        # thresholds for users with large inboxes, so JIT spends ~1s compiling
+        # for no benefit. (Same rationale as the legacy Q_INBOX_INFO.)
         await tx.execute('SET LOCAL jit = off')
-        row = await tx.require_one(Q_INBOX_SNAPSHOT, params)
+        row = await tx.require_one(query, params)
 
     return row['j']
 
@@ -405,7 +422,7 @@ async def get_inbox_entry(
     try:
         payload = await _fetch_inbox_conversations(
             username=viewer_username,
-            prospect_uuid=prospect_username,
+            prospect_username=prospect_username,
         )
 
         conversations = payload['conversations']

--- a/backend/service/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/chat/messagestorage/inbox/__init__.py
@@ -1,4 +1,3 @@
-import json
 import traceback
 
 from batcher import Batcher
@@ -385,7 +384,7 @@ async def get_inbox_snapshot(username: str) -> list[Outbound]:
     try:
         payload = await _fetch_inbox_conversations(username)
 
-        return [InboxSnapshot(payload_json=json.dumps(payload))]
+        return [InboxSnapshot(payload=payload)]
     except Exception:
         print(traceback.format_exc())
         return []
@@ -412,7 +411,7 @@ async def get_inbox_entry(
         if not conversations:
             return []
 
-        return [InboxEntry(payload_json=json.dumps(conversations[0]))]
+        return [InboxEntry(payload=conversations[0])]
     except Exception:
         print(traceback.format_exc())
         return []

--- a/backend/service/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/chat/messagestorage/inbox/__init__.py
@@ -207,6 +207,8 @@ SELECT
     ) AS j
 FROM
     gated
+WHERE
+    location <> 'nowhere'
 """
 
 

--- a/backend/service/chat/online/__init__.py
+++ b/backend/service/chat/online/__init__.py
@@ -4,6 +4,7 @@ from service.chat.chatutil import (
     fetch_is_public,
     fetch_is_skipped,
     fetch_id_from_username,
+    redis_has_subscribers,
 )
 from enum import Enum
 from commonsql import Q_UPDATE_LAST
@@ -96,15 +97,36 @@ async def _redis_subscribe_online(
     if isinstance(val, bytes):
         val = val.decode()
 
+    stored: OnlineEvent | None = None
+
     if isinstance(val, str):
         try:
             event = from_bus(val)
             if isinstance(event, OnlineEvent):
-                return event
+                stored = event
         except Exception:
             pass
 
-    return OnlineEvent(username=username, status=OnlineStatus.OFFLINE.value)
+    if stored is None:
+        return OnlineEvent(username=username, status=OnlineStatus.OFFLINE.value)
+
+    # The stored status can misreport whether the user is connected *right
+    # now*: a crashed worker never demotes 'online' (the key just expires,
+    # ONLINE_RECENTLY_SECONDS later), and a multi-device user dropping one
+    # connection is demoted to 'online-recently' until the surviving device's
+    # next heartbeat. Whether any of the user's websocket connections is
+    # subscribed to their username channel is authoritative -- it's the same
+    # subscription message delivery uses, and Redis drops it when a connection
+    # dies -- so it decides between 'online' and 'online-recently'. The stored
+    # event then only attests that the user was seen within the last
+    # ONLINE_RECENTLY_SECONDS. Pushed OnlineEvents need no such correction:
+    # they're emitted by actual connection lifecycle.
+    status = (
+        OnlineStatus.ONLINE.value
+        if await redis_has_subscribers(redis_client, username)
+        else OnlineStatus.ONLINE_RECENTLY.value)
+
+    return OnlineEvent(username=username, status=status)
 
 
 async def _redis_unsubscribe_online(

--- a/backend/service/cron/notifications/template/__init__.py
+++ b/backend/service/cron/notifications/template/__init__.py
@@ -59,7 +59,7 @@ def emailtemplate(email: str, has_intro: bool, has_chat: bool) -> str:
                         <table border="0" cellspacing="0" cellpadding="0">
                           <tbody><tr>
                             <td style="border-radius:50px; border:3px solid #70f; font-size: 20px; line-height:26px; color: #70f; text-align:center; min-width:auto!important">
-                              <a href="https://get.duolicious.app/" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
+                              <a href="https://get.duolicious.app/inbox" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
                                 <span style="text-decoration:none;color:#70f">
                                   <strong>
                                     Open Duolicious

--- a/backend/test/chatjsontest/index.js
+++ b/backend/test/chatjsontest/index.js
@@ -2,8 +2,22 @@ const WebSocket = require('ws');
 const express = require('express');
 const bodyParser = require('body-parser');
 
-let wsClient = null;
-let receivedMessages = [];
+// Each named connection is an independent websocket client, so tests can keep
+// several users online at once (e.g. to observe stanzas pushed to a recipient
+// while the sender is also connected). Requests select a connection with the
+// `?id=` query parameter; omitting it uses the connection named 'default',
+// preserving the original single-connection behaviour.
+const connections = {};
+
+const getConnection = (req) => {
+  const id = req.query.id || 'default';
+
+  if (!(id in connections)) {
+    connections[id] = { wsClient: null, receivedMessages: [] };
+  }
+
+  return connections[id];
+};
 
 const app = express();
 app.use(bodyParser.json());
@@ -16,19 +30,21 @@ app.post('/config', (req, res) => {
     return res.status(400).send('Missing required "server" parameter');
   }
 
+  const connection = getConnection(req);
+
   // If already connected, close the previous connection
-  if (wsClient) {
-    wsClient.close();
-    receivedMessages = [];
+  if (connection.wsClient) {
+    connection.wsClient.close();
+    connection.receivedMessages = [];
   }
 
-  wsClient = new WebSocket(server, ['json']);
+  connection.wsClient = new WebSocket(server, ['json']);
 
-  wsClient.on('open', () => {
+  connection.wsClient.on('open', () => {
     console.log(`Connected to ${server}`);
   });
 
-  wsClient.on('message', (message) => {
+  connection.wsClient.on('message', (message) => {
     let decodedMessage = message.toString();
 
     console.log('⮈', decodedMessage);
@@ -37,14 +53,14 @@ app.post('/config', (req, res) => {
       pretty = JSON.stringify(JSON.parse(decodedMessage), undefined, 2);
     } catch { }
 
-    receivedMessages.push(pretty);
+    connection.receivedMessages.push(pretty);
   });
 
-  wsClient.on('error', (error) => {
+  connection.wsClient.on('error', (error) => {
     console.error('WebSocket error:', error);
   });
 
-  wsClient.on('close', () => {
+  connection.wsClient.on('close', () => {
     console.log('WebSocket connection closed');
   });
 
@@ -53,13 +69,15 @@ app.post('/config', (req, res) => {
 
 // /send accepts raw message text and sends it over the WebSocket connection
 app.post('/send', (req, res) => {
-  if (!wsClient || wsClient.readyState !== WebSocket.OPEN) {
+  const connection = getConnection(req);
+
+  if (!connection.wsClient || connection.wsClient.readyState !== WebSocket.OPEN) {
     return res.status(500).send('WebSocket is not connected');
   }
   try {
     const payload = JSON.stringify(req.body);
     console.log('⮊', payload);
-    wsClient.send(payload, (error) => {
+    connection.wsClient.send(payload, (error) => {
       if (error) {
         return res.status(500).send('Error sending message: ' + error.toString());
       }
@@ -72,8 +90,10 @@ app.post('/send', (req, res) => {
 
 // /pop returns and clears the list of received messages
 app.get('/pop', (req, res) => {
-  res.status(200).send(receivedMessages.join('\n'));
-  receivedMessages = [];
+  const connection = getConnection(req);
+
+  res.status(200).send(connection.receivedMessages.join('\n'));
+  connection.receivedMessages = [];
 });
 
 const PORT = process.env.PORT || 3001;

--- a/backend/test/fixtures/cron-autodeactivate2-email
+++ b/backend/test/fixtures/cron-autodeactivate2-email
@@ -40,7 +40,7 @@ Body:     <!DOCTYPE html>
                             <table border="0" cellspacing="0" cellpadding="0">
                               <tbody><tr>
                                 <td style="border-radius:50px; border:3px solid #70f; font-size: 20px; line-height:26px; color: #70f; text-align:center; min-width:auto!important">
-                                  <a href="https://get.duolicious.app/" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
+                                  <a href="https://get.duolicious.app/inbox" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
                                     <span style="text-decoration:none;color:#70f">
                                       <strong>
                                         Get on Duolicious

--- a/backend/test/fixtures/cron-autodeactivate2-email
+++ b/backend/test/fixtures/cron-autodeactivate2-email
@@ -40,7 +40,7 @@ Body:     <!DOCTYPE html>
                             <table border="0" cellspacing="0" cellpadding="0">
                               <tbody><tr>
                                 <td style="border-radius:50px; border:3px solid #70f; font-size: 20px; line-height:26px; color: #70f; text-align:center; min-width:auto!important">
-                                  <a href="https://get.duolicious.app/inbox" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
+                                  <a href="https://get.duolicious.app/" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
                                     <span style="text-decoration:none;color:#70f">
                                       <strong>
                                         Get on Duolicious

--- a/backend/test/fixtures/cron-emails-active-users-notified-via-email
+++ b/backend/test/fixtures/cron-emails-active-users-notified-via-email
@@ -38,7 +38,7 @@ Body: <!DOCTYPE html>
                         <table border="0" cellspacing="0" cellpadding="0">
                           <tbody><tr>
                             <td style="border-radius:50px; border:3px solid #70f; font-size: 20px; line-height:26px; color: #70f; text-align:center; min-width:auto!important">
-                              <a href="https://get.duolicious.app/" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
+                              <a href="https://get.duolicious.app/inbox" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
                                 <span style="text-decoration:none;color:#70f">
                                   <strong>
                                     Open Duolicious

--- a/backend/test/fixtures/cron-emails-happy-path-chat-not-deffered-by-intro
+++ b/backend/test/fixtures/cron-emails-happy-path-chat-not-deffered-by-intro
@@ -38,7 +38,7 @@ Body: <!DOCTYPE html>
                         <table border="0" cellspacing="0" cellpadding="0">
                           <tbody><tr>
                             <td style="border-radius:50px; border:3px solid #70f; font-size: 20px; line-height:26px; color: #70f; text-align:center; min-width:auto!important">
-                              <a href="https://get.duolicious.app/" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
+                              <a href="https://get.duolicious.app/inbox" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
                                 <span style="text-decoration:none;color:#70f">
                                   <strong>
                                     Open Duolicious

--- a/backend/test/fixtures/cron-emails-happy-path-chats
+++ b/backend/test/fixtures/cron-emails-happy-path-chats
@@ -38,7 +38,7 @@ Body: <!DOCTYPE html>
                         <table border="0" cellspacing="0" cellpadding="0">
                           <tbody><tr>
                             <td style="border-radius:50px; border:3px solid #70f; font-size: 20px; line-height:26px; color: #70f; text-align:center; min-width:auto!important">
-                              <a href="https://get.duolicious.app/" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
+                              <a href="https://get.duolicious.app/inbox" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
                                 <span style="text-decoration:none;color:#70f">
                                   <strong>
                                     Open Duolicious

--- a/backend/test/fixtures/cron-emails-happy-path-intros
+++ b/backend/test/fixtures/cron-emails-happy-path-intros
@@ -38,7 +38,7 @@ Body: <!DOCTYPE html>
                         <table border="0" cellspacing="0" cellpadding="0">
                           <tbody><tr>
                             <td style="border-radius:50px; border:3px solid #70f; font-size: 20px; line-height:26px; color: #70f; text-align:center; min-width:auto!important">
-                              <a href="https://get.duolicious.app/" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
+                              <a href="https://get.duolicious.app/inbox" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
                                 <span style="text-decoration:none;color:#70f">
                                   <strong>
                                     Open Duolicious

--- a/backend/test/fixtures/cron-emails-sad-already-notified-for-particular-message
+++ b/backend/test/fixtures/cron-emails-sad-already-notified-for-particular-message
@@ -38,7 +38,7 @@ Body: <!DOCTYPE html>
                         <table border="0" cellspacing="0" cellpadding="0">
                           <tbody><tr>
                             <td style="border-radius:50px; border:3px solid #70f; font-size: 20px; line-height:26px; color: #70f; text-align:center; min-width:auto!important">
-                              <a href="https://get.duolicious.app/" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
+                              <a href="https://get.duolicious.app/inbox" style="display:block;padding:11px 40px;text-decoration:none;color:#70f" target="_blank">
                                 <span style="text-decoration:none;color:#70f">
                                   <strong>
                                     Open Duolicious

--- a/backend/test/functionality6/xmpp-inbox-snapshot.sh
+++ b/backend/test/functionality6/xmpp-inbox-snapshot.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "$script_dir"
+
+source ../util/setup.sh
+
+set -xe
+
+sleep 3 # The chat service takes some time to flush messages to the DB
+
+q "delete from person"
+q "delete from banned_person"
+q "delete from banned_person_admin_token"
+q "delete from duo_session"
+q "delete from mam_message"
+q "delete from inbox"
+q "delete from intro_hash"
+
+../util/create-user.sh user1 0 0
+../util/create-user.sh user2 0 1
+
+assume_role user1 ; user1token=$SESSION_TOKEN
+assume_role user2 ; user2token=$SESSION_TOKEN
+
+user1uuid=$(get_uuid 'user1@example.com')
+user2uuid=$(get_uuid 'user2@example.com')
+
+user1id=$(get_id 'user1@example.com')
+user2id=$(get_id 'user2@example.com')
+
+q "update photo set uuid = 'my-photo-uuid', blurhash = 'my-blurhash'"
+
+# Like setup.sh's chat_auth, but on a named harness connection so that several
+# users can be online at once.
+chat_auth_as () {
+  local connectionId=$1
+  local fromUuid=$2
+  local fromToken=$3
+
+  local auth64=$(printf '\0%s\0%s' "$fromUuid" "$fromToken" | base64 -w 0)
+
+  read -r -d '' authJson <<EOF || true
+{
+  "auth": {
+    "@xmlns": "urn:ietf:params:xml:ns:xmpp-sasl",
+    "@mechanism": "PLAIN",
+    "#text": "${auth64}"
+  }
+}
+EOF
+
+  curl -X POST "http://localhost:3001/config?id=${connectionId}" \
+    -H "Content-Type: application/json" \
+    -d '{ "server": "ws://chat:5443" }'
+
+  sleep 0.2
+
+  curl -X POST "http://localhost:3001/send?id=${connectionId}" \
+    -H "Content-Type: application/json" \
+    -d "$authJson"
+
+  sleep 1
+
+  curl -sX GET "http://localhost:3001/pop?id=${connectionId}" > /dev/null
+}
+
+send_message () {
+  local connectionId=$1
+  local fromUuid=$2
+  local toUuid=$3
+  local message=$4
+
+  read -r -d '' payload <<EOF || true
+{
+  "message": {
+    "@type": "chat",
+    "@from": "${fromUuid}@duolicious.app",
+    "@to": "${toUuid}@duolicious.app",
+    "@id": "id1",
+    "@xmlns": "jabber:client",
+    "body": "${message}",
+    "request": {
+      "@xmlns": "urn:xmpp:receipts"
+    }
+  }
+}
+EOF
+
+  curl -X POST "http://localhost:3001/send?id=${connectionId}" \
+    -H "Content-Type: application/json" \
+    -d "$payload"
+
+  # Wait for the message store to flush and the inbox entry to be pushed
+  sleep 2
+}
+
+query_inbox_snapshot () {
+  local connectionId=$1
+
+  curl -sX GET "http://localhost:3001/pop?id=${connectionId}" > /dev/null
+  sleep 0.5
+
+  curl -X POST "http://localhost:3001/send?id=${connectionId}" \
+    -H "Content-Type: application/json" \
+    -d '{ "duo_query_inbox": null }'
+
+  sleep 1
+
+  curl -sX GET "http://localhost:3001/pop?id=${connectionId}"
+}
+
+# Extracts the conversations from a popped `duo_inbox` stanza, redacting the
+# unstable fields.
+snapshot_conversations () {
+  jq -sS -r '
+    [.[] | .duo_inbox | select(. != null)][0]
+    | fromjson
+    | .conversations
+    | map(del(.url_slug) | .last_message_timestamp = "redacted")
+  '
+}
+
+chat_auth_as user1 "$user1uuid" "$user1token"
+chat_auth_as user2 "$user2uuid" "$user2token"
+
+
+echo "A message pushes a complete inbox entry to the recipient, before the message"
+
+send_message user2 "$user2uuid" "$user1uuid" "intro from user 2"
+
+received_1=$(curl -sX GET "http://localhost:3001/pop?id=user1")
+
+actual_stanza_order=$(jq -s -r '[.[] | keys[0]] | join(",")' <<< "$received_1")
+[[ "$actual_stanza_order" == "duo_inbox_entry,message" ]] \
+  || { echo "Expected an inbox entry then a message, got '$actual_stanza_order'"; exit 1; }
+
+actual_entry=$(jq -sS -r '
+  [.[] | .duo_inbox_entry | select(. != null)][0]
+  | fromjson
+  | del(.url_slug)
+  | .last_message_timestamp = "redacted"
+' <<< "$received_1")
+
+expected_entry=$(cat << EOF
+{
+  "image_blurhash": "my-blurhash",
+  "image_uuid": "my-photo-uuid",
+  "is_available": true,
+  "is_verified": false,
+  "last_message": "intro from user 2",
+  "last_message_read": false,
+  "last_message_timestamp": "redacted",
+  "location": "intros",
+  "match_percentage": 50,
+  "name": "user2",
+  "person_uuid": "${user2uuid}"
+}
+EOF
+)
+
+diff -u --color <(echo "$actual_entry") <(jq -S . <<< "$expected_entry")
+
+
+echo "The inbox snapshot returns the same complete conversation"
+
+actual_snapshot=$(query_inbox_snapshot user1 | snapshot_conversations)
+
+diff -u --color \
+  <(echo "$actual_snapshot") \
+  <(jq -S '[.]' <<< "$expected_entry")
+
+
+echo "A reply moves the conversation to chats on both sides"
+
+send_message user1 "$user1uuid" "$user2uuid" "reply from user 1"
+
+received_2=$(curl -sX GET "http://localhost:3001/pop?id=user2")
+
+actual_entry=$(jq -sS -r '
+  [.[] | .duo_inbox_entry | select(. != null)][0]
+  | fromjson
+  | del(.url_slug)
+  | .last_message_timestamp = "redacted"
+' <<< "$received_2")
+
+expected_entry=$(cat << EOF
+{
+  "image_blurhash": null,
+  "image_uuid": null,
+  "is_available": true,
+  "is_verified": false,
+  "last_message": "reply from user 1",
+  "last_message_read": false,
+  "last_message_timestamp": "redacted",
+  "location": "chats",
+  "match_percentage": 50,
+  "name": "user1",
+  "person_uuid": "${user1uuid}"
+}
+EOF
+)
+
+diff -u --color <(echo "$actual_entry") <(jq -S . <<< "$expected_entry")
+
+actual_snapshot=$(query_inbox_snapshot user1 | snapshot_conversations)
+
+expected_snapshot=$(cat << EOF
+[
+  {
+    "image_blurhash": "my-blurhash",
+    "image_uuid": "my-photo-uuid",
+    "is_available": true,
+    "is_verified": false,
+    "last_message": "reply from user 1",
+    "last_message_read": true,
+    "last_message_timestamp": "redacted",
+    "location": "chats",
+    "match_percentage": 50,
+    "name": "user2",
+    "person_uuid": "${user2uuid}"
+  }
+]
+EOF
+)
+
+diff -u --color <(echo "$actual_snapshot") <(jq -S . <<< "$expected_snapshot")
+
+
+echo "Being skipped hides the skipper's info and archives the conversation"
+
+q "insert into skipped values (${user2id}, ${user1id}, false)"
+
+actual_snapshot=$(query_inbox_snapshot user1 | snapshot_conversations)
+
+expected_snapshot=$(cat << EOF
+[
+  {
+    "image_blurhash": null,
+    "image_uuid": null,
+    "is_available": false,
+    "is_verified": false,
+    "last_message": "reply from user 1",
+    "last_message_read": true,
+    "last_message_timestamp": "redacted",
+    "location": "archive",
+    "match_percentage": null,
+    "name": null,
+    "person_uuid": "${user2uuid}"
+  }
+]
+EOF
+)
+
+diff -u --color <(echo "$actual_snapshot") <(jq -S . <<< "$expected_snapshot")

--- a/backend/test/functionality6/xmpp-inbox-snapshot.sh
+++ b/backend/test/functionality6/xmpp-inbox-snapshot.sh
@@ -115,7 +115,6 @@ query_inbox_snapshot () {
 snapshot_conversations () {
   jq -sS -r '
     [.[] | .duo_inbox | select(. != null)][0]
-    | fromjson
     | .conversations
     | map(del(.url_slug) | .last_message_timestamp = "redacted")
   '
@@ -137,7 +136,6 @@ actual_stanza_order=$(jq -s -r '[.[] | keys[0]] | join(",")' <<< "$received_1")
 
 actual_entry=$(jq -sS -r '
   [.[] | .duo_inbox_entry | select(. != null)][0]
-  | fromjson
   | del(.url_slug)
   | .last_message_timestamp = "redacted"
 ' <<< "$received_1")
@@ -179,7 +177,6 @@ received_2=$(curl -sX GET "http://localhost:3001/pop?id=user2")
 
 actual_entry=$(jq -sS -r '
   [.[] | .duo_inbox_entry | select(. != null)][0]
-  | fromjson
   | del(.url_slug)
   | .last_message_timestamp = "redacted"
 ' <<< "$received_2")

--- a/backend/test/functionality6/xmpp-inbox-snapshot.sh
+++ b/backend/test/functionality6/xmpp-inbox-snapshot.sh
@@ -168,6 +168,12 @@ diff -u --color \
   <(echo "$actual_snapshot") \
   <(jq -S '[.]' <<< "$expected_entry")
 
+actual_snapshot=$(query_inbox_snapshot user2 | snapshot_conversations)
+
+diff -u --color \
+  <(echo "$actual_snapshot") \
+  <(jq -S . <<< '[]')
+
 
 echo "A reply moves the conversation to chats on both sides"
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -49,7 +49,7 @@ import { verificationWatcher } from './verification/verification';
 import { ClubItem } from './club/club';
 import { Toast } from './components/toast';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { createLinking, isBannerRoute, focusedProspectHandle, focusedRouteIsWizard, getTopRouteName } from './navigation/linking';
+import { createLinking, isBannerRoute, focusedProspectHandle, focusedConversationHandle, focusedRouteIsWizard, getTopRouteName } from './navigation/linking';
 import { useScrollbarStyle } from './components/navigation/scroll-bar-hooks';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
@@ -57,6 +57,7 @@ import { ErrorBoundary } from './components/error-boundary';
 import { TooltipListener } from './components/tooltip';
 import { VerificationCameraModal } from './components/verification-camera';
 import { notify } from './events/events';
+import { setActiveConversation } from './chat/conversation-priority';
 import { PointOfSaleModal } from './components/modal/point-of-sale-modal';
 import { DateOfBirthConfirmationModal } from './components/modal/date-of-birth-confirmation-modal';
 import { SignUpModal, showSignUp } from './components/modal/sign-up-modal';
@@ -159,6 +160,12 @@ const App = () => {
       if (result.postLoginRedirectState) {
         pendingPostLoginStateRef.current = result.postLoginRedirectState;
       }
+      // Report the focused conversation as soon as the startup route is known -
+      // before the navigation container mounts - so the chat layer can order an
+      // open conversation's history ahead of the inbox without waiting on
+      // `onReady`, and doesn't stall the inbox query when no conversation is
+      // open. See `frontend/chat/conversation-priority`.
+      setActiveConversation(focusedConversationHandle(result.initialState) ?? null);
       setInitialState(result.initialState);
     };
 
@@ -267,10 +274,19 @@ const App = () => {
     setBannerProspectHandle(focusedProspectHandle(rootState));
   }, []);
 
+  // Tell the chat layer which conversation (if any) is on screen, so on connect
+  // it can load an open conversation's history before the inbox snapshot. See
+  // `frontend/chat/conversation-priority`.
+  const publishActiveConversation = useCallback((state?: NavigationState) => {
+    const rootState = state ?? navigationContainerRef.current?.getRootState?.();
+    setActiveConversation(focusedConversationHandle(rootState) ?? null);
+  }, []);
+
   const onNavigationReady = useCallback(() => {
     applyPostSignInRedirect();
     recomputeBannerVisible();
-  }, [applyPostSignInRedirect, recomputeBannerVisible]);
+    publishActiveConversation();
+  }, [applyPostSignInRedirect, recomputeBannerVisible, publishActiveConversation]);
 
   useEffect(() => {
     // On sign-out drop any remaining pending state so a stale entry from
@@ -372,6 +388,7 @@ const App = () => {
     if (!state) return;
 
     recomputeBannerVisible(state);
+    publishActiveConversation(state);
 
     // URL-bar sync is left entirely to React Navigation's linking integration.
     // Doing a `window.history.replaceState` here in addition to RN's own
@@ -421,7 +438,7 @@ const App = () => {
       // because intermittent failures on transient states are expected.
       console.warn('Failed to persist last navigation path', e);
     }
-  }, [linking, recomputeBannerVisible]);
+  }, [linking, recomputeBannerVisible, publishActiveConversation]);
 
   // Only need live updates on web (for browser tab title)
   const stats = useInboxStats(Platform.OS === 'web');

--- a/frontend/api/api.tsx
+++ b/frontend/api/api.tsx
@@ -7,7 +7,7 @@ import { delay } from '../util/util';
 import { notify } from '../events/events';
 import { ValidationErrorToast, SOMETHING_WENT_WRONG } from '../components/toast';
 
-const CLIENT_VERSION = 9;
+const CLIENT_VERSION = 10;
 
 type ApiResponse<T = unknown> = {
   ok: boolean

--- a/frontend/chat/application-layer/hooks/visitors.tsx
+++ b/frontend/chat/application-layer/hooks/visitors.tsx
@@ -10,6 +10,7 @@ import {
   send,
   EV_CHAT_WS_RECEIVE,
 } from '../../websocket-layer';
+import { awaitFocusedConversationFetch } from '../../conversation-priority';
 
 // Event keys
 const EVENT_NUM_VISITORS = 'num-visitors';
@@ -305,7 +306,12 @@ const markVisitorChecked = (personUuid: string) => {
   setVisitorDataItem(key, updated, false);
 };
 
-const requestVisitorsSnapshot = () => {
+const requestVisitorsSnapshot = async () => {
+  // An open conversation's history loads first (see
+  // `frontend/chat/conversation-priority`); resolves immediately outside of
+  // connect time.
+  await awaitFocusedConversationFetch();
+
   send({ data: { duo_query_visitors: null } });
 };
 

--- a/frontend/chat/application-layer/index.tsx
+++ b/frontend/chat/application-layer/index.tsx
@@ -325,7 +325,7 @@ const onReceiveInboxEntry = (doc: any) => { // eslint-disable-line @typescript-e
   }
 
   try {
-    const conversation = conversationFromWire(JSON.parse(doc.duo_inbox_entry));
+    const conversation = conversationFromWire(doc.duo_inbox_entry);
 
     if (conversation) {
       setInboxRecieved(conversation);
@@ -977,7 +977,7 @@ const refreshInbox = async (): Promise<void> => {
     }
 
     try {
-      const parsed = JSON.parse(doc.duo_inbox);
+      const parsed = doc.duo_inbox;
 
       if (!Array.isArray(parsed?.conversations)) {
         return null;

--- a/frontend/chat/application-layer/index.tsx
+++ b/frontend/chat/application-layer/index.tsx
@@ -1,6 +1,5 @@
 import { Platform } from 'react-native';
 import { getRandomString } from '../../random/string';
-import { japi } from '../../api/api';
 import { deleteFromArray, assert } from '../../util/util';
 import { listen, notify, lastEvent } from '../../events/events';
 import { getAndRegisterPushToken } from '../../notifications/notifications';
@@ -79,10 +78,6 @@ const findEarliestDateInConversations = (conversations: Conversation[]) => {
 const isValidUuid = (uuid: string): boolean => {
   const regex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   return regex.test(uuid);
-}
-
-const parseUuidOrNull = (uuid: string): string | null => {
-  return isValidUuid(uuid) ? uuid : null;
 }
 
 
@@ -222,40 +217,31 @@ const conversationListToMap = (
   );
 };
 
-const populateConversationList = (
-  conversationList: Conversation[],
-  apiData: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-): void => {
-  const personUuidToInfo = apiData.reduce((obj: Record<string, any>, item: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
-    obj[item.person_uuid] = item;
-    return obj;
-  }, {});
+// Builds a `Conversation` from the complete, snake-cased conversation objects
+// the server sends in `duo_inbox` snapshots and `duo_inbox_entry` pushes.
+const conversationFromWire = (
+  c: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+): Conversation | null => {
+  if (typeof c?.person_uuid !== 'string') {
+    return null;
+  }
 
+  const locations = ['chats', 'intros', 'archive', 'nowhere'];
 
-  conversationList.forEach((c: Conversation) => {
-    const personInfo = personUuidToInfo[c.personUuid];
-
-    // Update conversation information
-    c.name = personInfo?.name ?? 'Unavailable Person';
-    c.urlSlug = personInfo?.url_slug ?? null;
-    c.matchPercentage = personInfo?.match_percentage ?? 0;
-    c.photoUuid = personInfo?.image_uuid ?? null;
-    c.photoBlurhash = personInfo?.image_blurhash ?? null;
-    c.isAvailableUser = !!personInfo?.name;
-    c.isVerified = !!personInfo?.verified;
-    c.location = personInfo?.conversation_location ?? 'archive';
-    c.personUuid = personInfo?.person_uuid ?? c.personUuid ?? '';
-  });
-};
-
-const populateConversation = async (
-  conversation: Conversation
-): Promise<void> => {
-  const apiData = (
-    await japi('post',
-    '/inbox-info',
-    {person_uuids: [conversation.personUuid]})).json;
-  await populateConversationList([conversation], apiData);
+  return {
+    personUuid: c.person_uuid,
+    urlSlug: c.url_slug ?? null,
+    name: c.name ?? 'Unavailable Person',
+    matchPercentage: c.match_percentage ?? 0,
+    photoUuid: c.image_uuid ?? null,
+    photoBlurhash: c.image_blurhash ?? null,
+    lastMessage: c.last_message ?? '',
+    lastMessageRead: !!c.last_message_read,
+    lastMessageTimestamp: new Date(c.last_message_timestamp),
+    isAvailableUser: !!c.is_available,
+    isVerified: !!c.is_verified,
+    location: locations.includes(c.location) ? c.location : 'archive',
+  };
 };
 
 const jidToBareJid = (jid: string): string =>
@@ -314,76 +300,37 @@ const setInboxSent = (recipientPersonUuid: string, message: string) => {
   notify<Inbox>('inbox', {...i});
 };
 
-const setInboxRecieved = async (
-  fromPersonUuid: string,
-  message: string,
-) => {
+// Merges a complete conversation (pushed by the server as `duo_inbox_entry`
+// when a message arrives) into the inbox. The server's copy is authoritative,
+// so there's nothing left to fetch, even when the sender is a new person.
+const setInboxRecieved = (conversation: Conversation) => {
   const inbox = _.cloneDeep(getInbox() ?? emptyInbox());
 
-  if (!inbox) {
+  const conversations = [
+    ...inbox.chats.conversations,
+    ...inbox.intros.conversations,
+    ...inbox.archive.conversations,
+  ].filter((c) => c.personUuid !== conversation.personUuid);
+
+  conversations.push(conversation);
+
+  notifyOnWeb(conversation.name, conversation.lastMessage);
+
+  notify<Inbox>('inbox', conversationsToInbox(conversations));
+};
+
+const onReceiveInboxEntry = (doc: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+  if (doc?.duo_inbox_entry === undefined) {
     return;
   }
 
-  const chatsConversation =
-    inbox.chats.conversationsMap[fromPersonUuid] as Conversation | undefined;
-  const introsConversation =
-    inbox.intros.conversationsMap[fromPersonUuid] as Conversation | undefined;
-  const archiveConversation =
-    inbox.archive.conversationsMap[fromPersonUuid] as Conversation | undefined;
+  try {
+    const conversation = conversationFromWire(JSON.parse(doc.duo_inbox_entry));
 
-  const updatedConversation: Conversation = {
-    personUuid: fromPersonUuid,
-    urlSlug: null,
-    name: '',
-    matchPercentage: 0,
-    photoUuid: null,
-    isAvailableUser: true,
-    location: 'archive',
-    photoBlurhash: '',
-    isVerified: false,
-    ...chatsConversation,
-    ...introsConversation,
-    ...archiveConversation,
-    lastMessage: message,
-    lastMessageRead: false,
-    lastMessageTimestamp: new Date(),
-  };
-
-  // The conversation is missing data as it's either new or from the archive
-  if (!chatsConversation && !introsConversation) {
-    await populateConversation(updatedConversation);
-  }
-
-  // Update the conversation in-place, in the `inbox` object
-  if (chatsConversation) {
-    Object.assign(chatsConversation, updatedConversation);
-  } else if (introsConversation) {
-    Object.assign(introsConversation, updatedConversation);
-  } else if (archiveConversation) {
-    Object.assign(archiveConversation, updatedConversation);
-  }
-
-  // The conversation's `.location` might have changed, so we need to update the
-  // inbox
-  if (!chatsConversation && !introsConversation) {
-    const updatedConversationsMap = {
-      [fromPersonUuid]: updatedConversation
-    };
-
-    Object.assign(updatedConversationsMap, inbox.chats.conversationsMap);
-    Object.assign(updatedConversationsMap, inbox.intros.conversationsMap);
-    Object.assign(updatedConversationsMap, inbox.archive.conversationsMap);
-
-    const updatedConversations = Object.values(updatedConversationsMap);
-
-    const updatedInbox = conversationsToInbox(updatedConversations);
-
-    Object.assign(inbox, updatedInbox);
-  }
-
-  notifyOnWeb(updatedConversation.name, updatedConversation.lastMessage);
-
-  notify<Inbox>('inbox', {...inbox});
+    if (conversation) {
+      setInboxRecieved(conversation);
+    }
+  } catch { }
 };
 
 const setInboxDisplayed = (fromPersonUuid: string) => {
@@ -868,13 +815,9 @@ const onReceiveMessage = (
       fromCurrentUser: jidMatchesSignedInUser(unpacked.from),
     };
 
+    // The inbox itself is updated by the `duo_inbox_entry` the server pushes
+    // just before each message, so only the message event is emitted here.
     if (otherPersonUuid === undefined) {
-      if (unpacked.type === 'chat-text') {
-        await setInboxRecieved(bareFrom, unpacked.text);
-      } else if (unpacked.type === 'chat-audio') {
-        await setInboxRecieved(bareFrom, AUDIO_MESSAGE);
-      }
-
       notify(`message-from-${bareFrom}`);
     }
 
@@ -1025,120 +968,32 @@ const fetchConversation = async (
   return response;
 };
 
-const refreshInbox = async (
-  endTimestamp?: Date,
-  pageSize?: number,
-): Promise<void> => {
-  const apiDataPromise = japi('post', '/inbox-info', {person_uuids: []});
+const refreshInbox = async (): Promise<void> => {
+  const data = { duo_query_inbox: null };
 
-  const queryId = getRandomString(10);
-
-  const endTimestampFragment = !endTimestamp ? {} : {
-    x: {
-      '@xmlns': 'jabber:x:data',
-      '@type': 'form',
-      field: {
-        '@type': 'text-single',
-        '@var': 'end',
-        value: {
-          '#text': endTimestamp.toISOString()
-        }
-      }
+  const responseDetector = (doc: any): Conversation[] | null => { // eslint-disable-line @typescript-eslint/no-explicit-any
+    if (doc?.duo_inbox === undefined) {
+      return null;
     }
-  };
 
-  const maxPageSizeFragment = !pageSize ? {} : {
-    set: {
-      '@xmlns': 'http://jabber.org/protocol/rsm',
-      max: {
-        '#text': pageSize
-      }
-    }
-  };
-
-  const data = {
-    iq: {
-      '@type': 'set',
-      '@id': queryId,
-      inbox: {
-        '@xmlns': 'erlang-solutions.com:xmpp:inbox:0',
-        '@queryid': queryId,
-        ...endTimestampFragment,
-        ...maxPageSizeFragment,
-      }
-    }
-  };
-
-  const responseDetector = (doc: any): Conversation | null => { // eslint-disable-line @typescript-eslint/no-explicit-any
     try {
-      const {
-        message: {
-          result: {
-            '@unread': numUnread,
-            '@queryid': receivedQueryId,
-            forwarded: {
-              delay: {
-                '@stamp': timestamp,
-              },
-              message: {
-                '@from': from,
-                '@to': to,
-                'body': text,
-              }
-            }
-          }
-        }
-      } = doc;
+      const parsed = JSON.parse(doc.duo_inbox);
 
-      assert(receivedQueryId === queryId);
-
-      const fromCurrentUser = jidMatchesSignedInUser(from);
-      const bareTo = jidToBareJid(to);
-      const bareFrom = jidToBareJid(from);
-      const bareJid = fromCurrentUser ? bareTo : bareFrom;
-      const personUuid = parseUuidOrNull(bareJid);
-
-      if (!personUuid) {
+      if (!Array.isArray(parsed?.conversations)) {
         return null;
       }
 
-      // Some of these need to be fetched from the REST API instead of the XMPP
-      // server
-      return {
-        personUuid,
-        urlSlug: null,
-        name: '',
-        matchPercentage: 0,
-        photoUuid: null,
-        lastMessage: text,
-        lastMessageRead: numUnread === '0',
-        lastMessageTimestamp: new Date(timestamp),
-        isAvailableUser: true,
-        location: 'archive',
-        photoBlurhash: '',
-        isVerified: false,
-      };
+      return parsed.conversations
+        .map(conversationFromWire)
+        .filter((c: Conversation | null): c is Conversation => c !== null);
     } catch {
       return null;
     }
   };
 
-  const sentinelDetector = (doc: any): boolean => { // eslint-disable-line @typescript-eslint/no-explicit-any
-    const expectedDoc = {
-      iq: {
-        '@id': queryId,
-        '@type': 'result',
-        fin: null
-      }
-    };
-
-    return _.isEqual(doc, expectedDoc);
-  };
-
   const response = await send({
     data,
     responseDetector,
-    sentinelDetector,
     timeoutMs: fetchInboxTimeout,
   });
 
@@ -1146,17 +1001,7 @@ const refreshInbox = async (
     return;
   }
 
-  const conversations: Conversations = {
-    conversations: response,
-    conversationsMap: conversationListToMap(response),
-  };
-
-  const apiData = (await apiDataPromise).json;
-  populateConversationList(conversations.conversations, apiData);
-
-  const inbox = conversationsToInbox(conversations.conversations);
-
-  notify<Inbox>('inbox', {...inbox});
+  notify<Inbox>('inbox', conversationsToInbox(response));
 };
 
 const registerPushToken = async (token: string | null) => {
@@ -1179,8 +1024,11 @@ const registerPushToken = async (token: string | null) => {
   }
 };
 
-// Update the inbox upon receiving a message
+// Emit message events upon receiving a message
 onReceiveMessage();
+
+// Update the inbox upon receiving a conversation pushed by the server
+listen(EV_CHAT_WS_RECEIVE, onReceiveInboxEntry);
 
 const onWebsocketOpen = () => {
   notify('chat-is-websocket-open', true);

--- a/frontend/chat/application-layer/index.tsx
+++ b/frontend/chat/application-layer/index.tsx
@@ -14,6 +14,10 @@ import {
 } from '../websocket-layer';
 import { notifyOwnLastMessageAt } from './hooks/read-receipt';
 import { ingestMamReaction } from './hooks/reaction';
+import {
+  awaitFocusedConversationFetch,
+  markConversationFetchDispatched,
+} from '../conversation-priority';
 
 const AUDIO_MESSAGE = 'Audio message';
 
@@ -201,12 +205,18 @@ const inboxStats = (inbox: Inbox): {
   };
 };
 
-const emptyInbox = (): Inbox => ({
-  chats:   { conversations: [], conversationsMap: {} },
-  intros:  { conversations: [], conversationsMap: {} },
-  archive: { conversations: [], conversationsMap: {} },
-  endTimestamp: null
-});
+// A deep clone of the current inbox, ready for in-place mutation - or `null`
+// when the inbox hasn't loaded yet. Incremental updates (a sent/received
+// message, a read receipt, an archive) must go through this so they never
+// fabricate an inbox while it's still loading: a `null` inbox is what tells the
+// UI to show its loading spinner, and manufacturing an empty one instead flips
+// it to the "no conversations" empty state for the rest of the load. There's
+// nothing to preserve anyway - `refreshInbox` replaces the whole inbox with the
+// authoritative server snapshot moments later.
+const cloneInboxForUpdate = (): Inbox | null => {
+  const inbox = getInbox();
+  return inbox === null ? null : _.cloneDeep(inbox);
+};
 
 const conversationListToMap = (
   conversationList: Conversation[]
@@ -251,7 +261,8 @@ const personUuidToJid = (personUuid: string): string =>
   `${personUuid}@duolicious.app`;
 
 const setInboxSent = (recipientPersonUuid: string, message: string) => {
-  const i = _.cloneDeep(getInbox() ?? emptyInbox());
+  const i = cloneInboxForUpdate();
+  if (!i) return;
 
   const chatsConversation =
     i.chats.conversationsMap[recipientPersonUuid] as Conversation | undefined;
@@ -304,7 +315,8 @@ const setInboxSent = (recipientPersonUuid: string, message: string) => {
 // when a message arrives) into the inbox. The server's copy is authoritative,
 // so there's nothing left to fetch, even when the sender is a new person.
 const setInboxRecieved = (conversation: Conversation) => {
-  const inbox = _.cloneDeep(getInbox() ?? emptyInbox());
+  const inbox = cloneInboxForUpdate();
+  if (!inbox) return;
 
   const conversations = [
     ...inbox.chats.conversations,
@@ -334,11 +346,8 @@ const onReceiveInboxEntry = (doc: any) => { // eslint-disable-line @typescript-e
 };
 
 const setInboxDisplayed = (fromPersonUuid: string) => {
-  const inbox = _.cloneDeep(getInbox() ?? emptyInbox());
-
-  if (!inbox) {
-    return;
-  }
+  const inbox = cloneInboxForUpdate();
+  if (!inbox) return;
 
   const chatsConversation =
     inbox.chats.conversationsMap[fromPersonUuid] as Conversation | undefined;
@@ -695,11 +704,8 @@ const conversationsToInbox = (conversations: Conversation[]): Inbox => {
 };
 
 const setConversationArchived = (personUuid: string, isSkipped: boolean) => {
-  const inbox = _.cloneDeep(getInbox() ?? emptyInbox());
-
-  if (!inbox) {
-    return inbox;
-  }
+  const inbox = cloneInboxForUpdate();
+  if (!inbox) return;
 
   const conversationToUpdate = (
     inbox.chats .conversationsMap[personUuid] ??
@@ -942,6 +948,12 @@ const fetchConversation = async (
     return _.isEqual(doc, expectedDoc);
   };
 
+  // Release any snapshot queries held back in this conversation's favour (see
+  // `frontend/chat/conversation-priority`). Kept in the same synchronous block
+  // as the `send` below - the released waiters only resume as microtasks, so
+  // this query is guaranteed onto the wire before theirs.
+  markConversationFetchDispatched(withPersonUuid);
+
   const response = await send({
     data,
     responseDetector,
@@ -969,6 +981,11 @@ const fetchConversation = async (
 };
 
 const refreshInbox = async (): Promise<void> => {
+  // An open conversation's history loads first (see
+  // `frontend/chat/conversation-priority`); resolves immediately outside of
+  // connect time.
+  await awaitFocusedConversationFetch();
+
   const data = { duo_query_inbox: null };
 
   const responseDetector = (doc: any): Conversation[] | null => { // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/frontend/chat/conversation-priority.test.tsx
+++ b/frontend/chat/conversation-priority.test.tsx
@@ -1,0 +1,146 @@
+import { jest } from '@jest/globals';
+
+jest.useFakeTimers();
+
+// These tests pin down the connect-time ordering guarantee: when the app comes
+// online with a conversation open, the inbox/visitors snapshot queries are held
+// back until that conversation's history query has been dispatched. Losing
+// this doesn't break anything visibly - the app just gets slower for users
+// with big inboxes whenever a conversation is the first thing on screen -
+// which is exactly why it's pinned by tests.
+
+describe('conversation-priority', () => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let priority: any;
+  let events: any;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  beforeEach(() => {
+    // Reset modules and import fresh instances so each test starts with a
+    // clean event bus and dispatch bookkeeping. `jest.resetModules()` operates
+    // on the CommonJS require cache, so we deliberately use `require` here
+    // rather than ES `import` (which is hoisted and wouldn't pick up the reset
+    // module instance).
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    priority = require('./conversation-priority');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    events = require('../events/events');
+    jest.clearAllTimers();
+  });
+
+  // Let promise chains settle without advancing the (fake) clock.
+  const flushMicrotasks = async () => {
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+  };
+
+  // Runs the gate and reports whether it has resolved yet.
+  const startWaiting = () => {
+    const state = { released: false };
+    priority.awaitFocusedConversationFetch().then(() => {
+      state.released = true;
+    });
+    return state;
+  };
+
+  test('resolves immediately when no conversation is open', async () => {
+    priority.setActiveConversation(null);
+
+    const gate = startWaiting();
+    await flushMicrotasks();
+
+    expect(gate.released).toBe(true);
+  });
+
+  test('holds snapshots until the focused conversation fetch dispatches', async () => {
+    priority.setActiveConversation('person-a');
+
+    const gate = startWaiting();
+    await flushMicrotasks();
+    expect(gate.released).toBe(false);
+
+    priority.markConversationFetchDispatched('person-a');
+    await flushMicrotasks();
+    expect(gate.released).toBe(true);
+  });
+
+  test('ignores dispatches for other conversations', async () => {
+    priority.setActiveConversation('person-a');
+
+    const gate = startWaiting();
+
+    priority.markConversationFetchDispatched('person-b');
+    await flushMicrotasks();
+    expect(gate.released).toBe(false);
+
+    priority.markConversationFetchDispatched('person-a');
+    await flushMicrotasks();
+    expect(gate.released).toBe(true);
+  });
+
+  test('releases all concurrent waiters', async () => {
+    priority.setActiveConversation('person-a');
+
+    const gates = [startWaiting(), startWaiting()];
+    await flushMicrotasks();
+    expect(gates.map((g) => g.released)).toEqual([false, false]);
+
+    priority.markConversationFetchDispatched('person-a');
+    await flushMicrotasks();
+    expect(gates.map((g) => g.released)).toEqual([true, true]);
+  });
+
+  test('resolves immediately when the focused conversation already fetched', async () => {
+    priority.setActiveConversation('person-a');
+    priority.markConversationFetchDispatched('person-a');
+
+    // A mid-session call (e.g. `refreshInbox` after an unskip) mustn't be
+    // delayed by the connect-time gate.
+    const gate = startWaiting();
+    await flushMicrotasks();
+
+    expect(gate.released).toBe(true);
+  });
+
+  test('waits for navigation to report before assuming no conversation is open', async () => {
+    // Cold start: the gate can be entered before App has reported anything.
+    const gate = startWaiting();
+    await flushMicrotasks();
+    expect(gate.released).toBe(false);
+
+    priority.setActiveConversation(null);
+    await flushMicrotasks();
+    expect(gate.released).toBe(true);
+  });
+
+  test('times out rather than stalling snapshots forever', async () => {
+    priority.setActiveConversation('person-a');
+
+    const gate = startWaiting();
+    await flushMicrotasks();
+    expect(gate.released).toBe(false);
+
+    jest.advanceTimersByTime(2000);
+    await flushMicrotasks();
+    expect(gate.released).toBe(true);
+  });
+
+  test('forgets dispatches from previous connections', async () => {
+    priority.setActiveConversation('person-a');
+    priority.markConversationFetchDispatched('person-a');
+
+    // Going offline invalidates the fetch; the reconnect must wait for a
+    // fresh one.
+    events.notify('chat-is-online', false);
+
+    const gate = startWaiting();
+    await flushMicrotasks();
+    expect(gate.released).toBe(false);
+
+    priority.markConversationFetchDispatched('person-a');
+    await flushMicrotasks();
+    expect(gate.released).toBe(true);
+  });
+});

--- a/frontend/chat/conversation-priority.tsx
+++ b/frontend/chat/conversation-priority.tsx
@@ -1,0 +1,129 @@
+import { lastEvent, listen, nextEvent, notify } from '../events/events';
+
+// ── Focused-conversation priority ────────────────────────────────────────────
+//
+// When the chat socket connects (or reconnects) with a conversation open, that
+// conversation's message history should load *before* the connect-time
+// snapshots (the inbox and the visitors list). The chat server processes a
+// connection's stanzas sequentially, so sending a (potentially multi-second)
+// snapshot query first would stall the messages the user is actually looking
+// at.
+//
+// The mechanism has three touch-points, and only the first lives outside the
+// chat layer:
+//
+//   • `App` calls `setActiveConversation` whenever navigation settles, naming
+//     the focused conversation (or `null` when none is open). This is the
+//     single source of truth for "what's on screen", and it's reported from the
+//     computed startup route before the navigation container even mounts.
+//
+//   • `fetchConversation` calls `markConversationFetchDispatched` at the moment
+//     it puts a history query on the wire. The signal is emitted at the point
+//     of truth - the send itself - rather than by the conversation screen, so
+//     UI refactors can't silently stop it being sent.
+//
+//   • The connect-time snapshot queries (the chat layer's `refreshInbox`, the
+//     visitors hook's `requestVisitorsSnapshot`) each await
+//     `awaitFocusedConversationFetch` themselves, first thing, so the ordering
+//     guarantee can't be lost by reworking their call sites. The gate resolves
+//     once the focused conversation's history query is on the wire on the
+//     current connection - immediately when no conversation is open or the
+//     focused one has already fetched - and is bounded by a timeout so a
+//     backgrounded or absent conversation screen can never stall the snapshots
+//     indefinitely. Any number of callers may await it concurrently, at any
+//     time.
+//
+// The ordering guarantee itself rests on `markConversationFetchDispatched`
+// being called in the same synchronous block as the `ws.send` of the history
+// query: waiters released by it only resume as microtasks, which cannot run
+// until after that block completes, so the history query always reaches the
+// socket first.
+//
+// The event keys and dispatch bookkeeping live entirely in this file; the rest
+// of the app only sees the three functions. `conversation-priority.test.tsx`
+// pins the hold/release/timeout semantics down.
+
+const ACTIVE_CONVERSATION = 'active-conversation';
+const CONVERSATION_FETCH_DISPATCHED = 'conversation-fetch-dispatched';
+
+// How long a snapshot query will wait for the focused conversation to dispatch
+// its history query first. A fallback, not the expected path: the conversation
+// screen normally requests its first page within a render of coming online, so
+// the wait resolves in milliseconds.
+const priorityTimeout = 2000;
+
+// Conversations whose history query has been dispatched on the current
+// connection. Cleared on disconnect because a fetch from a previous connection
+// says nothing about this one - the conversation screen re-fetches when the
+// chat comes back online.
+const dispatchedThisConnection = new Set<string>();
+
+listen<boolean>('chat-is-online', (isOnline) => {
+  if (!isOnline) {
+    dispatchedThisConnection.clear();
+  }
+});
+
+// Report the focused conversation's personUuid, or `null` when none is open.
+// Always a concrete value so `awaitFocusedConversationFetch` can tell "no
+// conversation focused" (`null`) apart from "navigation hasn't reported yet"
+// (`undefined`).
+const setActiveConversation = (personUuid: string | null): void => {
+  notify<string | null>(ACTIVE_CONVERSATION, personUuid);
+};
+
+// Record that `personUuid`'s history query is going onto the wire, releasing
+// any snapshot queries held back by `awaitFocusedConversationFetch`. Must be
+// called in the same synchronous block as the send (see the overview above).
+const markConversationFetchDispatched = (personUuid: string): void => {
+  dispatchedThisConnection.add(personUuid);
+  notify<string>(CONVERSATION_FETCH_DISPATCHED, personUuid);
+};
+
+// Hold the caller (a connect-time snapshot query) until an open conversation's
+// history query is on the wire. Resolves immediately when no conversation is
+// open, or when the focused one has already fetched on this connection. See
+// the overview above.
+const awaitFocusedConversationFetch = async (): Promise<void> => {
+  const deadline = Date.now() + priorityTimeout;
+
+  // Cold start: the socket can authenticate before React has mounted the
+  // navigation container, so the focused conversation may not have been
+  // reported yet (`undefined`). Wait, briefly, for the first report rather
+  // than assuming no conversation is open and racing ahead.
+  let focused = lastEvent<string | null>(ACTIVE_CONVERSATION);
+  if (focused === undefined) {
+    focused = await nextEvent<string | null>(
+      ACTIVE_CONVERSATION,
+      deadline - Date.now(),
+    );
+  }
+
+  if (!focused) {
+    return;
+  }
+
+  // `markConversationFetchDispatched` updates the set before notifying, so
+  // re-checking the set each iteration can't miss a dispatch that lands
+  // between waits.
+  while (!dispatchedThisConnection.has(focused)) {
+    const timeLeft = deadline - Date.now();
+
+    if (timeLeft <= 0) {
+      return;
+    }
+
+    const dispatched =
+      await nextEvent<string>(CONVERSATION_FETCH_DISPATCHED, timeLeft);
+
+    if (dispatched === undefined) {
+      return; // Timed out.
+    }
+  }
+};
+
+export {
+  awaitFocusedConversationFetch,
+  markConversationFetchDispatched,
+  setActiveConversation,
+};

--- a/frontend/events/events.tsx
+++ b/frontend/events/events.tsx
@@ -52,6 +52,27 @@ const unlisten = (key: string, listener: Listener) => {
   listeners[key].listeners.delete(listener);
 };
 
+// Resolves with the next value published for `key`, or `undefined` if
+// `timeoutMs` elapses first. A one-shot `listen` for code that needs to await
+// a single event rather than subscribe to a stream of them.
+const nextEvent = <T = any>(
+  key: string,
+  timeoutMs: number,
+): Promise<T | undefined> =>
+  new Promise((resolve) => {
+    let unlistener = () => {};
+
+    const done = (value?: T) => {
+      clearTimeout(timer);
+      unlistener();
+      resolve(value);
+    };
+
+    const timer = setTimeout(() => done(undefined), Math.max(0, timeoutMs));
+
+    unlistener = listen<T>(key, (value) => done(value));
+  });
+
 const notify = <T = any>(key: string, data?: T) => {
   // Ensure `listeners[key]` is set
   listeners[key] = listeners[key] ?? {
@@ -67,8 +88,9 @@ const notify = <T = any>(key: string, data?: T) => {
 };
 
 export {
+  lastEvent,
   listen,
+  nextEvent,
   notify,
   unlisten,
-  lastEvent,
 };

--- a/frontend/navigation/linking.tsx
+++ b/frontend/navigation/linking.tsx
@@ -90,6 +90,16 @@ const focusedProspectHandle = (state: RouteState | undefined): string | undefine
   return readPersonUuid(nested?.params);
 };
 
+// The person the focused Conversation Screen is showing, if that's the top
+// route. App reports this to the chat layer so it can load an open
+// conversation's history before the inbox snapshot on connect. See
+// `frontend/chat/conversation-priority`.
+const focusedConversationHandle = (state: RouteState | undefined): string | undefined => {
+  const root = state?.routes?.[state?.index ?? 0];
+  if (root?.name !== 'Conversation Screen') return undefined;
+  return readPersonUuid(root.params);
+};
+
 const isBannerRoute = (state: RouteState | undefined): boolean => {
   const root = state?.routes?.[state?.index ?? 0];
   if (!root) return false;
@@ -244,7 +254,7 @@ const createLinking = () => {
 
 type Linking = ReturnType<typeof createLinking>;
 
-export { createLinking, isBannerRoute, focusedProspectHandle, focusedRouteIsWizard, getTopRouteName };
+export { createLinking, isBannerRoute, focusedProspectHandle, focusedConversationHandle, focusedRouteIsWizard, getTopRouteName };
 export type {
   Linking,
   RootParamList,


### PR DESCRIPTION
To-do:
- [x] `duo_inbox` is returned as a string containing JSON rather than as JSON.
- [x] Don't return messages in the "nowhere" location
- [x] Conversation-first loading causes the inbox to appear blank if you back out of a conversation after it loaded but before the inbox has finished loading

---

* Closes https://github.com/duolicious/duolicious/issues/534
* Closes https://github.com/duolicious/duolicious/issues/642