### PR TITLE
Fix replying to your own messages on mobile web

### DIFF
--- a/frontend/components/conversation-screen/chat-message.tsx
+++ b/frontend/components/conversation-screen/chat-message.tsx
@@ -468,7 +468,11 @@ const ChatMessage = ({
       runOnJS(openReactionBar)()
     });
 
-  const gesture = Gesture.Exclusive(longPress, pan, tap);
+  // RNGH's web orchestrator never reports failure for a disabled handler, so
+  // a disabled longPress in the composition blocks pan and tap forever
+  const gesture = canReact
+    ? Gesture.Exclusive(longPress, pan, tap)
+    : Gesture.Exclusive(pan, tap);
 
   const gestureStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: translateX.value }],


### PR DESCRIPTION
Fixes #1299

## Cause

On mobile, replying works via the swipe (pan) gesture, composed as `Gesture.Exclusive(longPress, pan, tap)`. The `longPress` gesture (reaction bar) is disabled on your own messages since you can't react to them.

`react-native-gesture-handler`'s web orchestrator records a disabled handler when a pointer goes down on its view, but `onHandlerStateChange` early-returns for disabled handlers, so the handler never reports failure. Because `pan` is exclusive with `longPress`, it waits for that failure forever and never activates — the swipe animation and quote never happen. The native orchestrator handles disabled handlers correctly, which is why only mobile web was affected (desktop web replies via the hover button instead).

## Fix

Only include `longPress` in the `Exclusive` composition when it can actually be enabled (`canReact`). This also unblocks the tap-for-timestamp gesture on your own messages on mobile web, which was stuck for the same reason.

## Verification

Drove the app end-to-end with Playwright (iPhone emulation, real touch events) against the local backend, using two fresh test accounts, on both this branch and an unfixed build:

| Build | Swipe their message | Swipe own message |
|---|---|---|
| main (unfixed) | quote preview appears | **nothing happens** (bug) |
| this branch | quote preview appears | quote preview appears |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
