### PR TITLE
Add quiz card answers to the feed

### DIFF
--- a/backend/constants/__init__.py
+++ b/backend/constants/__init__.py
@@ -31,6 +31,12 @@ MAX_ONLINE_SUBSCRIPTIONS = 500
 # signed out on each new sign-in.
 MAX_SIGNED_IN_SESSIONS = 100
 
+# Refreshing someone's 'answered-question' feed event on every public answer
+# would rewrite their (heavily indexed) person row once per swipe while they
+# play Q&A. Refreshing at most this often caps that churn; the advertised
+# question is at most this stale.
+ANSWERED_QUESTION_EVENT_REFRESH_SECONDS = 60 * 60  # 1 hour
+
 # Club SEO page tunables. Shared by person/sql (API reads) and
 # service/cron/clubseo/sql (cron aggregation); kept in this dependency-free
 # module so both sides can import them without pulling each other in.

--- a/backend/init-api.sql
+++ b/backend/init-api.sql
@@ -117,6 +117,7 @@ DO $$ BEGIN
         'added-voice-bio',
         'joined',
         'joined-club',
+        'answered-question',
         'updated-bio',
         'was-recently-online',
         'recently-online-with-photo',
@@ -875,8 +876,11 @@ CREATE INDEX IF NOT EXISTS idx__person__roles
 
 CREATE INDEX IF NOT EXISTS idx__search_cache__searcher_person_id__position ON search_cache(searcher_person_id, position);
 
-CREATE INDEX IF NOT EXISTS idx__answer__question_id ON answer(question_id);
 CREATE INDEX IF NOT EXISTS idx__answer__person_id_public_answer ON answer(person_id, public_, answer);
+-- Lets the feed's 'answered-question' facepiles scan a question's public
+-- yes/no answerers in person_id order
+CREATE INDEX IF NOT EXISTS idx__answer__question_id_public_answer
+    ON answer(question_id, public_, answer, person_id);
 -- Lets the club-top-answers cron index-only-scan (person, question, answer)
 -- instead of doing a heap fetch per row -- the PK is (person_id,
 -- question_id) without `answer`. ~80 s -> ~3 s per popular club.

--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -1,7 +1,15 @@
-ALTER TABLE duo_session
-    ADD COLUMN IF NOT EXISTS asns BIGINT[];
+-- Can run in a transaction block since Postgres 12, though later statements
+-- in the same transaction can't use the new value.
+ALTER TYPE person_event ADD VALUE IF NOT EXISTS 'answered-question' AFTER 'joined-club';
 
-ALTER TABLE inbox
-    ADD COLUMN IF NOT EXISTS reaction TEXT,
-    ADD COLUMN IF NOT EXISTS reaction_target_mam_id BIGINT,
-    ADD COLUMN IF NOT EXISTS reaction_body TEXT;
+-- Blocks writes to `answer` while it builds (~75 s against a copy of the
+-- production DB). To avoid that, build it with CONCURRENTLY by hand before
+-- deploying and this becomes a no-op. That is:
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS idx__answer__question_id_public_answer
+--    ON answer(question_id, public_, answer, person_id);
+CREATE INDEX IF NOT EXISTS idx__answer__question_id_public_answer
+    ON answer(question_id, public_, answer, person_id);
+
+-- A strict prefix of idx__answer__question_id_public_answer, so it only adds
+-- write amplification on a hot table now
+DROP INDEX IF EXISTS idx__answer__question_id;

--- a/backend/qanda/__init__.py
+++ b/backend/qanda/__init__.py
@@ -1,4 +1,8 @@
+from dataclasses import dataclass
+from itertools import groupby
 import numpy
+from batcher import Batcher
+from constants import ANSWERED_QUESTION_EVENT_REFRESH_SECONDS
 from database import Row, Tx, api_tx
 import duotypes as t
 from qanda import personality
@@ -50,6 +54,38 @@ WHERE
     question_id = %(question_id)s
 """
 
+Q_SET_ANSWERED_QUESTION_EVENT = """
+UPDATE person
+SET
+    last_event_time = now(),
+    last_event_name = 'answered-question',
+    last_event_data = jsonb_build_object(
+        'answered_question_id', %(question_id)s
+    )
+WHERE
+    id = %(person_id)s
+AND (
+    last_event_name <> 'answered-question'
+OR
+    last_event_time <= now() - make_interval(secs => %(refresh_seconds)s)
+)
+"""
+
+# Stop advertising the answer in the feed if it's the person's latest event
+Q_REVERT_ANSWERED_QUESTION_EVENT = """
+UPDATE person
+SET
+    last_event_time = sign_up_time,
+    last_event_name = 'joined',
+    last_event_data = '{}'::jsonb
+WHERE
+    id = %(person_id)s
+AND
+    last_event_name = 'answered-question'
+AND
+    last_event_data->>'answered_question_id' = %(question_id)s::TEXT
+"""
+
 Q_SET_PERSONALITY = """
 UPDATE person
 SET
@@ -88,6 +124,75 @@ SET answers = NULL
 WHERE session_token_hash = %(session_token_hash)s
 """
 
+
+# What a person's feed event should say after their latest answer write:
+# advertise the question, or stop advertising it
+@dataclass(frozen=True)
+class AnswerEventJob:
+    person_id: int
+    question_id: int
+    advertise: bool
+
+
+@dataclass(frozen=True)
+class YesNoCountJob:
+    question_id: int
+    add_yes: int
+    add_no: int
+
+
+async def _process_answer_event_batch(jobs: list[AnswerEventJob]) -> None:
+    # Grouped into runs of consecutive same-type jobs, one executemany per
+    # run. Runs execute in batch order, so a person who reverts one
+    # question's event and advertises another's within a batch gets the
+    # outcome of that sequence; a whole-batch set/revert split would not
+    # preserve it.
+    async with api_tx('read committed') as tx:
+        for advertise, run in groupby(jobs, key=lambda job: job.advertise):
+            if advertise:
+                await tx.executemany(Q_SET_ANSWERED_QUESTION_EVENT, [
+                    dict(
+                        person_id=job.person_id,
+                        question_id=job.question_id,
+                        refresh_seconds=ANSWERED_QUESTION_EVENT_REFRESH_SECONDS,
+                    )
+                    for job in run
+                ])
+            else:
+                await tx.executemany(Q_REVERT_ANSWERED_QUESTION_EVENT, [
+                    dict(person_id=job.person_id, question_id=job.question_id)
+                    for job in run
+                ])
+
+
+async def _process_yes_no_count_batch(jobs: list[YesNoCountJob]) -> None:
+    totals: dict[int, tuple[int, int]] = {}
+    for job in jobs:
+        add_yes, add_no = totals.get(job.question_id, (0, 0))
+        totals[job.question_id] = (add_yes + job.add_yes, add_no + job.add_no)
+
+    # Sorted so that concurrent batches (one per API instance) lock question
+    # rows in the same order and can't deadlock
+    params_seq = [
+        dict(question_id=question_id, add_yes=add_yes, add_no=add_no)
+        for question_id, (add_yes, add_no) in sorted(totals.items())
+        if add_yes or add_no
+    ]
+
+    if not params_seq:
+        return
+
+    async with api_tx('read committed') as tx:
+        await tx.executemany(Q_ADD_YES_NO_COUNT, params_seq)
+
+
+def _enqueue_yes_no_count(question_id: int, answer: bool | None) -> None:
+    _yes_no_count_batcher.enqueue(YesNoCountJob(
+        question_id=question_id,
+        add_yes=1 if answer is True else 0,
+        add_no=1 if answer is False else 0,
+    ))
+
 async def _set_answer(
     tx: Tx,
     person_id: int,
@@ -95,7 +200,7 @@ async def _set_answer(
     answer: bool | None,
     public: bool | None,
     delete: bool,
-) -> None:
+) -> AnswerEventJob | None:
     question_tx = await tx.execute(
         Q_QUESTION_SCORE_VECTORS,
         dict(question_ids=[question_id]),
@@ -103,7 +208,7 @@ async def _set_answer(
     question: Row | None = await question_tx.fetchone()
 
     if question is None:
-        return
+        return None
 
     scores = await tx.require_one(
         Q_GET_PERSONALITY_SCORES,
@@ -153,22 +258,33 @@ async def _set_answer(
         count_answers=int(count),
     ))
 
+    # Returned rather than enqueued so callers only enqueue after their
+    # transaction commits; a rolled-back answer must not reach the feed
+    return AnswerEventJob(
+        person_id=person_id,
+        question_id=question_id,
+        advertise=not delete and answer is not None and bool(public),
+    )
+
 async def post_answer(req: t.PostAnswer, s: t.SessionInfo) -> object | None:
     if s.person_id is None:
         return '', 500
 
-    params_add_yes_no_count = dict(
-        question_id=req.question_id,
-        add_yes=1 if req.answer is True else 0,
-        add_no=1 if req.answer is False else 0,
-    )
-
-    async with api_tx('READ COMMITTED') as tx:
-        await tx.execute(Q_ADD_YES_NO_COUNT, params_add_yes_no_count)
-
     async with api_tx() as tx:
-        await _set_answer(
-            tx, s.person_id, req.question_id, req.answer, req.public, delete=False)
+        event_job = await _set_answer(
+            tx,
+            s.person_id,
+            req.question_id,
+            req.answer,
+            req.public,
+            delete=False,
+        )
+
+    if event_job:
+        _answer_event_batcher.enqueue(event_job)
+
+    _enqueue_yes_no_count(req.question_id, req.answer)
+
     return None
 
 async def delete_answer(req: t.DeleteAnswer, s: t.SessionInfo) -> object | None:
@@ -176,8 +292,18 @@ async def delete_answer(req: t.DeleteAnswer, s: t.SessionInfo) -> object | None:
         return '', 500
 
     async with api_tx() as tx:
-        await _set_answer(
-            tx, s.person_id, req.question_id, None, None, delete=True)
+        event_job = await _set_answer(
+            tx,
+            s.person_id,
+            req.question_id,
+            None,
+            None,
+            delete=True,
+        )
+
+    if event_job:
+        _answer_event_batcher.enqueue(event_job)
+
     return None
 
 
@@ -198,12 +324,10 @@ async def _flush_session_answers(
     answers = (row and row['answers']) or []
 
     for answer in answers:
-        await tx.execute(Q_ADD_YES_NO_COUNT, dict(
-            question_id=answer['question_id'],
-            add_yes=1 if answer['answer'] is True else 0,
-            add_no=1 if answer['answer'] is False else 0,
-        ))
+        _enqueue_yes_no_count(answer['question_id'], answer['answer'])
 
+        # The returned event job is deliberately dropped: answers stashed
+        # before signup shouldn't advertise in the feed
         await _set_answer(
             tx,
             person_id,
@@ -217,3 +341,24 @@ async def _flush_session_answers(
         Q_CLEAR_SESSION_ANSWERS,
         dict(session_token_hash=session_token_hash),
     )
+
+
+# Every answer write lands on two hot rows -- the answerer's person row (the
+# feed event) and the question row (the yes/no counts) -- and quiz players
+# write in bursts. Batching moves those writes off the request path and
+# coalesces each batch into one write per person/question.
+_answer_event_batcher = Batcher[AnswerEventJob](
+    process_fn=_process_answer_event_batch,
+    flush_interval=1.0,
+    min_batch_size=1,
+    max_batch_size=1000,
+    retry=False,
+)
+
+_yes_no_count_batcher = Batcher[YesNoCountJob](
+    process_fn=_process_yes_no_count_batch,
+    flush_interval=1.0,
+    min_batch_size=1,
+    max_batch_size=1000,
+    retry=False,
+)

--- a/backend/search/sql/__init__.py
+++ b/backend/search/sql/__init__.py
@@ -7,12 +7,171 @@ FEED_RESULTS_PER_PAGE = 50
 # The inverse of the proportion of feed results to discard.
 FEED_SELECTIVITY = 2
 
-# How many members to show in a `joined-club` feed item's facepile
-FEED_CLUB_FACEPILE_SIZE = 5
+# How many members to send for a feed item's facepile. For an
+# `answered-question` item's "yes" and "no" piles, mobile clients only show
+# the first 3 because the two piles share the card's width.
+FEED_FACEPILE_SIZE = 5
 
-# How many of a club's members to consider for the facepile. Bounds the work
-# done per feed item when the club is huge.
-FEED_CLUB_FACEPILE_POOL = 50
+# How many candidate members to consider for a facepile. Bounds the work done
+# per feed item when the club or question is huge.
+FEED_FACEPILE_POOL = 50
+
+
+def _facepile(pool: str, member_condition: str = 'TRUE') -> str:
+    """
+    A `jsonb_agg` of up to `FEED_FACEPILE_SIZE` members drawn from `pool`, a
+    subquery yielding at most `FEED_FACEPILE_POOL` candidate `person_id`s.
+    Members the searcher isn't allowed to see are filtered here, so `pool`
+    doesn't have to get that right; `member_condition` may extend the filter
+    with per-event-type conditions on `member`. Evaluated as a lateral join
+    within `Q_FEED_V2`, where `feed_page` and `searcher` are in scope.
+    """
+    return f"""
+        SELECT
+            jsonb_agg(
+                jsonb_build_object(
+                    'person_uuid', facepile_member.person_uuid,
+                    'url_slug', facepile_member.url_slug,
+                    'photo_uuid', facepile_member.photo_uuid,
+                    'photo_blurhash', facepile_member.photo_blurhash
+                )
+                ORDER BY
+                    facepile_member.matches_gender_preference DESC,
+                    facepile_member.last_online_time DESC
+            ) AS j
+        FROM (
+            SELECT
+                member.uuid AS person_uuid,
+                member.url_slug,
+                member_photo.uuid AS photo_uuid,
+                member_photo.blurhash AS photo_blurhash,
+                member.last_online_time,
+                EXISTS (
+                    SELECT
+                        1
+                    FROM
+                        search_preference_gender AS preference
+                    WHERE
+                        preference.person_id = searcher.searcher_id
+                    AND
+                        preference.gender_id = member.gender_id
+                ) AS matches_gender_preference
+            FROM (
+                {pool}
+            ) AS pool
+            JOIN
+                person AS member
+            ON
+                member.id = pool.person_id
+            JOIN LATERAL (
+                SELECT
+                    photo.uuid,
+                    photo.blurhash
+                FROM
+                    photo
+                WHERE
+                    photo.person_id = member.id
+                AND
+                    COALESCE(photo.nsfw_score, 0) <= 0.2
+                ORDER BY
+                    photo.position
+                LIMIT 1
+            ) AS member_photo
+            ON TRUE
+            WHERE
+                -- The event's subject is already the feed item's hero avatar
+                member.id <> feed_page.id
+            AND
+                -- The searcher is already in the payload as the viewer entry
+                -- (club_viewer/question_viewer), so including them here would
+                -- double them up
+                member.id <> searcher.searcher_id
+            AND (
+                {member_condition}
+            )
+            AND
+                member.shadow_banned_at IS NULL
+            AND
+                NOT member.hide_me_from_strangers
+            AND
+                -- The member did not skip the searcher; their profile would
+                -- be inaccessible if they did
+                NOT EXISTS (
+                    SELECT
+                        1
+                    FROM
+                        skipped
+                    WHERE
+                        skipped.subject_person_id = member.id
+                    AND
+                        skipped.object_person_id = searcher.searcher_id
+                )
+            AND
+                member.privacy_verification_level_id <=
+                    searcher.verification_level_id
+            AND (
+                    member.verification_level_id > 1
+                OR
+                    NOT member.verification_required
+            )
+            ORDER BY
+                matches_gender_preference DESC,
+                member.last_online_time DESC
+            LIMIT
+                {FEED_FACEPILE_SIZE}
+        ) AS facepile_member
+    """
+
+
+def _club_facepile() -> str:
+    """
+    The facepile for a 'joined-club' feed item; `club` is in scope at the
+    call site.
+    """
+    return _facepile(f"""
+                SELECT
+                    person_id
+                FROM
+                    person_club
+                WHERE
+                    person_club.club_name = club.name
+                AND
+                    person_club.activated
+                ORDER BY
+                    person_club.person_id DESC
+                LIMIT
+                    {FEED_FACEPILE_POOL}
+    """)
+
+
+def _question_facepile(answer: bool) -> str:
+    """
+    The facepile of people who publicly answered `question.id` with `answer`;
+    `question` is in scope at the call site.
+    """
+    return _facepile(
+        f"""
+                SELECT
+                    person_id
+                FROM
+                    answer
+                WHERE
+                    answer.question_id = question.id
+                AND
+                    answer.public_
+                AND
+                    answer.answer = {'TRUE' if answer else 'FALSE'}
+                ORDER BY
+                    answer.person_id DESC
+                LIMIT
+                    {FEED_FACEPILE_POOL}
+        """,
+        member_condition="""
+                -- Unlike `person_club` rows, `answer` rows aren't deactivated
+                -- with the account, so members must be filtered here
+                member.activated
+        """,
+    )
 
 
 
@@ -1396,7 +1555,8 @@ WITH searcher AS (
         person.id = %(searcher_person_id)s
 ), searcher_photo AS (
     -- The searcher's first photo, for rendering their own avatar in
-    -- 'joined-club' facepiles. Zero rows if they have no photos.
+    -- 'joined-club' and 'answered-question' facepiles. Zero rows if they
+    -- have no photos.
     SELECT
         photo.uuid,
         photo.blurhash
@@ -1880,6 +2040,7 @@ SELECT
     )
     || mapped_last_event_data
     || COALESCE(joined_club_data.j, '{{}}'::jsonb)
+    || COALESCE(answered_question_data.j, '{{}}'::jsonb)
     AS j
 FROM
     feed_page
@@ -1904,106 +2065,7 @@ LEFT JOIN LATERAL (
     ON
         TRUE
     LEFT JOIN LATERAL (
-        SELECT
-            jsonb_agg(
-                jsonb_build_object(
-                    'person_uuid', facepile_member.person_uuid,
-                    'url_slug', facepile_member.url_slug,
-                    'photo_uuid', facepile_member.photo_uuid,
-                    'photo_blurhash', facepile_member.photo_blurhash
-                )
-                ORDER BY
-                    facepile_member.matches_gender_preference DESC,
-                    facepile_member.last_online_time DESC
-            ) AS j
-        FROM (
-            SELECT
-                member.uuid AS person_uuid,
-                member.url_slug,
-                member_photo.uuid AS photo_uuid,
-                member_photo.blurhash AS photo_blurhash,
-                member.last_online_time,
-                EXISTS (
-                    SELECT
-                        1
-                    FROM
-                        search_preference_gender AS preference
-                    WHERE
-                        preference.person_id = searcher.searcher_id
-                    AND
-                        preference.gender_id = member.gender_id
-                ) AS matches_gender_preference
-            FROM (
-                SELECT
-                    person_id
-                FROM
-                    person_club
-                WHERE
-                    person_club.club_name = club.name
-                AND
-                    person_club.activated
-                ORDER BY
-                    person_club.person_id DESC
-                LIMIT
-                    {FEED_CLUB_FACEPILE_POOL}
-            ) AS pool
-            JOIN
-                person AS member
-            ON
-                member.id = pool.person_id
-            JOIN LATERAL (
-                SELECT
-                    photo.uuid,
-                    photo.blurhash
-                FROM
-                    photo
-                WHERE
-                    photo.person_id = member.id
-                AND
-                    COALESCE(photo.nsfw_score, 0) <= 0.2
-                ORDER BY
-                    photo.position
-                LIMIT 1
-            ) AS member_photo
-            ON TRUE
-            WHERE
-                -- The joiner is already the feed item's hero avatar
-                member.id <> feed_page.id
-            AND
-                -- The searcher is already in the payload as club_viewer,
-                -- so including them here would double them up
-                member.id <> searcher.searcher_id
-            AND
-                member.shadow_banned_at IS NULL
-            AND
-                NOT member.hide_me_from_strangers
-            AND
-                -- The member did not skip the searcher; their profile would be
-                -- inaccessible if they did
-                NOT EXISTS (
-                    SELECT
-                        1
-                    FROM
-                        skipped
-                    WHERE
-                        skipped.subject_person_id = member.id
-                    AND
-                        skipped.object_person_id = searcher.searcher_id
-                )
-            AND
-                member.privacy_verification_level_id <=
-                    searcher.verification_level_id
-            AND (
-                    member.verification_level_id > 1
-                OR
-                    NOT member.verification_required
-            )
-            ORDER BY
-                matches_gender_preference DESC,
-                member.last_online_time DESC
-            LIMIT
-                {FEED_CLUB_FACEPILE_SIZE}
-        ) AS facepile_member
+        {_club_facepile()}
     ) AS facepile
     ON TRUE
     WHERE
@@ -2019,6 +2081,64 @@ LEFT JOIN LATERAL (
         club.name <= (feed_page.mapped_last_event_data
             ->> 'joined_club_name')
 ) AS joined_club_data
+ON TRUE
+LEFT JOIN LATERAL (
+    SELECT
+        jsonb_build_object(
+            'question_text', question.question,
+            'question_topic', question.topic,
+            -- Like the quiz screen's counts, these include private answers,
+            -- which is also what makes them cheap: counting only public
+            -- answers would mean aggregating over the question's answers on
+            -- every read
+            'question_count_yes', question.count_yes,
+            'question_count_no', question.count_no,
+            'question_yes_members', COALESCE(yes_facepile.j, '[]'::jsonb),
+            'question_no_members', COALESCE(no_facepile.j, '[]'::jsonb),
+            'question_viewer', jsonb_build_object(
+                'person_uuid', searcher.searcher_uuid,
+                'url_slug', searcher.searcher_url_slug,
+                'photo_uuid', searcher_photo.uuid,
+                'photo_blurhash', searcher_photo.blurhash,
+                'answer', viewer_answer.answer,
+                'public_', viewer_answer.public_
+            )
+        ) AS j
+    FROM
+        question
+    LEFT JOIN
+        searcher_photo
+    ON
+        TRUE
+    LEFT JOIN LATERAL (
+        -- The searcher's own answer, sent whether or not it's public (it's
+        -- their own answer). Were a private answer sent as unanswered,
+        -- answering from the feed would silently re-answer it publicly.
+        SELECT
+            answer.answer,
+            answer.public_
+        FROM
+            answer
+        WHERE
+            answer.person_id = searcher.searcher_id
+        AND
+            answer.question_id = question.id
+    ) AS viewer_answer
+    ON TRUE
+    LEFT JOIN LATERAL (
+        {_question_facepile(True)}
+    ) AS yes_facepile
+    ON TRUE
+    LEFT JOIN LATERAL (
+        {_question_facepile(False)}
+    ) AS no_facepile
+    ON TRUE
+    WHERE
+        feed_page.type = 'answered-question'
+    AND
+        question.id = (feed_page.mapped_last_event_data
+            ->> 'answered_question_id')::SMALLINT
+) AS answered_question_data
 ON TRUE
 ORDER BY
     came_online_time DESC

--- a/backend/test/functionality1/feed-v2.sh
+++ b/backend/test/functionality1/feed-v2.sh
@@ -587,5 +587,316 @@ test_joined_club () {
   q "delete from banned_club where name = 'cats'"
 }
 
+# Answer events and yes/no counts land via one-second batchers in the API,
+# not in the POST /answer transaction, so give them a moment to flush before
+# asserting on them
+flush_answer_batchers () {
+  sleep 2
+}
+
+answered_question_feed_items () {
+  local before
+
+  assume_role searcher
+
+  before=$(q "select iso8601_utc(now()::timestamp)")
+
+  c GET "/feed-v2?before=${before}" \
+    | jq -S '
+      def redact: if . == null then . else "redacted_nonnull_value" end;
+
+      def redact_if_present($k):
+        if has($k) and .[$k] != null
+        then .[$k] |= redact
+        else .
+        end ;
+
+      [ .[] | select(.type == "answered-question") ]
+      | map(
+            redact_if_present("person_uuid")
+          | redact_if_present("url_slug")
+          | redact_if_present("photo_uuid")
+          | redact_if_present("photo_blurhash")
+          | redact_if_present("time")
+          | redact_if_present("online_time")
+          | redact_if_present("came_online_time")
+          | .question_yes_members |= map(map_values(redact))
+          | .question_no_members |= map(map_values(redact))
+          | .question_viewer |= (
+                .person_uuid |= redact
+              | .url_slug |= redact
+            )
+      )
+    '
+}
+
+expected_answered_question_item () {
+  local name=$1
+  local count_yes_members=$2
+  local count_no_members=$3
+  local count_yes=$4
+  local count_no=$5
+  local viewer_answer=$6
+  local viewer_public=$7
+  local match_percentage=$8
+
+  jq -nS \
+    --arg name "$name" \
+    --argjson question_id "$question_id" \
+    --arg question_text "$question_text" \
+    --arg question_topic "$question_topic" \
+    --argjson count_yes_members "$count_yes_members" \
+    --argjson count_no_members "$count_no_members" \
+    --argjson count_yes "$count_yes" \
+    --argjson count_no "$count_no" \
+    --argjson viewer_answer "$viewer_answer" \
+    --argjson viewer_public "$viewer_public" \
+    --argjson match_percentage "$match_percentage" \
+    '
+    def members($n):
+      [ range($n)
+        | {
+            "person_uuid": "redacted_nonnull_value",
+            "photo_blurhash": "redacted_nonnull_value",
+            "photo_uuid": "redacted_nonnull_value",
+            "url_slug": "redacted_nonnull_value"
+          }
+      ];
+
+    {
+      "advertiser_friendly": false,
+      "age": 26,
+      "answered_question_id": $question_id,
+      "question_text": $question_text,
+      "question_topic": $question_topic,
+      "question_count_yes": $count_yes,
+      "question_count_no": $count_no,
+      "question_yes_members": members($count_yes_members),
+      "question_no_members": members($count_no_members),
+      "question_viewer": {
+        "person_uuid": "redacted_nonnull_value",
+        "url_slug": "redacted_nonnull_value",
+        "photo_uuid": null,
+        "photo_blurhash": null,
+        "answer": $viewer_answer,
+        "public_": $viewer_public
+      },
+      "flair": ["gold"],
+      "gender": "Other",
+      "is_verified": false,
+      "location": "New York, New York, United States",
+      "match_percentage": $match_percentage,
+      "name": $name,
+      "came_online_time": "redacted_nonnull_value",
+      "online_time": "redacted_nonnull_value",
+      "person_uuid": "redacted_nonnull_value",
+      "photo_blurhash": "redacted_nonnull_value",
+      "photo_uuid": "redacted_nonnull_value",
+      "time": "redacted_nonnull_value",
+      "type": "answered-question",
+      "url_slug": "redacted_nonnull_value"
+    }
+    '
+}
+
+test_answered_question () {
+  local response
+  local expected
+  local user_type
+  local match_user1
+  local match_user2
+  local match_user3
+
+  reset_db
+
+  ../util/create-user.sh searcher 0
+  ../util/create-user.sh user1 0 1
+  ../util/create-user.sh user2 0 1
+  ../util/create-user.sh user3 0 1
+
+  q "update person set privacy_verification_level_id = 1"
+  q "update person set background_color = '#aaaaaa'"
+
+  question_id=10
+  question_text=$(q "select question from question where id = ${question_id}")
+  question_topic=$(q "select topic from question where id = ${question_id}")
+
+  # The yes/no counts include private answers and survive `reset_db`, so zero
+  # them for determinism. They're only ever incremented, even on re-answers,
+  # so the expectations below track every POST, public or private.
+  q "update question set count_yes = 0, count_no = 0
+     where id = ${question_id}"
+
+  # user2 and user3 answer publicly
+  assume_role user2
+  jc POST /answer \
+    -d "{ \"question_id\": ${question_id}, \"answer\": true, \"public\": true }"
+
+  assume_role user3
+  jc POST /answer \
+    -d "{ \"question_id\": ${question_id}, \"answer\": false, \"public\": true }"
+
+  # user1 answers privately, which mustn't be advertised in the feed
+  assume_role user1
+  jc POST /answer \
+    -d "{ \"question_id\": ${question_id}, \"answer\": true, \"public\": false }"
+
+  flush_answer_batchers
+
+  user_type=$(q "select last_event_name from person where name = 'user1'")
+  [[ "$user_type" != answered-question ]]
+
+  set_deterministic_online_times
+
+  # user1's private answer doesn't appear as an event or in the piles. The
+  # searcher hasn't answered, so `question_viewer.answer` is null.
+  # question_count_yes is 2: user1's private answer counts, like on the quiz
+  # screen, despite being hidden from the piles
+  response=$(answered_question_feed_items)
+  expected=$(
+    jq -sS . \
+      <(expected_answered_question_item user2 0 1 2 1 null null 50) \
+      <(expected_answered_question_item user3 1 0 2 1 null null 50)
+  )
+  diff -u --color <(echo "$response") <(echo "$expected")
+
+  # user1 re-answers publicly; their event appears and they join the piles
+  assume_role user1
+  jc POST /answer \
+    -d "{ \"question_id\": ${question_id}, \"answer\": true, \"public\": true }"
+
+  flush_answer_batchers
+
+  set_deterministic_online_times
+
+  # Re-answering increments question_count_yes again; the counts only ever
+  # grow
+  response=$(answered_question_feed_items)
+  expected=$(
+    jq -sS . \
+      <(expected_answered_question_item user1 1 1 3 1 null null 50) \
+      <(expected_answered_question_item user2 1 1 3 1 null null 50) \
+      <(expected_answered_question_item user3 2 0 3 1 null null 50)
+  )
+  diff -u --color <(echo "$response") <(echo "$expected")
+
+  # The searcher answers publicly. Their answer appears in question_viewer,
+  # but they never appear among the sample members. Answering shifts the
+  # searcher's personality, and with it the match percentages.
+  assume_role searcher
+  jc POST /answer \
+    -d "{ \"question_id\": ${question_id}, \"answer\": false, \"public\": true }"
+
+  flush_answer_batchers
+
+  match_user1=$(q "
+    select clamp(
+      0, 99,
+      100 * (1 - (a.personality <#> b.personality)) / 2
+    )::smallint
+    from person a, person b
+    where a.name = 'searcher' and b.name = 'user1'")
+  match_user2=$(q "
+    select clamp(
+      0, 99,
+      100 * (1 - (a.personality <#> b.personality)) / 2
+    )::smallint
+    from person a, person b
+    where a.name = 'searcher' and b.name = 'user2'")
+  match_user3=$(q "
+    select clamp(
+      0, 99,
+      100 * (1 - (a.personality <#> b.personality)) / 2
+    )::smallint
+    from person a, person b
+    where a.name = 'searcher' and b.name = 'user3'")
+
+  set_deterministic_online_times
+
+  response=$(answered_question_feed_items)
+  expected=$(
+    jq -sS . \
+      <(expected_answered_question_item user1 1 1 3 2 false true "$match_user1") \
+      <(expected_answered_question_item user2 1 1 3 2 false true "$match_user2") \
+      <(expected_answered_question_item user3 2 0 3 2 false true "$match_user3")
+  )
+  diff -u --color <(echo "$response") <(echo "$expected")
+
+  # The searcher makes their answer private. It's their own answer, so it's
+  # still sent to them -- flagged private -- or answering from the feed could
+  # mistake it for unanswered and silently re-publish it
+  jc POST /answer \
+    -d "{ \"question_id\": ${question_id}, \"answer\": false, \"public\": false }"
+
+  flush_answer_batchers
+
+  set_deterministic_online_times
+
+  response=$(answered_question_feed_items)
+  expected=$(
+    jq -sS . \
+      <(expected_answered_question_item user1 1 1 3 3 false false "$match_user1") \
+      <(expected_answered_question_item user2 1 1 3 3 false false "$match_user2") \
+      <(expected_answered_question_item user3 2 0 3 3 false false "$match_user3")
+  )
+  diff -u --color <(echo "$response") <(echo "$expected")
+
+  # Making an answer private reverts the answerer's event and removes them
+  # from the piles
+  assume_role user3
+  jc POST /answer \
+    -d "{ \"question_id\": ${question_id}, \"answer\": false, \"public\": false }"
+
+  flush_answer_batchers
+
+  user_type=$(q "select last_event_name from person where name = 'user3'")
+  [[ "$user_type" == joined ]]
+
+  set_deterministic_online_times
+
+  response=$(answered_question_feed_items)
+  expected=$(
+    jq -sS . \
+      <(expected_answered_question_item user1 1 0 3 4 false false "$match_user1") \
+      <(expected_answered_question_item user2 1 0 3 4 false false "$match_user2")
+  )
+  diff -u --color <(echo "$response") <(echo "$expected")
+
+  # Deleting an answer reverts the deleter's event and removes them from the
+  # piles
+  assume_role user2
+  jc DELETE /answer -d "{ \"question_id\": ${question_id} }"
+
+  flush_answer_batchers
+
+  user_type=$(q "select last_event_name from person where name = 'user2'")
+  [[ "$user_type" == joined ]]
+
+  set_deterministic_online_times
+
+  response=$(answered_question_feed_items)
+  expected=$(
+    jq -sS . \
+      <(expected_answered_question_item user1 0 0 3 4 false false "$match_user1")
+  )
+  diff -u --color <(echo "$response") <(echo "$expected")
+
+  # Skipping the question (a null answer) reverts the event too
+  assume_role user1
+  jc POST /answer \
+    -d "{ \"question_id\": ${question_id}, \"answer\": null, \"public\": true }"
+
+  flush_answer_batchers
+
+  user_type=$(q "select last_event_name from person where name = 'user1'")
+  [[ "$user_type" == joined ]]
+
+  set_deterministic_online_times
+
+  response=$(answered_question_feed_items)
+  diff -u --color <(echo "$response") <(echo "[]")
+}
+
 test_json_format
 test_joined_club
+test_answered_question

--- a/backend/test/functionality1/onboarding.sh
+++ b/backend/test/functionality1/onboarding.sh
@@ -97,6 +97,10 @@ c GET /search-locations?q=Syd
 jc POST /answer -d '{ "question_id": 1001, "answer": true, "public": false }'
 jc POST /answer -d '{ "question_id": 1002, "answer": false, "public": false }'
 
+# The yes/no counts land via a one-second batcher, not in the POST /answer
+# transaction
+sleep 2
+
 [[ "$(q "select count_yes   from question where id = 1001")" -eq 1 ]]
 [[ "$(q "select count_no    from question where id = 1001")" -eq 0 ]]
 [[ "$(q "select count_yes   from question where id = 1002")" -eq 0 ]]

--- a/backend/test/functionality1/public-qanda.sh
+++ b/backend/test/functionality1/public-qanda.sh
@@ -135,8 +135,10 @@ answers_saved_on_onboarding () {
   [[ "$(q "select public_ from answer where person_id = $pid and question_id = $q2")" == "f" ]]
   [[ "$(q "select count_answers from person where id = $pid")" -eq 2 ]]
 
-  # The stash is cleared and the question stats were bumped.
+  # The stash is cleared and the question stats were bumped. The yes/no
+  # counts land via a one-second batcher, not in the flush transaction.
   [[ "$(q "select count(*) from duo_session where answers is not null")" -eq 0 ]]
+  sleep 2
   [[ "$(q "select count_yes from question where id = $q1")" -eq 1 ]]
   [[ "$(q "select count_no  from question where id = $q2")" -eq 1 ]]
 }

--- a/frontend/api/answer.tsx
+++ b/frontend/api/answer.tsx
@@ -1,0 +1,170 @@
+// The only place that's allowed to write Q&A answers to the server. Answering
+// a question re-ranks search results and match percentages, so every write
+// must flag the cached search results and inbox as stale; every write must
+// also go through `answerWriteQueue`, or two writes in short succession could land
+// on the server out of order; and every surface that renders the viewer's
+// answer must hear about the write, or it drifts from the ones that do.
+// Routing all writes through here makes all three impossible to forget.
+//
+// This module is also the store for what the viewer has answered, keyed by
+// question. `saveAnswer` and `deleteAnswer` update it optimistically, before
+// their writes land.
+
+import { useLayoutEffect, useState } from 'react';
+import { japi } from './api';
+import { answerWriteQueue } from './queue';
+import { markSearchResultsStale } from '../events/stale-search-results';
+import { markInboxStale } from '../events/stale-inbox';
+import { notify, listen, lastEvent } from '../events/events';
+
+type ViewerAnswer = {
+  answer: boolean | null
+  public_: boolean
+};
+
+const unansweredViewerAnswer: ViewerAnswer = {
+  answer: null,
+  public_: true,
+};
+
+const viewerAnswerKey = (questionId: number) =>
+  `viewer-answer-${questionId}`;
+
+// Which questions have store entries, so sign-out can clear them all
+const storedQuestionIds = new Set<number>();
+
+const getViewerAnswer = (questionId: number): ViewerAnswer =>
+  lastEvent<ViewerAnswer>(viewerAnswerKey(questionId))
+    ?? unansweredViewerAnswer;
+
+// Updates what the viewer sees without writing to the server, e.g. for
+// settings (like publicness) that don't mean anything until there's an answer
+const setViewerAnswerLocally = (questionId: number, state: ViewerAnswer) => {
+  storedQuestionIds.add(questionId);
+  notify<ViewerAnswer>(viewerAnswerKey(questionId), state);
+};
+
+// Adopts server-sent state, but never clobbers what the viewer did in this
+// session; the store hears about every write, so it's fresher than any fetch
+const seedViewerAnswer = (questionId: number, state: ViewerAnswer) => {
+  if (lastEvent(viewerAnswerKey(questionId)) === undefined) {
+    setViewerAnswerLocally(questionId, state);
+  }
+};
+
+// Sign-out must call this so a subsequent sign-in by a different user on the
+// same browser tab doesn't inherit (and, via `seedViewerAnswer`, keep) the
+// previous user's answers
+const resetViewerAnswers = () => {
+  for (const questionId of storedQuestionIds) {
+    notify(viewerAnswerKey(questionId), undefined);
+  }
+  storedQuestionIds.clear();
+};
+
+const useViewerAnswer = (questionId: number): ViewerAnswer => {
+  const [value, setValue] = useState(() => getViewerAnswer(questionId));
+
+  useLayoutEffect(() => {
+    // Re-read on every (re)subscription: `questionId` may have changed since
+    // the useState initializer ran, and a write may have landed since render
+    setValue(getViewerAnswer(questionId));
+
+    return listen(
+      viewerAnswerKey(questionId),
+      () => setValue(getViewerAnswer(questionId)),
+    );
+  }, [questionId]);
+
+  return value;
+};
+
+const saveAnswer = (
+  questionId: number,
+  answer: boolean | null | undefined,
+  answerPublicly: boolean,
+): Promise<void> => {
+  setViewerAnswerLocally(
+    questionId,
+    { answer: answer ?? null, public_: answerPublicly },
+  );
+
+  return answerWriteQueue.addTask(async () => {
+    await japi('post', '/answer', {
+      question_id: questionId,
+      answer: answer,
+      public: answerPublicly,
+    });
+
+    markSearchResultsStale();
+    markInboxStale();
+  });
+};
+
+const deleteAnswer = (questionId: number): Promise<void> => {
+  setViewerAnswerLocally(questionId, unansweredViewerAnswer);
+
+  return answerWriteQueue.addTask(async () => {
+    await japi('delete', '/answer', { question_id: questionId });
+
+    markSearchResultsStale();
+    markInboxStale();
+  });
+};
+
+const nextAnswer = (curAnswer: boolean | null, pressedButton?: boolean) => {
+  if (pressedButton === undefined) {
+    if (curAnswer === true) return false;
+    if (curAnswer === false) return null;
+    return true;
+  } else {
+    if (curAnswer === pressedButton) {
+      return null;
+    } else {
+      return pressedButton;
+    }
+  }
+};
+
+// The viewer pressed a yes/no button: select that answer, or deselect (skip)
+// if it was already selected
+const toggleAnswer = (
+  questionId: number,
+  pressedButton: boolean,
+): Promise<void> => {
+  const current = getViewerAnswer(questionId);
+
+  return saveAnswer(
+    questionId,
+    nextAnswer(current.answer, pressedButton),
+    current.public_,
+  );
+};
+
+const setAnswerPublicly = (
+  questionId: number,
+  public_: boolean,
+): Promise<void> => {
+  const current = getViewerAnswer(questionId);
+
+  if (current.answer === null) {
+    // There's no answer to write yet; the choice still has to be remembered
+    // for when they answer
+    setViewerAnswerLocally(questionId, { ...current, public_ });
+    return Promise.resolve();
+  }
+
+  return saveAnswer(questionId, current.answer, public_);
+};
+
+export {
+  ViewerAnswer,
+  deleteAnswer,
+  nextAnswer,
+  resetViewerAnswers,
+  saveAnswer,
+  seedViewerAnswer,
+  setAnswerPublicly,
+  toggleAnswer,
+  useViewerAnswer,
+};

--- a/frontend/api/queue.tsx
+++ b/frontend/api/queue.tsx
@@ -45,12 +45,18 @@ class PromiseQueue {
 // Answer writes (and undos) need to finish in order. If we send two http
 // requests at roughly the same time, the server will see them in an arbitrary
 // order. So if the user undoes then re-answers a question in short succession,
-// their re-answer might be deleted. So we use a queue to make sure that doesn't
-// happen.
-const quizQueue = new PromiseQueue();
+// their re-answer might be deleted. Only `api/answer` may enqueue here; it
+// does so on every write, so callers can't forget to.
+const answerWriteQueue = new PromiseQueue();
+
+// The quiz stack's prospect-strip updates also need to happen in swipe order,
+// each after its swipe's answer write has landed so the fetched prospects
+// reflect the new answer. They get their own queue because their tasks await
+// answerWriteQueue tasks, which would deadlock on a single queue.
+const prospectUpdateQueue = new PromiseQueue();
 
 // Fetching the next batch of cards is kept on its own queue, separate from
-// quizQueue. Otherwise an answer write that's stuck retrying (e.g. while
+// answerWriteQueue. Otherwise an answer write that's stuck retrying (e.g. while
 // offline) would block the queue and prevent us from ever topping up the stack,
 // so the user would never see the skeleton cards as they swipe to the end.
 const cardQueue = new PromiseQueue();
@@ -70,10 +76,11 @@ const photoQueue = new PromiseQueue();
 
 export {
   aboutQueue,
+  answerWriteQueue,
   cardQueue,
   nameQueue,
   onboardingQueue,
   photoQueue,
-  quizQueue,
+  prospectUpdateQueue,
   searchQueue,
 };

--- a/frontend/components/feed-tab.tsx
+++ b/frontend/components/feed-tab.tsx
@@ -14,9 +14,9 @@ import { DefaultText } from './default-text';
 import { DuoliciousTopNavBar } from './top-nav-bar';
 import { useScrollbar } from './navigation/scroll-bar-hooks';
 import { Avatar } from './avatar';
-import { getShortElapsedTime, isMobile, assertNever, capLuminance } from '../util/util';
+import { getShortElapsedTime, isMobile, assertNever, capLuminance, formatCount } from '../util/util';
 import { makeLinkProps } from '../util/navigation';
-import { GestureResponderEvent, Pressable, Animated, ViewStyle } from 'react-native';
+import { GestureResponderEvent, LayoutChangeEvent, Pressable, Animated, ViewStyle } from 'react-native';
 import { EnlargeablePhoto } from './enlargeable-image';
 import { commonStyles } from '../styles';
 import { VerificationBadge } from './verification-badge';
@@ -24,6 +24,13 @@ import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootParamList } from '../navigation/linking';
 import { japi } from '../api/api';
+import {
+  ViewerAnswer,
+  seedViewerAnswer,
+  setAnswerPublicly,
+  toggleAnswer,
+  useViewerAnswer,
+} from '../api/answer';
 import { DefaultFlatList, DefaultFlashList } from './default-flat-list';
 import { z } from 'zod';
 import { notify, listen, lastEvent } from '../events/events';
@@ -35,7 +42,6 @@ import { IMAGES_URL } from '../env/env';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import Reanimated, {
   Easing,
-  interpolate,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -52,6 +58,11 @@ import { faReply } from '@fortawesome/free-solid-svg-icons/faReply';
 import { OnlineIndicator } from './online-indicator';
 import { useAppTheme } from '../app-theme/app-theme';
 import { usePressableAnimation } from '../animation/animation';
+import {
+  ANSWER_ICON_SIZE,
+  AnswerIcon,
+  NonInteractiveQuizCard,
+} from './quiz-card';
 
 const NAME_ACTION_TIME_GAP_VERTICAL = 16;
 
@@ -63,6 +74,7 @@ type Action =
   | "Erased their bio"
   | "Joined"
   | "Joined a club"
+  | "Played Q&A"
   | "Recently online"
   | "Updated their bio"
 
@@ -104,32 +116,51 @@ const UpdatedBioFieldsSchema = DataItemBaseSchema.extend({
 
 const JoinedFieldsSchema = DataItemBaseSchema;
 
+const FacepileMemberSchema = z.object({
+  person_uuid: z.string(),
+  url_slug: z.string().nullable(),
+  photo_uuid: z.string(),
+  photo_blurhash: z.string(),
+});
+
+// The viewer, as a facepile entry. Sent by the server so the facepile
+// doesn't depend on the profile-info store, which is only populated when
+// the profile tab mounts. Unlike the sample members, the viewer might not
+// have a photo.
+const FacepileViewerSchema = z.object({
+  person_uuid: z.string(),
+  url_slug: z.string().nullable(),
+  photo_uuid: z.string().nullable(),
+  photo_blurhash: z.string().nullable(),
+});
+
 const JoinedClubFieldsSchema = DataItemBaseSchema.extend({
   joined_club_name: z.string(),
   club_count_members: z.number(),
-  club_sample_members: z.array(
-    z.object({
-      person_uuid: z.string(),
-      url_slug: z.string().nullable(),
-      photo_uuid: z.string(),
-      photo_blurhash: z.string(),
-    })
-  ),
-  // The viewer, as a facepile entry. Sent by the server so the facepile
-  // doesn't depend on the profile-info store, which is only populated when
-  // the profile tab mounts. Unlike the sample members, the viewer might not
-  // have a photo.
-  club_viewer: z.object({
-    person_uuid: z.string(),
-    url_slug: z.string().nullable(),
-    photo_uuid: z.string().nullable(),
-    photo_blurhash: z.string().nullable(),
-  }),
+  club_sample_members: z.array(FacepileMemberSchema),
+  club_viewer: FacepileViewerSchema,
   // Not sent by the server; stamped by fetchPage when the page arrives.
   // Records whether the viewer was a member (and so counted in
   // club_count_members) at fetch time, so join/leave presses can adjust the
   // count without any per-card state.
   viewer_was_member: z.boolean().optional(),
+});
+
+const AnsweredQuestionFieldsSchema = DataItemBaseSchema.extend({
+  answered_question_id: z.number(),
+  question_text: z.string(),
+  question_topic: z.string(),
+  // Like the quiz screen's counts, these include private answers
+  question_count_yes: z.number(),
+  question_count_no: z.number(),
+  question_yes_members: z.array(FacepileMemberSchema),
+  question_no_members: z.array(FacepileMemberSchema),
+  // The viewer's own answer, private or not; `public_` is null when they
+  // haven't answered
+  question_viewer: FacepileViewerSchema.extend({
+    answer: z.boolean().nullable(),
+    public_: z.boolean().nullable(),
+  }),
 });
 
 const DataItemJoinedSchema = JoinedFieldsSchema.extend({
@@ -138,6 +169,10 @@ const DataItemJoinedSchema = JoinedFieldsSchema.extend({
 
 const DataItemJoinedClubSchema = JoinedClubFieldsSchema.extend({
   type: z.literal('joined-club'),
+});
+
+const DataItemAnsweredQuestionSchema = AnsweredQuestionFieldsSchema.extend({
+  type: z.literal('answered-question'),
 });
 
 const DataItemAddedPhotoSchema = AddedPhotoFieldsSchema.extend({
@@ -167,6 +202,7 @@ const DataItemWasRecentlyOnlineWithVoiceBioSchema = AddedVoiceBioFieldsSchema.ex
 const DataItemSchema = z.discriminatedUnion('type', [
   DataItemJoinedSchema,
   DataItemJoinedClubSchema,
+  DataItemAnsweredQuestionSchema,
   DataItemWasRecentlyOnlineWithBioSchema,
   DataItemWasRecentlyOnlineWithPhotoSchema,
   DataItemWasRecentlyOnlineWithVoiceBioSchema,
@@ -182,6 +218,9 @@ type DataItemWasRecentlyOnlineWithVoiceBio = z.infer<typeof DataItemWasRecentlyO
 
 type JoinedFields = z.infer<typeof JoinedFieldsSchema>;
 type JoinedClubFields = z.infer<typeof JoinedClubFieldsSchema>;
+type AnsweredQuestionFields = z.infer<typeof AnsweredQuestionFieldsSchema>;
+type FacepileMember = z.infer<typeof FacepileMemberSchema>;
+type FacepileViewer = z.infer<typeof FacepileViewerSchema>;
 type UpdatedBioFields = z.infer<typeof UpdatedBioFieldsSchema>;
 type AddedPhotoFields = z.infer<typeof AddedPhotoFieldsSchema>;
 type AddedVoiceBioFields = z.infer<typeof AddedVoiceBioFieldsSchema>;
@@ -216,6 +255,15 @@ const stampViewerMembership = (item: DataItem): DataItem =>
   item.type === 'joined-club'
     ? { ...item, viewer_was_member: isClubMember(item.joined_club_name) }
     : item;
+
+const seedViewerAnswerFromItem = (item: DataItem): void => {
+  if (item.type === 'answered-question') {
+    seedViewerAnswer(item.answered_question_id, {
+      answer: item.question_viewer.answer,
+      public_: item.question_viewer.public_ ?? true,
+    });
+  }
+};
 
 const fetchPage = async (pageNumber: number): Promise<DataItem[] | null> => {
   if (pageNumber === 1) {
@@ -253,6 +301,8 @@ const fetchPage = async (pageNumber: number): Promise<DataItem[] | null> => {
     .filter(isValidDataItem)
     .filter(isDistinctItem)
     .map(stampViewerMembership);
+
+  pageMetadata.lastPage.forEach(seedViewerAnswerFromItem);
 
   return [...pageMetadata.lastPage];
 };
@@ -540,33 +590,32 @@ const useIsClubMember = (clubName: string) => {
   return useSyncExternalStore(subscribe, () => isClubMember(clubName));
 };
 
-// While the pile is collapsed the avatars overlap; spreading separates them
-// so each face can be seen and pressed. The margin is animated directly with
-// an explicit easing curve rather than via a layout transition, whose easing
-// isn't respected on web.
-const useFacepileSpreadStyle = (overlap: boolean, spread: boolean) => {
-  const progress = useSharedValue(spread ? 1 : 0);
+// Facepile geometry. Named because the width math in QuestionFacepiles
+// depends on these, so it can't silently disagree with the styles.
+const FACEPILE_AVATAR_SIZE = 28;
 
-  useEffect(() => {
-    progress.value = withTiming(spread ? 1 : 0, {
-      duration: 250,
-      easing: Easing.out(Easing.poly(4)),
-    });
-  }, [spread, progress]);
+// How far each avatar tucks behind its left neighbour while a pile is
+// collapsed
+const FACEPILE_OVERLAP = 8;
 
-  return useAnimatedStyle(() => ({
-    marginLeft: overlap ? interpolate(progress.value, [0, 1], [-8, 4]) : 0,
-  }), [overlap]);
-};
+// The gap left between neighbouring avatars once a pile spreads
+const FACEPILE_SPREAD_GAP = 4;
+
+// How far spreading moves each avatar relative to its neighbour
+const FACEPILE_SPREAD_STEP = FACEPILE_OVERLAP + FACEPILE_SPREAD_GAP;
+
+// The gap between an answer icon and its pile in a question facepile row
+const FACEPILE_GROUP_GAP = 8;
+
+// A question facepile row's horizontal padding, per side
+const FACEPILE_ROW_PADDING = 12;
 
 const FacepileAvatar = ({
   member,
-  overlap,
   spread,
   onRequestSpread,
 }: {
-  member: JoinedClubFields['club_sample_members'][number]
-  overlap: boolean
+  member: FacepileMember
   spread: boolean
   onRequestSpread: () => void
 }) => {
@@ -587,45 +636,40 @@ const FacepileAvatar = ({
     }
   }, [spread, navigateToProfile, onRequestSpread]);
 
-  const spreadStyle = useFacepileSpreadStyle(overlap, spread);
-
   return (
-    <Reanimated.View style={spreadStyle}>
-      <Pressable onPress={onPress} {...makeLinkProps(`/${handle}`)}>
-        <ImageBackground
-          source={{
-            uri: `${IMAGES_URL}/450-${member.photo_uuid}.jpg`,
-            height: 450,
-            width: 450,
-          }}
-          placeholder={{ blurhash: member.photo_blurhash }}
-          transition={150}
-          style={styles.facepileImage}
-          contentFit="cover"
-          recyclingKey={member.photo_uuid}
-        />
-      </Pressable>
-    </Reanimated.View>
+    <Pressable onPress={onPress} {...makeLinkProps(`/${handle}`)}>
+      <ImageBackground
+        source={{
+          uri: `${IMAGES_URL}/450-${member.photo_uuid}.jpg`,
+          height: 450,
+          width: 450,
+        }}
+        placeholder={{ blurhash: member.photo_blurhash }}
+        transition={150}
+        style={styles.facepileImage}
+        contentFit="cover"
+        recyclingKey={member.photo_uuid}
+      />
+    </Pressable>
   );
 };
 
-// The viewer's own avatar, at the end of the facepile. Always rendered, but
-// only visible while the viewer is a member of the club, fading in and out as
-// they join and leave. Animating visibility on an always-mounted view rather
-// than mounting and unmounting means joining can't be confused with anything
-// else that recreates the view (navigating away and back, list recycling,
-// refetches), which is what made `entering` animations here replay when they
-// shouldn't. Falls back to a placeholder if the viewer has no photo.
+// The viewer's own avatar. Always rendered, but only visible while the
+// viewer belongs in the pile (they're a club member; they publicly gave the
+// pile's answer), fading in and out as that changes. Animating visibility on
+// an always-mounted view rather than mounting and unmounting means joining
+// can't be confused with anything else that recreates the view (navigating
+// away and back, list recycling, refetches), which is what made `entering`
+// animations here replay when they shouldn't. Falls back to a placeholder if
+// the viewer has no photo.
 const ViewerFacepileAvatar = ({
   viewer,
   visible,
-  overlap,
   spread,
   onRequestSpread,
 }: {
-  viewer: JoinedClubFields['club_viewer']
+  viewer: FacepileViewer
   visible: boolean
-  overlap: boolean
   spread: boolean
   onRequestSpread: () => void
 }) => {
@@ -647,8 +691,6 @@ const ViewerFacepileAvatar = ({
     }
   }, [spread, navigateToProfile, onRequestSpread]);
 
-  const spreadStyle = useFacepileSpreadStyle(overlap, spread);
-
   const opacity = useSharedValue(visible ? 1 : 0);
 
   useEffect(() => {
@@ -666,7 +708,6 @@ const ViewerFacepileAvatar = ({
     <Reanimated.View
       style={[
         styles.facepileImage,
-        spreadStyle,
         fadeStyle,
         {
           backgroundColor: appTheme.avatarBackgroundColor,
@@ -705,65 +746,172 @@ const ViewerFacepileAvatar = ({
   );
 };
 
+// A facepile avatar's animated position. Translated rather than
+// margin-animated so that spreading a pile can't reflow the layout around it
+const FacepileSlot = ({
+  overlap,
+  offsetX,
+  zIndex,
+  children,
+}: {
+  overlap: boolean
+  offsetX: number
+  zIndex?: number
+  children: React.ReactNode
+}) => {
+  const offset = useSharedValue(offsetX);
+
+  useEffect(() => {
+    offset.value = withTiming(offsetX, {
+      duration: 250,
+      easing: Easing.out(Easing.poly(4)),
+    });
+  }, [offsetX, offset]);
+
+  const offsetStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: offset.value }],
+  }));
+
+  return (
+    <Reanimated.View
+      style={[
+        offsetStyle,
+        { marginLeft: overlap ? -FACEPILE_OVERLAP : 0, zIndex },
+      ]}
+    >
+      {children}
+    </Reanimated.View>
+  );
+};
+
+// While the pile is collapsed the avatars overlap, which makes them hard to
+// make out and to press, so the pile spreads on hover (desktop) or on a first
+// press (mobile) before individual avatars navigate anywhere. The avatar
+// beside `viewerPosition` is the anchor: the pile spreads away from it, so a
+// pile can sit against that edge of its container.
+const Facepile = ({
+  members,
+  viewer,
+  viewerVisible,
+  viewerPosition,
+  spread,
+  onRequestSpread,
+  onRequestCollapse,
+}: {
+  members: FacepileMember[]
+  viewer: FacepileViewer
+  viewerVisible: boolean
+  viewerPosition: 'start' | 'end'
+  spread: boolean
+  onRequestSpread: () => void
+  onRequestCollapse: () => void
+}) => {
+  const spreadDirection = viewerPosition === 'start' ? -1 : 1;
+
+  const anchorDistanceOf = (documentOrder: number) =>
+    viewerPosition === 'start'
+      ? members.length - documentOrder
+      : documentOrder;
+
+  const offsetOf = (documentOrder: number) =>
+    spreadDirection
+      * anchorDistanceOf(documentOrder)
+      * (spread ? FACEPILE_SPREAD_STEP : 0);
+
+  const zIndexOf = (documentOrder: number) =>
+    viewerPosition === 'start'
+      ? members.length + 1 - documentOrder
+      : undefined;
+
+  const viewerAvatar = (documentOrder: number) => (
+    <FacepileSlot
+      overlap={documentOrder > 0}
+      offsetX={offsetOf(documentOrder)}
+      zIndex={zIndexOf(documentOrder)}
+    >
+      <ViewerFacepileAvatar
+        viewer={viewer}
+        visible={viewerVisible}
+        spread={spread}
+        onRequestSpread={onRequestSpread}
+      />
+    </FacepileSlot>
+  );
+
+  return (
+    <Pressable
+      style={{ flexDirection: 'row' }}
+      onPress={onRequestSpread}
+      // Raw DOM events rather than onHoverIn/onHoverOut: Pressable's
+      // hover uses contain semantics, so hovering the nested avatar
+      // Pressables would end the container's hover and re-collapse the
+      // pile. mouseenter/mouseleave don't refire on child transitions.
+      //
+      // Desktop-only: mobile web browsers emulate mouseenter on tap,
+      // which would spread the pile an instant before the press lands
+      // and turn the first press into a profile navigation.
+      {...(isMobile() ? {} : {
+        /* @ts-ignore */
+        onMouseEnter: onRequestSpread,
+        onMouseLeave: onRequestCollapse,
+      })}
+    >
+      {viewerPosition === 'start' && viewerAvatar(0)}
+      {members.map((member, i) => {
+        const documentOrder = viewerPosition === 'start' ? i + 1 : i;
+
+        return (
+          <FacepileSlot
+            key={member.person_uuid}
+            overlap={documentOrder > 0}
+            offsetX={offsetOf(documentOrder)}
+            zIndex={zIndexOf(documentOrder)}
+          >
+            <FacepileAvatar
+              member={member}
+              spread={spread}
+              onRequestSpread={onRequestSpread}
+            />
+          </FacepileSlot>
+        );
+      })}
+      {viewerPosition === 'end' && viewerAvatar(members.length)}
+    </Pressable>
+  );
+};
+
 const ClubFacepile = ({
   sampleMembers,
   countMembers,
   viewer,
   viewerIsMember,
 }: {
-  sampleMembers: JoinedClubFields['club_sample_members']
+  sampleMembers: FacepileMember[]
   countMembers: number
-  viewer: JoinedClubFields['club_viewer']
+  viewer: FacepileViewer
   viewerIsMember: boolean
 }) => {
   const { appTheme } = useAppTheme();
 
-  // Overlapped avatars are hard to make out and to press, so the pile spreads
-  // on hover (desktop) or on a first press (mobile) before individual avatars
-  // navigate anywhere
   const [spread, setSpread] = useState(false);
 
-  const onRequestSpread = useCallback(() => setSpread(true), []);
+  const onRequestSpread   = useCallback(() => setSpread(true),  []);
+  const onRequestCollapse = useCallback(() => setSpread(false), []);
 
   return (
     // On mobile the count goes on its own line: were it beside the pile,
-    // spreading the pile could wrap the text and change the card's height
+    // a spread pile would slide over the text
     <View style={styles.facepileColumn}>
       {(sampleMembers.length > 0 || viewerIsMember) &&
-        <Pressable
-          style={{ flexDirection: 'row' }}
-          onPress={onRequestSpread}
-          // Raw DOM events rather than onHoverIn/onHoverOut: Pressable's
-          // hover uses contain semantics, so hovering the nested avatar
-          // Pressables would end the container's hover and re-collapse the
-          // pile. mouseenter/mouseleave don't refire on child transitions.
-          //
-          // Desktop-only: mobile web browsers emulate mouseenter on tap,
-          // which would spread the pile an instant before the press lands
-          // and turn the first press into a profile navigation.
-          {...(isMobile() ? {} : {
-            /* @ts-ignore */
-            onMouseEnter: onRequestSpread,
-            onMouseLeave: () => setSpread(false),
-          })}
-        >
-          {sampleMembers.map((member, i) =>
-            <FacepileAvatar
-              key={member.person_uuid}
-              member={member}
-              overlap={i > 0}
-              spread={spread}
-              onRequestSpread={onRequestSpread}
-            />
-          )}
-          <ViewerFacepileAvatar
-            viewer={viewer}
-            visible={viewerIsMember}
-            overlap={sampleMembers.length > 0}
-            spread={spread}
-            onRequestSpread={onRequestSpread}
-          />
-        </Pressable>
+        <Facepile
+          members={sampleMembers}
+          viewer={viewer}
+          viewerVisible={viewerIsMember}
+          viewerPosition="end"
+          spread={spread}
+          onRequestSpread={onRequestSpread}
+          onRequestCollapse={onRequestCollapse}
+        />
       }
       <DefaultText style={{ color: appTheme.hintColor }}>
         {countMembers.toLocaleString()}
@@ -863,6 +1011,248 @@ const FeedItemJoinedClub = ({ fields }: { fields: JoinedClubFields }) => {
         </View>
       </Animated.View>
     </Pressable>
+  );
+};
+
+const QuestionFacepiles = ({
+  fields,
+  viewerAnswer,
+  onPressNo,
+  onPressYes,
+}: {
+  fields: AnsweredQuestionFields
+  viewerAnswer: ViewerAnswer
+  onPressNo: () => void
+  onPressYes: () => void
+}) => {
+  const { appTheme } = useAppTheme();
+
+  const [spread, setSpread] = useState<'yes' | 'no' | null>(null);
+
+  const onRequestSpreadNo  = useCallback(() => setSpread('no'),  []);
+  const onRequestSpreadYes = useCallback(() => setSpread('yes'), []);
+  const onRequestCollapse  = useCallback(() => setSpread(null),  []);
+
+  const [rowInnerWidth, setRowInnerWidth] = useState<number | null>(null);
+
+  const onLayoutRow = useCallback((e: LayoutChangeEvent) => {
+    // On web, navigating to another tab hides this one via `display: none`,
+    // which fires a zero-width layout. Adopting it would drop facepile members
+    // and replay their entering animations upon returning to this tab.
+    if (e.nativeEvent.layout.width === 0) {
+      return;
+    }
+
+    setRowInnerWidth(
+      e.nativeEvent.layout.width - 2 * FACEPILE_ROW_PADDING);
+  }, []);
+
+  // Per side: answer icon + gap + viewer slot + the visible sliver of each
+  // overlapped member; the middle must absorb a spread's step per member,
+  // plus breathing room so the piles never read as one
+  const fitsMembers = (n: number) =>
+    rowInnerWidth !== null
+    && rowInnerWidth >=
+      2 * (ANSWER_ICON_SIZE + FACEPILE_GROUP_GAP + FACEPILE_AVATAR_SIZE)
+      + (2 * (FACEPILE_AVATAR_SIZE - FACEPILE_OVERLAP) + FACEPILE_SPREAD_STEP)
+        * n
+      + 16;
+
+  const maxMembers =
+    rowInnerWidth === null ? (isMobile() ? 3 : 5) :
+    fitsMembers(5) ? 5 :
+    fitsMembers(4) ? 4 :
+    3;
+
+  // The counts include private answers, so publicness is ignored here,
+  // unlike in the viewer's pile membership
+  const adjustedCount = (countAtFetch: number, answer: boolean) =>
+    Math.max(0, countAtFetch
+      + (viewerAnswer.answer === answer ? 1 : 0)
+      - (fields.question_viewer.answer === answer ? 1 : 0));
+
+  const countYes = adjustedCount(fields.question_count_yes, true);
+  const countNo = adjustedCount(fields.question_count_no, false);
+
+  // "No" on the left and "yes" on the right, matching the quiz screen's
+  // swipe directions
+  return (
+    <View style={styles.questionFacepileRow} onLayout={onLayoutRow}>
+      <View
+        style={[
+          styles.questionFacepileGroup,
+          spread === 'no' && styles.spreadFacepileGroup,
+        ]}
+      >
+        <AnswerIcon
+          answer="no"
+          selected={viewerAnswer.answer === false}
+          enabled={true}
+          onPress={onPressNo}
+        />
+        <View style={styles.questionFacepileColumn}>
+          <Facepile
+            members={fields.question_no_members.slice(0, maxMembers)}
+            viewer={fields.question_viewer}
+            viewerVisible={
+              viewerAnswer.answer === false && viewerAnswer.public_}
+            viewerPosition="end"
+            spread={spread === 'no'}
+            onRequestSpread={onRequestSpreadNo}
+            onRequestCollapse={onRequestCollapse}
+          />
+          <DefaultText style={{ color: appTheme.hintColor }}>
+             No • {formatCount(countNo)}
+          </DefaultText>
+        </View>
+      </View>
+      <View
+        style={[
+          styles.questionFacepileGroup,
+          spread === 'yes' && styles.spreadFacepileGroup,
+        ]}
+      >
+        <View
+          style={[styles.questionFacepileColumn, { alignItems: 'flex-end' }]}
+        >
+          <Facepile
+            members={fields.question_yes_members.slice(0, maxMembers)}
+            viewer={fields.question_viewer}
+            viewerVisible={
+              viewerAnswer.answer === true && viewerAnswer.public_}
+            viewerPosition="start"
+            spread={spread === 'yes'}
+            onRequestSpread={onRequestSpreadYes}
+            onRequestCollapse={onRequestCollapse}
+          />
+          <DefaultText style={{ color: appTheme.hintColor }}>
+            {formatCount(countYes)} • Yes
+          </DefaultText>
+        </View>
+        <AnswerIcon
+          answer="yes"
+          selected={viewerAnswer.answer === true}
+          enabled={true}
+          onPress={onPressYes}
+        />
+      </View>
+    </View>
+  );
+};
+
+const FeedItemAnsweredQuestion = ({
+  fields
+}: {
+  fields: AnsweredQuestionFields
+}) => {
+  const { appTheme } = useAppTheme();
+
+  const onPress = useNavigationToProfile(
+    fields.person_uuid,
+    fields.photo_blurhash,
+  );
+
+  const { backgroundColor, onPressIn, onPressOut } = usePressableAnimation();
+
+  const viewerAnswer = useViewerAnswer(fields.answered_question_id);
+
+  const onPressYes = useCallback(
+    () => toggleAnswer(fields.answered_question_id, true),
+    [fields.answered_question_id],
+  );
+
+  const onPressNo = useCallback(
+    () => toggleAnswer(fields.answered_question_id, false),
+    [fields.answered_question_id],
+  );
+
+  const onChangeAnswerPublicly = useCallback(
+    (public_: boolean) => setAnswerPublicly(
+      fields.answered_question_id, public_),
+    [fields.answered_question_id],
+  );
+
+  const props = isMobile() ? {
+    onPress,
+    onPressIn,
+    onPressOut,
+  } : {
+    disabled: true,
+  };
+
+  const extraChildren = (
+    <QuestionFacepiles
+      // Keying by the card's identity resets the spread state when the
+      // native list recycles this component instance for another item
+      key={`${fields.person_uuid}:${fields.answered_question_id}`}
+      fields={fields}
+      viewerAnswer={viewerAnswer}
+      onPressNo={onPressNo}
+      onPressYes={onPressYes}
+    />
+  );
+
+  return (
+    <View style={styles.pressableStyle}>
+      <Animated.View
+        style={[
+          styles.answeredQuestionCardBorders,
+          appTheme.card,
+          { backgroundColor },
+        ]}
+      >
+        {/* Only this row navigates to the profile: a card-wide Pressable
+            would swallow presses on the checkbox, whose gesture handler
+            doesn't take part in the responder negotiation */}
+        <Pressable style={styles.answeredQuestionHeader} {...props}>
+          {fields.photo_uuid &&
+            <Avatar
+              percentage={fields.match_percentage}
+              personUuid={fields.person_uuid}
+              urlSlug={fields.url_slug}
+              photoUuid={fields.photo_uuid}
+              photoBlurhash={fields.photo_blurhash}
+              doUseOnline={!!fields.photo_uuid}
+            />
+          }
+          <View style={{ flex: 1, gap: NAME_ACTION_TIME_GAP_VERTICAL }}>
+            <AgeGenderLocation
+              personUuid={fields.person_uuid}
+              urlSlug={fields.url_slug}
+              photoBlurhash={fields.photo_blurhash}
+              name={fields.name}
+              isVerified={fields.is_verified}
+              age={fields.age}
+              gender={fields.gender}
+              userLocation={fields.location}
+              doUseOnline={!fields.photo_uuid}
+            />
+            <ActionTime action="Played Q&A" time={new Date(fields.time)} />
+          </View>
+        </Pressable>
+        <NonInteractiveQuizCard
+          questionNumber={fields.answered_question_id}
+          topic={fields.question_topic}
+          answerPubliclyValue={viewerAnswer.public_}
+          onChangeAnswerPublicly={onChangeAnswerPublicly}
+          containerStyle={{
+            height: undefined,
+            width: undefined,
+            paddingLeft: 0,
+            paddingRight: 0,
+          }}
+          innerStyle={{
+            flexGrow: undefined,
+            height: undefined,
+            width: '100%',
+          }}
+          maxFontSize={18}
+          extraChildren={extraChildren}
+        >
+          {fields.question_text}
+        </NonInteractiveQuizCard>
+      </Animated.View>
+    </View>
   );
 };
 
@@ -1139,6 +1529,8 @@ const FeedItem = ({ dataItem }: { dataItem: DataItem }) => {
       return <FeedItemJoined fields={dataItem} />;
     case 'joined-club':
       return <FeedItemJoinedClub fields={dataItem} />;
+    case 'answered-question':
+      return <FeedItemAnsweredQuestion fields={dataItem} />;
     case 'recently-online-with-bio':
     case 'recently-online-with-photo':
     case 'recently-online-with-voice-bio':
@@ -1245,9 +1637,44 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     gap: 8,
   },
+  answeredQuestionCardBorders: {
+    ...commonStyles.cardBorders,
+    flexDirection: 'column',
+    gap: 10,
+    padding: 10,
+  },
+  answeredQuestionHeader: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  questionFacepileRow: {
+    width: '100%',
+    maxWidth: 440,
+    alignSelf: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    rowGap: 8,
+    paddingBottom: 20,
+    paddingLeft: FACEPILE_ROW_PADDING,
+    paddingRight: FACEPILE_ROW_PADDING,
+  },
+  questionFacepileColumn: {
+    alignItems: 'flex-start',
+    gap: 4,
+  },
+  questionFacepileGroup: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: FACEPILE_GROUP_GAP,
+  },
+  spreadFacepileGroup: {
+    zIndex: 1,
+  },
   facepileImage: {
-    height: 28,
-    width: 28,
+    height: FACEPILE_AVATAR_SIZE,
+    width: FACEPILE_AVATAR_SIZE,
     borderRadius: 999,
     overflow: 'hidden',
     alignItems: 'center',

--- a/frontend/components/in-depth-screen.tsx
+++ b/frontend/components/in-depth-screen.tsx
@@ -8,6 +8,7 @@ import {
   useLayoutEffect,
   useState,
 } from 'react';
+import { seedViewerAnswer, useViewerAnswer } from '../api/answer';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TopNavBar } from './top-nav-bar';
 import { DefaultText } from './default-text';
@@ -21,7 +22,6 @@ import { FloatingBackButton } from './prospect-profile-screen/prospect-profile-s
 import type { ProspectNavigationRef } from './prospect-profile-screen/prospect-profile-screen';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { ProspectParamList } from '../navigation/linking';
-import { CardState } from './quiz-card';
 import { useSignedInUser } from '../events/signed-in-user';
 import { getProspectHint, setProspectHint } from '../navigation/prospect-cache';
 
@@ -218,6 +218,15 @@ const fetchAnswersPage = (
 
   const responseList = response.ok ? response.json : [];
 
+  // The store is the live source of truth for the viewer's own answers; the
+  // fetched `person_answer`/`person_public_` only seed it
+  for (const item of responseList) {
+    seedViewerAnswer(item.question_id, {
+      answer: item.person_answer,
+      public_: item.person_public_ ?? true,
+    });
+  }
+
   return responseList.map((item) => ({
     kind: 'answer',
     item: item,
@@ -248,36 +257,34 @@ const InDepthScreen = (navigationRef: ProspectNavigationRef) => {
   />;
 }
 
-const InDepthItem = ({personId, item}: {personId: number, item: InDepthListItem}) => {
+const InDepthAnswer = ({personId, item}: {personId: number, item: CompareAnswer}) => {
   const [signedInUser] = useSignedInUser();
   const isViewingSelf = personId === signedInUser?.personId;
 
-  const [, triggerRender] = useState({});
+  const viewerAnswer = useViewerAnswer(item.question_id);
 
-  const onStateChange = (state: CardState) => {
-    if (item.kind !== 'answer') return;
-    item.item.person_public_ = state.public_;
-    item.item.person_answer = state.answer;
-    if (isViewingSelf) {
-      item.item.prospect_answer = state.answer;
-      triggerRender({});
-    }
-  };
+  // When viewing yourself, you're the prospect too, so the prospect column
+  // has to track your live answer
+  const prospectAnswer =
+    isViewingSelf ? viewerAnswer.answer : item.prospect_answer;
 
+  return (
+    <AnsweredQuizCard
+      questionNumber={item.question_id}
+      topic={item.topic}
+      user1={item.prospect_name}
+      answer1={prospectAnswer}
+      user2="You"
+    >
+      {item.question}
+    </AnsweredQuizCard>
+  );
+};
+
+const InDepthItem = ({personId, item}: {personId: number, item: InDepthListItem}) => {
   switch (item.kind) {
     case 'answer':
-      return <AnsweredQuizCard
-          questionNumber={item.item.question_id}
-          topic={item.item.topic}
-          user1={item.item.prospect_name}
-          answer1={item.item.prospect_answer}
-          user2="You"
-          answer2={item.item.person_answer}
-          answer2Publicly={item.item.person_public_ ?? true}
-          onStateChange={onStateChange}
-        >
-          {item.item.question}
-        </AnsweredQuizCard>;
+      return <InDepthAnswer personId={personId} item={item.item} />;
     case 'mbti':
     case 'big5':
     case 'politics':

--- a/frontend/components/quiz-card-stack.tsx
+++ b/frontend/components/quiz-card-stack.tsx
@@ -27,7 +27,7 @@ import { DonutChart } from './donut-chart';
 import { DefaultText } from './default-text';
 import { LinearGradient } from 'expo-linear-gradient';
 import { api, japi } from '../api/api';
-import { cardQueue, quizQueue } from '../api/queue';
+import { cardQueue, prospectUpdateQueue } from '../api/queue';
 import * as _ from "lodash";
 import { useSkipped } from '../hide-and-block/hide-and-block';
 import { useAppTheme } from '../app-theme/app-theme';
@@ -39,8 +39,7 @@ import {
   anonymousAnswers,
   removeAnonymousAnswer,
 } from '../events/anonymous-answers';
-import { markSearchResultsStale } from '../events/stale-search-results';
-import { markInboxStale } from '../events/stale-inbox';
+import { saveAnswer, deleteAnswer } from '../api/answer';
 
 // How many questions an unauthenticated web user may answer before we ask them
 // to sign up.
@@ -430,18 +429,6 @@ const removeNextProspectInPlace = async (
   });
 };
 
-const deleteAnswer = async (
-  questionNumber: number,
-  isPublic: boolean,
-) => {
-  if (!isPublic) {
-    await japi('delete', '/answer', { question_id: questionNumber });
-  }
-
-  markSearchResultsStale();
-  markInboxStale();
-};
-
 const removePreviousAnswerInPlace = async (
   card: CardState,
   swipeDirection: Direction | undefined,
@@ -453,7 +440,9 @@ const removePreviousAnswerInPlace = async (
     return;
   }
 
-  await deleteAnswer(card.questionNumber, isPublic);
+  if (!isPublic) {
+    await deleteAnswer(card.questionNumber);
+  }
 
   if (swipeDirection === 'left' || swipeDirection === 'right') {
     removeNextProspectInPlace(state, triggerRender);
@@ -468,24 +457,6 @@ const directionToAnswer = (
   if (direction === 'down') return null;
 };
 
-const saveAnswer = async (
-  questionNumber: number,
-  answer: boolean | null | undefined,
-  answerPublicly: boolean,
-  isPublic: boolean,
-) => {
-  if (!isPublic) {
-    await japi('post', '/answer', {
-      question_id: questionNumber,
-      answer: answer,
-      public: answerPublicly,
-    });
-  }
-
-  markSearchResultsStale();
-  markInboxStale();
-};
-
 const addAnswerInPlace = async (
   direction: Direction,
   swipedCard: CardState,
@@ -493,12 +464,11 @@ const addAnswerInPlace = async (
   state: StackState,
   triggerRender: () => void,
 ) => {
-  if (swipedCard.questionNumber !== undefined) {
+  if (swipedCard.questionNumber !== undefined && !isPublic) {
     await saveAnswer(
       swipedCard.questionNumber,
       directionToAnswer(direction),
       swipedCard.answerPublicly,
-      isPublic,
     );
   }
 
@@ -875,7 +845,7 @@ const QuizCardStack = (props: {
         removeAnonymousAnswer(previouslySwipedCard.questionNumber);
       }
 
-      quizQueue.addTask(() => removePreviousAnswerInPlace(
+      prospectUpdateQueue.addTask(() => removePreviousAnswerInPlace(
         previouslySwipedCard,
         previousSwipeDirection,
         isPublic,
@@ -932,7 +902,7 @@ const QuizCardStack = (props: {
       });
     }
 
-    quizQueue.addTask(() => addAnswerInPlace(
+    prospectUpdateQueue.addTask(() => addAnswerInPlace(
       direction,
       swipedCard,
       isPublic,

--- a/frontend/components/quiz-card.tsx
+++ b/frontend/components/quiz-card.tsx
@@ -13,7 +13,6 @@ import {
   createElement,
   memo,
   useCallback,
-  useLayoutEffect,
   useState,
 } from 'react';
 import { StatelessCheckBox } from './check-box';
@@ -23,7 +22,12 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { X, Check, FastForward } from "react-native-feather";
 import { Skeleton } from './skeleton';
 import { japi } from '../api/api';
-import { quizQueue } from '../api/queue';
+import {
+  nextAnswer,
+  setAnswerPublicly,
+  toggleAnswer,
+  useViewerAnswer,
+} from '../api/answer';
 import { IndeterminateProgressBar } from './indeterminate-progress-bar';
 import { Logo14 } from './logo';
 import { useAppTheme } from '../app-theme/app-theme';
@@ -47,11 +51,6 @@ const cardPadding = {
   paddingTop: 5,
   paddingBottom: 10,
 };
-
-type CardState = {
-  answer: boolean | null,
-  public_: boolean,
-}
 
 type SearchFilterAnswerResponse = {
   error?: string
@@ -527,6 +526,10 @@ const NonInteractiveQuizCard = ({children, ...props}: {
   );
 };
 
+// Exported so layouts around AnswerIcons (like the feed's facepile row) can
+// size themselves against it
+const ANSWER_ICON_SIZE = 26;
+
 const AnswerIcon = ({
   answer,
   selected,
@@ -564,8 +567,8 @@ const AnswerIcon = ({
         borderWidth: 1,
         borderRadius: 999,
         overflow: 'visible',
-        width: 26,
-        height: 26,
+        width: ANSWER_ICON_SIZE,
+        height: ANSWER_ICON_SIZE,
       },
       onPress,
     },
@@ -621,20 +624,6 @@ const AnswerIconGroup = ({
   );
 };
 
-const nextAnswer = (curAnswer: boolean | null, pressedButton?: boolean) => {
-  if (pressedButton === undefined) {
-    if (curAnswer === true) return false;
-    if (curAnswer === false) return null;
-    return true;
-  } else {
-    if (curAnswer === pressedButton) {
-      return null;
-    } else {
-      return pressedButton;
-    }
-  }
-};
-
 const AnsweredQuizCard = ({
   children,
   questionNumber,
@@ -642,9 +631,6 @@ const AnsweredQuizCard = ({
   user1,
   answer1,
   user2,
-  answer2,
-  answer2Publicly,
-  onStateChange,
 }: {
   children: string,
   questionNumber: number
@@ -652,28 +638,18 @@ const AnsweredQuizCard = ({
   user1: string,
   answer1: boolean | null,
   user2: string,
-  answer2: boolean | null,
-  answer2Publicly: boolean,
-  onStateChange: (state: CardState) => void,
 }) => {
-  const [state, setState] = useState<CardState>({
-    answer: answer2,
-    public_: answer2Publicly
-  });
+  const viewerAnswer = useViewerAnswer(questionNumber);
 
-  useLayoutEffect(() => {
-    onStateChange(state);
-  }, [JSON.stringify(state)]);
-
-  const textColor = useCallback(() => {
-    if (state.answer === null)
+  const textColor = (() => {
+    if (viewerAnswer.answer === null)
       return '#666';
-    if (answer1 === state.answer) {
+    if (answer1 === viewerAnswer.answer) {
       return '#5a5';
     } else {
       return '#e57';
     }
-  }, [answer1, state.answer])();
+  })();
 
   const textStyle: StyleProp<TextStyle> = {
     fontWeight: '500',
@@ -681,51 +657,13 @@ const AnsweredQuizCard = ({
     maxWidth: 120,
   };
 
-  const onPressAnswerIconGroup = useCallback(async (pressedButton: boolean) => {
-    setState((state: CardState): CardState => {
-      const nextAnswer_ = nextAnswer(state.answer, pressedButton);
-
-      quizQueue.addTask(async () => {
-        await japi(
-          'post',
-          '/answer',
-          {
-            question_id: questionNumber,
-            answer: nextAnswer_,
-            public: state.public_,
-          }
-        );
-      });
-
-      const nextState = {
-        ...state,
-        answer: nextAnswer_,
-      };
-
-      return nextState;
-    });
-  }, [setState]);
+  const onPressAnswerIconGroup = useCallback((pressedButton: boolean) => {
+    toggleAnswer(questionNumber, pressedButton);
+  }, [questionNumber]);
 
   const onChangeAnswerPublicly = useCallback((public_: boolean) => {
-    setState((state: CardState): CardState => {
-      quizQueue.addTask(async () =>
-        japi(
-          'post',
-          '/answer',
-          {
-            question_id: questionNumber,
-            answer: state.answer,
-            public: public_,
-          }
-        )
-      );
-
-      return {
-        ...state,
-        public_: public_,
-      };
-    });
-  }, [setState]);
+    setAnswerPublicly(questionNumber, public_);
+  }, [questionNumber]);
 
   const extraChildren = (
     <View
@@ -766,7 +704,7 @@ const AnsweredQuizCard = ({
           {user2}:
         </DefaultText>
         <AnswerIconGroup
-          answer={state.answer}
+          answer={viewerAnswer.answer}
           enabled={true}
           onPress={onPressAnswerIconGroup}
         />
@@ -776,7 +714,7 @@ const AnsweredQuizCard = ({
 
   return (
     <NonInteractiveQuizCard
-      answerPubliclyValue={state.public_}
+      answerPubliclyValue={viewerAnswer.public_}
       onChangeAnswerPublicly={onChangeAnswerPublicly}
       questionNumber={questionNumber}
       topic={topic}
@@ -1027,9 +965,11 @@ const NoMoreCards = () => {
 };
 
 export {
+  ANSWER_ICON_SIZE,
+  AnswerIcon,
   AnsweredQuizCard,
-  CardState,
   NoMoreCards,
+  NonInteractiveQuizCard,
   QuizCard,
   SearchQuizCard,
   SkeletonQuizCard,

--- a/frontend/navigation/reset-client-state.tsx
+++ b/frontend/navigation/reset-client-state.tsx
@@ -3,6 +3,7 @@ import { resetProspectHints } from './prospect-cache';
 import { resetSearchFilterAnswers } from './search-filter-state';
 import { resetProfileInfo } from '../events/profile-info';
 import { resetSearchFilters } from '../events/search-filters';
+import { resetViewerAnswers } from '../api/answer';
 
 // Drop every piece of in-memory, user-scoped client state. Call this from
 // any path that signs the user out (explicit sign-out, account deletion,
@@ -22,4 +23,5 @@ export const resetUserScopedClientState = () => {
   resetOptionScreenPayloads();
   resetProfileInfo();
   resetSearchFilters();
+  resetViewerAnswers();
 };


### PR DESCRIPTION
- [x] Answering Q&A doesn't call `markSearchResultsStale`. There should be one function in the code to answer Q&A questions, otherwise this mistake will get made repeatedly.
- [x] On desktop web platforms, navigating away from the 'Feed' tab and then back to the feed tab causes the facepile's avatars to play the entering animation. Similar issues were encountered when while implementing the facepile on the `joined-a-club` cards in https://github.com/duolicious/duolicious/pull/1239, however that implementation is okay now. It might be worthwhile looking at that to understand how to make it work well for the new feed event in this PR.

---

Closes https://github.com/duolicious/duolicious/issues/1269
