### PR TITLE
Make replying to profile cards possible via the feed

### DIFF
--- a/backend/answerspush/__init__.py
+++ b/backend/answerspush/__init__.py
@@ -1,0 +1,34 @@
+"""
+Publishes quiz-answer changes to the `answers-{username}` Redis channel, which
+chat connections join alongside the person's online-status channel. Callers
+must only publish publicly visible state (see `AnswerWriteResult` in `qanda`);
+nothing on this channel is access-controlled beyond the subscription checks in
+`service.api.chat.online`.
+"""
+import traceback
+from chatprotocol.outbound import AnswerUpdate, answer_to_wire, to_bus
+from redisclient import make_redis_client
+
+_redis = make_redis_client()
+
+
+def answers_channel(username: str) -> str:
+    return f'answers-{username}'
+
+
+async def publish_answer_update(
+    username: str,
+    question_id: int,
+    answer: bool | None,
+) -> None:
+    try:
+        await _redis.publish(
+            answers_channel(username),
+            to_bus(AnswerUpdate(
+                username=username,
+                question_id=question_id,
+                answer=answer_to_wire(answer),
+            )),
+        )
+    except Exception:
+        print(traceback.format_exc())

--- a/backend/chatprotocol/inbound.py
+++ b/backend/chatprotocol/inbound.py
@@ -203,6 +203,14 @@ def message_from_element(el: Element) -> Message | None:
 
     to_username = jid_to_username(el.get('to'))
 
+    raw_question_id = el.get('question_id')
+    question_id = (
+        int(raw_question_id)
+        if raw_question_id and raw_question_id.isdigit()
+        else None
+    )
+    question_id = question_id if question_id and question_id <= 0x7fff else None
+
     if not stanza_id:
         return None
     if not to_username:
@@ -225,6 +233,7 @@ def message_from_element(el: Element) -> Message | None:
                 stanza_id=stanza_id,
                 to_username=to_username,
                 body=body,
+                question_id=question_id,
             )
 
     return None

--- a/backend/chatprotocol/message/__init__.py
+++ b/backend/chatprotocol/message/__init__.py
@@ -22,6 +22,7 @@ class BaseMessage:
 @dataclass(frozen=True)
 class ChatMessage(BaseMessage):
     body: str
+    question_id: int | None = None
 
 
 @dataclass(frozen=True)

--- a/backend/chatprotocol/outbound.py
+++ b/backend/chatprotocol/outbound.py
@@ -68,6 +68,39 @@ def _jid(username: str) -> str:
     return f'{username}@{LSERVER}'
 
 
+def answer_to_wire(answer: bool | None) -> str | None:
+    if answer is None:
+        return None
+    return 'yes' if answer else 'no'
+
+
+def _question_card_attrs(
+    question_id: int | None,
+    question: str | None,
+    question_topic: str | None,
+    viewer_answer: str | None,
+    viewer_answer_public: bool | None,
+    partner_answer: str | None,
+) -> dict:
+    if question_id is None:
+        return {}
+    if question is None or question_topic is None:
+        return {}
+    attrs: dict = {
+        '@question_id': str(question_id),
+        '@question': question,
+        '@question_topic': question_topic,
+    }
+    if viewer_answer is not None:
+        attrs['@viewer_answer'] = viewer_answer
+    if viewer_answer_public is not None:
+        attrs['@viewer_answer_public'] = (
+            'true' if viewer_answer_public else 'false')
+    if partner_answer is not None:
+        attrs['@partner_answer'] = partner_answer
+    return attrs
+
+
 # --------------------------------------------------------------------------- #
 # Control stanzas                                                             #
 # --------------------------------------------------------------------------- #
@@ -136,6 +169,29 @@ class OnlineEvent(Outbound):
             '@uuid': self.username,
             '@status': self.status,
         }}
+
+
+@_register
+@dataclass(frozen=True)
+class AnswerUpdate(Outbound):
+    """
+    Pushed on the `answers-{username}` channel when a person's publicly
+    visible answer to a quiz question changes. `answer` is 'yes'/'no', or None
+    when the answer is no longer visible (deleted or made private) -- private
+    state never reaches the wire.
+    """
+    username: str
+    question_id: int
+    answer: str | None = None
+
+    def canonical(self) -> dict:
+        attrs: dict = {
+            '@uuid': self.username,
+            '@question_id': str(self.question_id),
+        }
+        if self.answer is not None:
+            attrs['@answer'] = self.answer
+        return {'duo_answer_update': attrs}
 
 
 @_register
@@ -247,6 +303,12 @@ class IncomingChat(Outbound):
     body: str
     audio_uuid: str | None = None
     mam_id: str | None = None
+    question_id: int | None = None
+    question: str | None = None
+    question_topic: str | None = None
+    viewer_answer: str | None = None
+    viewer_answer_public: bool | None = None
+    partner_answer: str | None = None
 
     def canonical(self) -> dict:
         message: dict = {
@@ -260,6 +322,14 @@ class IncomingChat(Outbound):
             message['@audio_uuid'] = self.audio_uuid
         if self.mam_id is not None:
             message['@mam_id'] = self.mam_id
+        message.update(_question_card_attrs(
+            question_id=self.question_id,
+            question=self.question,
+            question_topic=self.question_topic,
+            viewer_answer=self.viewer_answer,
+            viewer_answer_public=self.viewer_answer_public,
+            partner_answer=self.partner_answer,
+        ))
         message['body'] = self.body
         message['request'] = {'@xmlns': NS_RECEIPTS}
         return {'message': message}
@@ -358,6 +428,12 @@ class MamResult(Outbound):
     audio_uuid: str | None = None
     reaction: str | None = None
     reaction_from: str | None = None
+    question_id: int | None = None
+    question: str | None = None
+    question_topic: str | None = None
+    viewer_answer: str | None = None
+    viewer_answer_public: bool | None = None
+    partner_answer: str | None = None
 
     def canonical(self) -> dict:
         inner: dict = {
@@ -373,6 +449,14 @@ class MamResult(Outbound):
         if self.reaction is not None:
             inner['@reaction'] = self.reaction
             inner['@reaction_from'] = self.reaction_from
+        inner.update(_question_card_attrs(
+            question_id=self.question_id,
+            question=self.question,
+            question_topic=self.question_topic,
+            viewer_answer=self.viewer_answer,
+            viewer_answer_public=self.viewer_answer_public,
+            partner_answer=self.partner_answer,
+        ))
         inner['body'] = self.body
         inner['request'] = {'@xmlns': NS_RECEIPTS}
 

--- a/backend/chatprotocol/outbound.py
+++ b/backend/chatprotocol/outbound.py
@@ -174,12 +174,6 @@ class OnlineEvent(Outbound):
 @_register
 @dataclass(frozen=True)
 class AnswerUpdate(Outbound):
-    """
-    Pushed on the `answers-{username}` channel when a person's publicly
-    visible answer to a quiz question changes. `answer` is 'yes'/'no', or None
-    when the answer is no longer visible (deleted or made private) -- private
-    state never reaches the wire.
-    """
     username: str
     question_id: int
     answer: str | None = None

--- a/backend/init-api.sql
+++ b/backend/init-api.sql
@@ -1673,6 +1673,10 @@ CREATE TABLE IF NOT EXISTS mam_message(
   -- The stanza's XMPP `id` attribute.
   stanza_id TEXT NOT NULL,
   reaction TEXT,
+  -- The quiz question this message replies to. No FK: messages are inserted
+  -- in shared batches, and one bad reference would abort the whole batch. The
+  -- chat server validates ids before storing instead.
+  question_id SMALLINT,
   PRIMARY KEY(person_id, id)
 );
 

--- a/backend/init-api.sql
+++ b/backend/init-api.sql
@@ -1673,9 +1673,6 @@ CREATE TABLE IF NOT EXISTS mam_message(
   -- The stanza's XMPP `id` attribute.
   stanza_id TEXT NOT NULL,
   reaction TEXT,
-  -- The quiz question this message replies to. No FK: messages are inserted
-  -- in shared batches, and one bad reference would abort the whole batch. The
-  -- chat server validates ids before storing instead.
   question_id SMALLINT,
   PRIMARY KEY(person_id, id)
 );

--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -13,3 +13,6 @@ CREATE INDEX IF NOT EXISTS idx__answer__question_id_public_answer
 -- A strict prefix of idx__answer__question_id_public_answer, so it only adds
 -- write amplification on a hot table now
 DROP INDEX IF EXISTS idx__answer__question_id;
+
+ALTER TABLE mam_message
+    ADD COLUMN IF NOT EXISTS question_id SMALLINT;

--- a/backend/qanda/__init__.py
+++ b/backend/qanda/__init__.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from itertools import groupby
 import numpy
+from answerspush import publish_answer_update
 from batcher import Batcher
 from constants import ANSWERED_QUESTION_EVENT_REFRESH_SECONDS
 from database import Row, Tx, api_tx
@@ -21,7 +22,8 @@ WHERE
 
 Q_GET_ANSWER = """
 SELECT
-    answer
+    answer,
+    public_
 FROM
     answer
 WHERE
@@ -134,6 +136,17 @@ class AnswerEventJob:
     advertise: bool
 
 
+# `visible_answer` is what other users may now see: the answer when it's
+# public, else None. Publishing to the answers channel only when
+# `visible_answer_changed` means private edits can never leak -- an edit that
+# starts and ends hidden produces no event at all.
+@dataclass(frozen=True)
+class AnswerWriteResult:
+    event_job: AnswerEventJob
+    visible_answer: bool | None
+    visible_answer_changed: bool
+
+
 @dataclass(frozen=True)
 class YesNoCountJob:
     question_id: int
@@ -200,7 +213,7 @@ async def _set_answer(
     answer: bool | None,
     public: bool | None,
     delete: bool,
-) -> AnswerEventJob | None:
+) -> AnswerWriteResult | None:
     question_tx = await tx.execute(
         Q_QUESTION_SCORE_VECTORS,
         dict(question_ids=[question_id]),
@@ -258,12 +271,24 @@ async def _set_answer(
         count_answers=int(count),
     ))
 
-    # Returned rather than enqueued so callers only enqueue after their
-    # transaction commits; a rolled-back answer must not reach the feed
-    return AnswerEventJob(
-        person_id=person_id,
-        question_id=question_id,
-        advertise=not delete and answer is not None and bool(public),
+    is_visible = not delete and answer is not None and bool(public)
+    old_visible = (
+        old['answer']
+        if old is not None and old['answer'] is not None and old['public_']
+        else None)
+    new_visible = answer if is_visible else None
+
+    # Returned rather than enqueued/published so callers only act after their
+    # transaction commits; a rolled-back answer must not reach the feed or the
+    # answers channel
+    return AnswerWriteResult(
+        event_job=AnswerEventJob(
+            person_id=person_id,
+            question_id=question_id,
+            advertise=is_visible,
+        ),
+        visible_answer=new_visible,
+        visible_answer_changed=new_visible != old_visible,
     )
 
 async def post_answer(req: t.PostAnswer, s: t.SessionInfo) -> object | None:
@@ -271,7 +296,7 @@ async def post_answer(req: t.PostAnswer, s: t.SessionInfo) -> object | None:
         return '', 500
 
     async with api_tx() as tx:
-        event_job = await _set_answer(
+        result = await _set_answer(
             tx,
             s.person_id,
             req.question_id,
@@ -280,10 +305,17 @@ async def post_answer(req: t.PostAnswer, s: t.SessionInfo) -> object | None:
             delete=False,
         )
 
-    if event_job:
-        _answer_event_batcher.enqueue(event_job)
+    if result:
+        _answer_event_batcher.enqueue(result.event_job)
 
     _enqueue_yes_no_count(req.question_id, req.answer)
+
+    if result and result.visible_answer_changed and s.person_uuid:
+        await publish_answer_update(
+            username=s.person_uuid,
+            question_id=req.question_id,
+            answer=result.visible_answer,
+        )
 
     return None
 
@@ -292,7 +324,7 @@ async def delete_answer(req: t.DeleteAnswer, s: t.SessionInfo) -> object | None:
         return '', 500
 
     async with api_tx() as tx:
-        event_job = await _set_answer(
+        result = await _set_answer(
             tx,
             s.person_id,
             req.question_id,
@@ -301,8 +333,15 @@ async def delete_answer(req: t.DeleteAnswer, s: t.SessionInfo) -> object | None:
             delete=True,
         )
 
-    if event_job:
-        _answer_event_batcher.enqueue(event_job)
+    if result:
+        _answer_event_batcher.enqueue(result.event_job)
+
+    if result and result.visible_answer_changed and s.person_uuid:
+        await publish_answer_update(
+            username=s.person_uuid,
+            question_id=req.question_id,
+            answer=result.visible_answer,
+        )
 
     return None
 
@@ -326,8 +365,8 @@ async def _flush_session_answers(
     for answer in answers:
         _enqueue_yes_no_count(answer['question_id'], answer['answer'])
 
-        # The returned event job is deliberately dropped: answers stashed
-        # before signup shouldn't advertise in the feed
+        # The returned write result is deliberately dropped: answers stashed
+        # before signup shouldn't advertise in the feed or publish updates
         await _set_answer(
             tx,
             person_id,

--- a/backend/qanda/__init__.py
+++ b/backend/qanda/__init__.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from itertools import groupby
 import numpy
 import psycopg
 from answerspush import publish_answer_update
@@ -31,6 +30,14 @@ WHERE
     person_id = %(person_id)s AND
     question_id = %(question_id)s
 """
+
+# A person's quiz answer is only ever visible to *other* people while it's
+# public and actually answered. Every query that serves someone else's answer
+# -- chat question-cards on live delivery (`questioncard`) and MAM
+# (`Q_SELECT_MESSAGE`), and the feed's subject answer (`Q_FEED_V2`) --
+# interpolates this one predicate, so the privacy rule can't silently drift
+# between those paths. Assumes the answer table is aliased `answer`.
+ANSWER_VISIBLE_TO_OTHERS = "(answer.public_ AND answer.answer IS NOT NULL)"
 
 Q_UPSERT_ANSWER = """
 INSERT INTO answer (
@@ -128,22 +135,12 @@ WHERE session_token_hash = %(session_token_hash)s
 """
 
 
-# What a person's feed event should say after their latest answer write:
-# advertise the question, or stop advertising it
-@dataclass(frozen=True)
-class AnswerEventJob:
-    person_id: int
-    question_id: int
-    advertise: bool
-
-
 # `visible_answer` is what other users may now see: the answer when it's
 # public, else None. Publishing to the answers channel only when
 # `visible_answer_changed` means private edits can never leak -- an edit that
 # starts and ends hidden produces no event at all.
 @dataclass(frozen=True)
 class AnswerWriteResult:
-    event_job: AnswerEventJob
     visible_answer: bool | None
     visible_answer_changed: bool
 
@@ -153,30 +150,6 @@ class YesNoCountJob:
     question_id: int
     add_yes: int
     add_no: int
-
-
-async def _process_answer_event_batch(jobs: list[AnswerEventJob]) -> None:
-    # Grouped into runs of consecutive same-type jobs, one executemany per
-    # run. Runs execute in batch order, so a person who reverts one
-    # question's event and advertises another's within a batch gets the
-    # outcome of that sequence; a whole-batch set/revert split would not
-    # preserve it.
-    async with api_tx('read committed') as tx:
-        for advertise, run in groupby(jobs, key=lambda job: job.advertise):
-            if advertise:
-                await tx.executemany(Q_SET_ANSWERED_QUESTION_EVENT, [
-                    dict(
-                        person_id=job.person_id,
-                        question_id=job.question_id,
-                        refresh_seconds=ANSWERED_QUESTION_EVENT_REFRESH_SECONDS,
-                    )
-                    for job in run
-                ])
-            else:
-                await tx.executemany(Q_REVERT_ANSWERED_QUESTION_EVENT, [
-                    dict(person_id=job.person_id, question_id=job.question_id)
-                    for job in run
-                ])
 
 
 async def _process_yes_no_count_batch(jobs: list[YesNoCountJob]) -> None:
@@ -214,6 +187,7 @@ async def _set_answer(
     answer: bool | None,
     public: bool | None,
     delete: bool,
+    write_event: bool = True,
 ) -> AnswerWriteResult | None:
     question_tx = await tx.execute(
         Q_QUESTION_SCORE_VECTORS,
@@ -273,32 +247,49 @@ async def _set_answer(
     ))
 
     is_visible = not delete and answer is not None and bool(public)
+
+    # The feed event is written in this same transaction, so it commits (or
+    # rolls back) atomically with the answer and personality columns and
+    # nothing else contends for the person row. `write_event` is False for
+    # pre-signup answers, which must never advertise in the feed.
+    if write_event and is_visible:
+        await tx.execute(Q_SET_ANSWERED_QUESTION_EVENT, dict(
+            person_id=person_id,
+            question_id=question_id,
+            refresh_seconds=ANSWERED_QUESTION_EVENT_REFRESH_SECONDS,
+        ))
+    elif write_event:
+        await tx.execute(Q_REVERT_ANSWERED_QUESTION_EVENT, dict(
+            person_id=person_id,
+            question_id=question_id,
+        ))
+
     old_visible = (
         old['answer']
         if old is not None and old['answer'] is not None and old['public_']
         else None)
     new_visible = answer if is_visible else None
 
-    # Returned rather than enqueued/published so callers only act after their
-    # transaction commits; a rolled-back answer must not reach the feed or the
-    # answers channel
+    # The answers-channel publish is left to the caller so it happens only
+    # after this transaction commits: a rolled-back answer must not reach the
+    # channel.
     return AnswerWriteResult(
-        event_job=AnswerEventJob(
-            person_id=person_id,
-            question_id=question_id,
-            advertise=is_visible,
-        ),
         visible_answer=new_visible,
         visible_answer_changed=new_visible != old_visible,
     )
 
-# The answer-event batcher updates the answerer's person row (the feed event)
-# while `_set_answer`'s repeatable-read transaction updates the same row's
-# personality columns, so a flush landing mid-transaction aborts it with a
-# serialization failure. Retrying re-runs the whole read-modify-write on a
-# fresh snapshot, which is safe: nothing is enqueued or published until a
-# transaction commits.
+# `_set_answer` is the only writer of a person's row per answer now that the
+# feed event is written inside its transaction, so serialization failures are
+# no longer routine. The one remaining conflict is a person answering two
+# questions truly concurrently -- both read-modify-write their personality
+# columns, and repeatable-read must abort one to prevent a lost update. That's
+# rare, and retrying re-runs the read-modify-write on a fresh snapshot, which
+# is safe: nothing is published until the transaction commits.
 _SET_ANSWER_TRIES = 3
+_SET_ANSWER_RETRYABLE = (
+    psycopg.errors.SerializationFailure,
+    psycopg.errors.DeadlockDetected,
+)
 
 async def _set_answer_with_retry(
     person_id: int,
@@ -307,17 +298,16 @@ async def _set_answer_with_retry(
     public: bool | None,
     delete: bool,
 ) -> AnswerWriteResult | None:
-    for _ in range(_SET_ANSWER_TRIES - 1):
+    for attempt in range(_SET_ANSWER_TRIES):
         try:
             async with api_tx() as tx:
                 return await _set_answer(
                     tx, person_id, question_id, answer, public, delete)
-        except psycopg.errors.SerializationFailure:
-            continue
+        except _SET_ANSWER_RETRYABLE:
+            if attempt == _SET_ANSWER_TRIES - 1:
+                raise
 
-    async with api_tx() as tx:
-        return await _set_answer(
-            tx, person_id, question_id, answer, public, delete)
+    return None
 
 async def post_answer(req: t.PostAnswer, s: t.SessionInfo) -> object | None:
     if s.person_id is None:
@@ -330,9 +320,6 @@ async def post_answer(req: t.PostAnswer, s: t.SessionInfo) -> object | None:
         req.public,
         delete=False,
     )
-
-    if result:
-        _answer_event_batcher.enqueue(result.event_job)
 
     _enqueue_yes_no_count(req.question_id, req.answer)
 
@@ -356,9 +343,6 @@ async def delete_answer(req: t.DeleteAnswer, s: t.SessionInfo) -> object | None:
         None,
         delete=True,
     )
-
-    if result:
-        _answer_event_batcher.enqueue(result.event_job)
 
     if result and result.visible_answer_changed and s.person_uuid:
         await publish_answer_update(
@@ -389,8 +373,8 @@ async def _flush_session_answers(
     for answer in answers:
         _enqueue_yes_no_count(answer['question_id'], answer['answer'])
 
-        # The returned write result is deliberately dropped: answers stashed
-        # before signup shouldn't advertise in the feed or publish updates
+        # `write_event=False` and the dropped result: answers stashed before
+        # signup shouldn't advertise in the feed or publish updates.
         await _set_answer(
             tx,
             person_id,
@@ -398,6 +382,7 @@ async def _flush_session_answers(
             answer['answer'],
             answer.get('public', True),
             delete=False,
+            write_event=False,
         )
 
     await tx.execute(
@@ -406,18 +391,13 @@ async def _flush_session_answers(
     )
 
 
-# Every answer write lands on two hot rows -- the answerer's person row (the
-# feed event) and the question row (the yes/no counts) -- and quiz players
-# write in bursts. Batching moves those writes off the request path and
-# coalesces each batch into one write per person/question.
-_answer_event_batcher = Batcher[AnswerEventJob](
-    process_fn=_process_answer_event_batch,
-    flush_interval=1.0,
-    min_batch_size=1,
-    max_batch_size=1000,
-    retry=False,
-)
-
+# Every answer write bumps a globally hot row -- the question's yes/no counts
+# -- and quiz players write in bursts, so many users hammer the same question
+# row at once. Batching moves those writes off the request path and coalesces
+# each batch into one write per question. (The answerer's person row, by
+# contrast, is written inside `_set_answer`'s own transaction: it's per-person,
+# not globally hot, so it needs no batching and stays free of cross-transaction
+# contention.)
 _yes_no_count_batcher = Batcher[YesNoCountJob](
     process_fn=_process_yes_no_count_batch,
     flush_interval=1.0,

--- a/backend/qanda/__init__.py
+++ b/backend/qanda/__init__.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from itertools import groupby
 import numpy
+import psycopg
 from answerspush import publish_answer_update
 from batcher import Batcher
 from constants import ANSWERED_QUESTION_EVENT_REFRESH_SECONDS
@@ -291,19 +292,44 @@ async def _set_answer(
         visible_answer_changed=new_visible != old_visible,
     )
 
+# The answer-event batcher updates the answerer's person row (the feed event)
+# while `_set_answer`'s repeatable-read transaction updates the same row's
+# personality columns, so a flush landing mid-transaction aborts it with a
+# serialization failure. Retrying re-runs the whole read-modify-write on a
+# fresh snapshot, which is safe: nothing is enqueued or published until a
+# transaction commits.
+_SET_ANSWER_TRIES = 3
+
+async def _set_answer_with_retry(
+    person_id: int,
+    question_id: int,
+    answer: bool | None,
+    public: bool | None,
+    delete: bool,
+) -> AnswerWriteResult | None:
+    for _ in range(_SET_ANSWER_TRIES - 1):
+        try:
+            async with api_tx() as tx:
+                return await _set_answer(
+                    tx, person_id, question_id, answer, public, delete)
+        except psycopg.errors.SerializationFailure:
+            continue
+
+    async with api_tx() as tx:
+        return await _set_answer(
+            tx, person_id, question_id, answer, public, delete)
+
 async def post_answer(req: t.PostAnswer, s: t.SessionInfo) -> object | None:
     if s.person_id is None:
         return '', 500
 
-    async with api_tx() as tx:
-        result = await _set_answer(
-            tx,
-            s.person_id,
-            req.question_id,
-            req.answer,
-            req.public,
-            delete=False,
-        )
+    result = await _set_answer_with_retry(
+        s.person_id,
+        req.question_id,
+        req.answer,
+        req.public,
+        delete=False,
+    )
 
     if result:
         _answer_event_batcher.enqueue(result.event_job)
@@ -323,15 +349,13 @@ async def delete_answer(req: t.DeleteAnswer, s: t.SessionInfo) -> object | None:
     if s.person_id is None:
         return '', 500
 
-    async with api_tx() as tx:
-        result = await _set_answer(
-            tx,
-            s.person_id,
-            req.question_id,
-            None,
-            None,
-            delete=True,
-        )
+    result = await _set_answer_with_retry(
+        s.person_id,
+        req.question_id,
+        None,
+        None,
+        delete=True,
+    )
 
     if result:
         _answer_event_batcher.enqueue(result.event_job)

--- a/backend/qanda/__init__.py
+++ b/backend/qanda/__init__.py
@@ -1,3 +1,26 @@
+"""
+Reads and writes a person's quiz answers and the derived personality vectors,
+feed events, and yes/no tallies.
+
+`ANSWER_VISIBLE_TO_OTHERS` is the one predicate that decides whether someone
+else may see an answer (public and actually answered). The live question-card
+path (`questioncard`), the MAM fetch (`Q_SELECT_MESSAGE`), and the feed's
+subject answer (`Q_FEED_V2`) all interpolate it, so the rule can't drift
+between them; it assumes the `answer` table is aliased `answer`.
+
+`_set_answer` writes the answer, personality columns, and feed event in one
+transaction, so they commit or roll back together. The answers-channel publish
+is left to the caller, which fires it only after the transaction commits and
+only when the visible answer changed, so a rolled-back or private edit never
+reaches the wire. Two answers written truly concurrently can serialize on the
+personality columns; `_set_answer_with_retry` re-runs on a fresh snapshot,
+which is safe because nothing publishes before commit. `write_event` is False
+for pre-signup answers, which must never advertise or publish.
+
+Yes/no tallies are batched because every answer bumps the same globally hot
+question row; the answerer's own row isn't hot, so it stays in `_set_answer`'s
+transaction unbatched.
+"""
 from dataclasses import dataclass
 import numpy
 import psycopg
@@ -31,12 +54,6 @@ WHERE
     question_id = %(question_id)s
 """
 
-# A person's quiz answer is only ever visible to *other* people while it's
-# public and actually answered. Every query that serves someone else's answer
-# -- chat question-cards on live delivery (`questioncard`) and MAM
-# (`Q_SELECT_MESSAGE`), and the feed's subject answer (`Q_FEED_V2`) --
-# interpolates this one predicate, so the privacy rule can't silently drift
-# between those paths. Assumes the answer table is aliased `answer`.
 ANSWER_VISIBLE_TO_OTHERS = "(answer.public_ AND answer.answer IS NOT NULL)"
 
 Q_UPSERT_ANSWER = """
@@ -135,10 +152,6 @@ WHERE session_token_hash = %(session_token_hash)s
 """
 
 
-# `visible_answer` is what other users may now see: the answer when it's
-# public, else None. Publishing to the answers channel only when
-# `visible_answer_changed` means private edits can never leak -- an edit that
-# starts and ends hidden produces no event at all.
 @dataclass(frozen=True)
 class AnswerWriteResult:
     visible_answer: bool | None
@@ -248,10 +261,6 @@ async def _set_answer(
 
     is_visible = not delete and answer is not None and bool(public)
 
-    # The feed event is written in this same transaction, so it commits (or
-    # rolls back) atomically with the answer and personality columns and
-    # nothing else contends for the person row. `write_event` is False for
-    # pre-signup answers, which must never advertise in the feed.
     if write_event and is_visible:
         await tx.execute(Q_SET_ANSWERED_QUESTION_EVENT, dict(
             person_id=person_id,
@@ -270,21 +279,11 @@ async def _set_answer(
         else None)
     new_visible = answer if is_visible else None
 
-    # The answers-channel publish is left to the caller so it happens only
-    # after this transaction commits: a rolled-back answer must not reach the
-    # channel.
     return AnswerWriteResult(
         visible_answer=new_visible,
         visible_answer_changed=new_visible != old_visible,
     )
 
-# `_set_answer` is the only writer of a person's row per answer now that the
-# feed event is written inside its transaction, so serialization failures are
-# no longer routine. The one remaining conflict is a person answering two
-# questions truly concurrently -- both read-modify-write their personality
-# columns, and repeatable-read must abort one to prevent a lost update. That's
-# rare, and retrying re-runs the read-modify-write on a fresh snapshot, which
-# is safe: nothing is published until the transaction commits.
 _SET_ANSWER_TRIES = 3
 _SET_ANSWER_RETRYABLE = (
     psycopg.errors.SerializationFailure,
@@ -373,8 +372,6 @@ async def _flush_session_answers(
     for answer in answers:
         _enqueue_yes_no_count(answer['question_id'], answer['answer'])
 
-        # `write_event=False` and the dropped result: answers stashed before
-        # signup shouldn't advertise in the feed or publish updates.
         await _set_answer(
             tx,
             person_id,
@@ -391,13 +388,6 @@ async def _flush_session_answers(
     )
 
 
-# Every answer write bumps a globally hot row -- the question's yes/no counts
-# -- and quiz players write in bursts, so many users hammer the same question
-# row at once. Batching moves those writes off the request path and coalesces
-# each batch into one write per question. (The answerer's person row, by
-# contrast, is written inside `_set_answer`'s own transaction: it's per-person,
-# not globally hot, so it needs no batching and stays free of cross-transaction
-# contention.)
 _yes_no_count_batcher = Batcher[YesNoCountJob](
     process_fn=_process_yes_no_count_batch,
     flush_interval=1.0,

--- a/backend/search/sql/__init__.py
+++ b/backend/search/sql/__init__.py
@@ -1,5 +1,6 @@
 from constants import ONLINE_RECENTLY_SECONDS
 from commonsql import Q_COMPUTED_FLAIR
+from qanda import ANSWER_VISIBLE_TO_OTHERS
 
 # How many feed results to send to the client per request
 FEED_RESULTS_PER_PAGE = 50
@@ -2177,9 +2178,7 @@ LEFT JOIN LATERAL (
         AND
             answer.question_id = question.id
         AND
-            answer.public_
-        AND
-            answer.answer IS NOT NULL
+            {ANSWER_VISIBLE_TO_OTHERS}
     ) AS subject_answer
     ON TRUE
     LEFT JOIN LATERAL (

--- a/backend/search/sql/__init__.py
+++ b/backend/search/sql/__init__.py
@@ -2165,10 +2165,6 @@ LEFT JOIN LATERAL (
     ) AS viewer_answer
     ON TRUE
     LEFT JOIN LATERAL (
-        -- The feed subject's own answer, so replying can quote it. Filtered
-        -- by publicness even though the feed event only fires for public
-        -- answers: the event lingers until the batcher reverts it, so it can
-        -- briefly outlive the answer's visibility.
         SELECT
             answer.answer
         FROM

--- a/backend/search/sql/__init__.py
+++ b/backend/search/sql/__init__.py
@@ -2132,6 +2132,7 @@ LEFT JOIN LATERAL (
             'question_count_no', question.count_no,
             'question_yes_members', COALESCE(yes_facepile.j, '[]'::jsonb),
             'question_no_members', COALESCE(no_facepile.j, '[]'::jsonb),
+            'question_subject_answer', subject_answer.answer,
             'question_viewer', jsonb_build_object(
                 'person_uuid', searcher.searcher_uuid,
                 'url_slug', searcher.searcher_url_slug,
@@ -2161,6 +2162,25 @@ LEFT JOIN LATERAL (
         AND
             answer.question_id = question.id
     ) AS viewer_answer
+    ON TRUE
+    LEFT JOIN LATERAL (
+        -- The feed subject's own answer, so replying can quote it. Filtered
+        -- by publicness even though the feed event only fires for public
+        -- answers: the event lingers until the batcher reverts it, so it can
+        -- briefly outlive the answer's visibility.
+        SELECT
+            answer.answer
+        FROM
+            answer
+        WHERE
+            answer.person_id = feed_page.id
+        AND
+            answer.question_id = question.id
+        AND
+            answer.public_
+        AND
+            answer.answer IS NOT NULL
+    ) AS subject_answer
     ON TRUE
     LEFT JOIN LATERAL (
         {_question_facepile(True)}

--- a/backend/service/api/chat/__init__.py
+++ b/backend/service/api/chat/__init__.py
@@ -736,7 +736,10 @@ async def process_text(
         if isinstance(maybe_message, ChatMessage)
         else None)
 
-    if question_id is not None and await fetch_question(question_id) is None:
+    if \
+            isinstance(maybe_message, ChatMessage) and \
+            question_id is not None and \
+            await fetch_question(question_id) is None:
         maybe_message = dataclasses.replace(maybe_message, question_id=None)
         question_id = None
 

--- a/backend/service/api/chat/__init__.py
+++ b/backend/service/api/chat/__init__.py
@@ -736,10 +736,11 @@ async def process_text(
         if isinstance(maybe_message, ChatMessage)
         else None)
 
-    if \
-            isinstance(maybe_message, ChatMessage) and \
-            question_id is not None and \
-            await fetch_question(question_id) is None:
+    if (
+        isinstance(maybe_message, ChatMessage) and
+        question_id is not None and
+        await fetch_question(question_id) is None
+    ):
         maybe_message = dataclasses.replace(maybe_message, question_id=None)
         question_id = None
 

--- a/backend/service/api/chat/__init__.py
+++ b/backend/service/api/chat/__init__.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 from database import (
     api_tx,
@@ -100,8 +101,13 @@ from chatprotocol.outbound import (
     ReadReceipt,
     RegistrationSuccessful,
     ServerError,
+    answer_to_wire,
     from_bus,
     to_bus,
+)
+from service.api.chat.questioncard import (
+    fetch_card,
+    fetch_question,
 )
 from service.api.chat.audiomessage import (
     transcode_and_put,
@@ -723,6 +729,17 @@ async def process_text(
     if not to_id:
         return None
 
+    # A reference to a question that doesn't exist degrades to a plain text
+    # message; the body's blockquote fallback still reads fine.
+    question_id = (
+        maybe_message.question_id
+        if isinstance(maybe_message, ChatMessage)
+        else None)
+
+    if question_id is not None and await fetch_question(question_id) is None:
+        maybe_message = dataclasses.replace(maybe_message, question_id=None)
+        question_id = None
+
     # Shadow-banned senders perceive the app as normal -- validation runs as
     # usual and their own client/storage behave normally -- but nothing they
     # send reaches the recipient: no real-time delivery, push notification, or
@@ -812,6 +829,18 @@ async def process_text(
         sender_mam_id = encode_mam_id(sender_copy_id)
         recipient_mam_id = encode_mam_id(sibling_mam_id(sender_copy_id))
 
+        # Runs after the message batch commits, so the card reflects committed
+        # answer state. Viewer/partner are from the recipient's perspective:
+        # they're the one this stanza is delivered to.
+        card = (
+            await fetch_card(
+                question_id=question_id,
+                viewer_id=to_id,
+                partner_id=from_id,
+            )
+            if question_id is not None
+            else None)
+
         delivery_message = IncomingChat(
             from_username=from_username,
             to_username=to_username,
@@ -819,6 +848,12 @@ async def process_text(
             body=maybe_message.body,
             audio_uuid=audio_uuid,
             mam_id=recipient_mam_id,
+            question_id=question_id if card else None,
+            question=card.question if card else None,
+            question_topic=card.topic if card else None,
+            viewer_answer=answer_to_wire(card.viewer_answer) if card else None,
+            viewer_answer_public=card.viewer_answer_public if card else None,
+            partner_answer=answer_to_wire(card.partner_answer) if card else None,
         )
 
         immediate_data = await fetch_immediate_data(

--- a/backend/service/api/chat/__init__.py
+++ b/backend/service/api/chat/__init__.py
@@ -729,8 +729,6 @@ async def process_text(
     if not to_id:
         return None
 
-    # A reference to a question that doesn't exist degrades to a plain text
-    # message; the body's blockquote fallback still reads fine.
     question_id = (
         maybe_message.question_id
         if isinstance(maybe_message, ChatMessage)
@@ -833,9 +831,6 @@ async def process_text(
         sender_mam_id = encode_mam_id(sender_copy_id)
         recipient_mam_id = encode_mam_id(sibling_mam_id(sender_copy_id))
 
-        # Runs after the message batch commits, so the card reflects committed
-        # answer state. Viewer/partner are from the recipient's perspective:
-        # they're the one this stanza is delivered to.
         card = (
             await fetch_card(
                 question_id=question_id,

--- a/backend/service/api/chat/messagestorage/__init__.py
+++ b/backend/service/api/chat/messagestorage/__init__.py
@@ -52,6 +52,11 @@ def store_message(
                 if isinstance(message, AudioMessage)
                 else None
             ),
+            question_id=(
+                message.question_id
+                if isinstance(message, ChatMessage)
+                else None
+            ),
             deliver_to_recipient=deliver_to_recipient,
         ),
         upsert_conversation_job=UpsertConversationJob(

--- a/backend/service/api/chat/messagestorage/mam/__init__.py
+++ b/backend/service/api/chat/messagestorage/mam/__init__.py
@@ -1,3 +1,13 @@
+"""
+Reads and writes the message archive (MAM).
+
+`mam_message.question_id` has no foreign key on purpose: messages are inserted
+in shared batches, so one bad reference would abort the whole batch. The chat
+server validates question ids before storing instead. Card answers are joined
+fresh on every fetch, so a partner answer deleted or made private since the
+message was sent simply disappears; the viewer's own answer is unfiltered (it's
+theirs, and seeds the client's answer store).
+"""
 from dataclasses import dataclass
 from database import Tx, api_tx
 from qanda import ANSWER_VISIBLE_TO_OTHERS
@@ -66,10 +76,6 @@ WHERE
 
 
 Q_SELECT_MESSAGE = f"""
--- The card answers are joined fresh on every fetch, so a partner answer that
--- was deleted or made private since the message was sent disappears without
--- any bookkeeping. The viewer's own answer is deliberately unfiltered: it's
--- their own state and seeds the client's answer store.
 WITH page AS (
     SELECT
         mam_message.id,
@@ -79,8 +85,6 @@ WITH page AS (
         mam_message.audio_uuid,
         mam_message.reaction,
         mam_message.question_id,
-        -- The viewer owns every row on this page (the CTE filters on it), so
-        -- their person id is free here -- no per-row person lookup needed.
         mam_message.person_id AS viewer_id
     FROM
         mam_message
@@ -100,7 +104,6 @@ WITH page AS (
     LIMIT
         LEAST(50, COALESCE(%(max)s, 50))
 ),
--- Resolved once for the whole page rather than re-joining person per row.
 partner AS (
     SELECT
         id AS partner_id

--- a/backend/service/api/chat/messagestorage/mam/__init__.py
+++ b/backend/service/api/chat/messagestorage/mam/__init__.py
@@ -120,7 +120,7 @@ LEFT JOIN LATERAL (
     ON
         person.id = answer.person_id
     WHERE
-        person.uuid = uuid_or_null(%(from_username)s)
+        person.uuid = %(from_username)s
     AND
         answer.question_id = page.question_id
 ) AS viewer_answer

--- a/backend/service/api/chat/messagestorage/mam/__init__.py
+++ b/backend/service/api/chat/messagestorage/mam/__init__.py
@@ -16,6 +16,7 @@ from chatprotocol.outbound import (
     MamResult,
     Outbound,
     ReadReceipt,
+    answer_to_wire,
 )
 import uuid
 
@@ -30,6 +31,7 @@ INSERT INTO
         audio_uuid,
         body,
         stanza_id,
+        question_id,
         person_id
     )
 -- The sender's archive copy (direction 'O') is always stored. The recipient's
@@ -44,6 +46,7 @@ SELECT
     %(audio_uuid)s,
     %(body)s,
     %(stanza_id)s,
+    %(question_id)s::SMALLINT,
     (SELECT id FROM person WHERE uuid = uuid_or_null(%(from_username)s))
 UNION ALL
 SELECT
@@ -54,6 +57,7 @@ SELECT
     %(audio_uuid)s,
     %(body)s,
     %(stanza_id)s,
+    %(question_id)s::SMALLINT,
     (SELECT id FROM person WHERE uuid = uuid_or_null(%(to_username)s))
 WHERE
     %(deliver_to_recipient)s::BOOLEAN
@@ -61,6 +65,10 @@ WHERE
 
 
 Q_SELECT_MESSAGE = f"""
+-- The card answers are joined fresh on every fetch, so a partner answer that
+-- was deleted or made private since the message was sent disappears without
+-- any bookkeeping. The viewer's own answer is deliberately unfiltered: it's
+-- their own state and seeds the client's answer store.
 WITH page AS (
     SELECT
         mam_message.id,
@@ -68,7 +76,8 @@ WITH page AS (
         mam_message.stanza_id,
         mam_message.body,
         mam_message.audio_uuid,
-        mam_message.reaction
+        mam_message.reaction,
+        mam_message.question_id
     FROM
         mam_message
     JOIN
@@ -88,11 +97,57 @@ WITH page AS (
         LEAST(50, COALESCE(%(max)s, 50))
 )
 SELECT
-    *
+    page.*,
+    question.question AS question,
+    question.topic AS question_topic,
+    viewer_answer.answer AS viewer_answer,
+    viewer_answer.public_ AS viewer_answer_public,
+    partner_answer.answer AS partner_answer
 FROM
     page
+LEFT JOIN
+    question
+ON
+    question.id = page.question_id
+LEFT JOIN LATERAL (
+    SELECT
+        answer.answer,
+        answer.public_
+    FROM
+        answer
+    JOIN
+        person
+    ON
+        person.id = answer.person_id
+    WHERE
+        person.uuid = uuid_or_null(%(from_username)s)
+    AND
+        answer.question_id = page.question_id
+) AS viewer_answer
+ON
+    page.question_id IS NOT NULL
+LEFT JOIN LATERAL (
+    SELECT
+        answer.answer
+    FROM
+        answer
+    JOIN
+        person
+    ON
+        person.id = answer.person_id
+    WHERE
+        person.uuid = uuid_or_null(%(to_username)s)
+    AND
+        answer.question_id = page.question_id
+    AND
+        answer.public_
+    AND
+        answer.answer IS NOT NULL
+) AS partner_answer
+ON
+    page.question_id IS NOT NULL
 ORDER BY
-    id
+    page.id
 """
 
 
@@ -117,6 +172,7 @@ class StoreMamMessageJob:
     message_body: str
     audio_uuid: str | None
     deliver_to_recipient: bool = True
+    question_id: int | None = None
 
 
 async def get_conversation(
@@ -139,6 +195,7 @@ async def process_store_mam_message_batch(tx: Tx, batch: list[StoreMamMessageJob
             audio_uuid=message.audio_uuid,
             body=message.message_body,
             stanza_id=message.id,
+            question_id=message.question_id,
             deliver_to_recipient=message.deliver_to_recipient,
         )
         for message in batch
@@ -194,6 +251,12 @@ async def _get_conversation(
             audio_uuid=row['audio_uuid'],
             reaction=reaction,
             reaction_from=reaction_from,
+            question_id=row['question_id'],
+            question=row['question'],
+            question_topic=row['question_topic'],
+            viewer_answer=answer_to_wire(row['viewer_answer']),
+            viewer_answer_public=row['viewer_answer_public'],
+            partner_answer=answer_to_wire(row['partner_answer']),
         ))
 
     # The receipt belongs under the most recent outgoing message, so it's only

--- a/backend/service/api/chat/messagestorage/mam/__init__.py
+++ b/backend/service/api/chat/messagestorage/mam/__init__.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from database import Tx, api_tx
+from qanda import ANSWER_VISIBLE_TO_OTHERS
 from service.api.chat.chatutil import (
     LSERVER,
     fetch_has_gold,
@@ -77,7 +78,10 @@ WITH page AS (
         mam_message.body,
         mam_message.audio_uuid,
         mam_message.reaction,
-        mam_message.question_id
+        mam_message.question_id,
+        -- The viewer owns every row on this page (the CTE filters on it), so
+        -- their person id is free here -- no per-row person lookup needed.
+        mam_message.person_id AS viewer_id
     FROM
         mam_message
     JOIN
@@ -95,6 +99,15 @@ WITH page AS (
         mam_message.id DESC
     LIMIT
         LEAST(50, COALESCE(%(max)s, 50))
+),
+-- Resolved once for the whole page rather than re-joining person per row.
+partner AS (
+    SELECT
+        id AS partner_id
+    FROM
+        person
+    WHERE
+        uuid = uuid_or_null(%(to_username)s)
 )
 SELECT
     page.*,
@@ -106,6 +119,10 @@ SELECT
 FROM
     page
 LEFT JOIN
+    partner
+ON
+    TRUE
+LEFT JOIN
     question
 ON
     question.id = page.question_id
@@ -115,12 +132,8 @@ LEFT JOIN LATERAL (
         answer.public_
     FROM
         answer
-    JOIN
-        person
-    ON
-        person.id = answer.person_id
     WHERE
-        person.uuid = %(from_username)s
+        answer.person_id = page.viewer_id
     AND
         answer.question_id = page.question_id
 ) AS viewer_answer
@@ -131,18 +144,12 @@ LEFT JOIN LATERAL (
         answer.answer
     FROM
         answer
-    JOIN
-        person
-    ON
-        person.id = answer.person_id
     WHERE
-        person.uuid = uuid_or_null(%(to_username)s)
+        answer.person_id = partner.partner_id
     AND
         answer.question_id = page.question_id
     AND
-        answer.public_
-    AND
-        answer.answer IS NOT NULL
+        {ANSWER_VISIBLE_TO_OTHERS}
 ) AS partner_answer
 ON
     page.question_id IS NOT NULL

--- a/backend/service/api/chat/online/__init__.py
+++ b/backend/service/api/chat/online/__init__.py
@@ -104,10 +104,6 @@ async def _redis_subscribe_online(
     key = FMT_KEY.format(username=username)
     val = await redis_client.get(key)
 
-    # Watching someone's online status also watches their quiz-answer changes;
-    # both carry only state the subscriber may see, and `should_subscribe` has
-    # already gated the subscription itself. There's no answer snapshot to
-    # send: MAM results carry current answers, so a fetch is the snapshot.
     await pubsub.subscribe(key)
     await pubsub.subscribe(answers_channel(username))
 

--- a/backend/service/api/chat/online/__init__.py
+++ b/backend/service/api/chat/online/__init__.py
@@ -1,5 +1,6 @@
 import redis.asyncio as redis
 import traceback
+from answerspush import answers_channel
 from service.api.chat.chatutil import (
     fetch_is_public,
     fetch_is_skipped,
@@ -103,7 +104,12 @@ async def _redis_subscribe_online(
     key = FMT_KEY.format(username=username)
     val = await redis_client.get(key)
 
+    # Watching someone's online status also watches their quiz-answer changes;
+    # both carry only state the subscriber may see, and `should_subscribe` has
+    # already gated the subscription itself. There's no answer snapshot to
+    # send: MAM results carry current answers, so a fetch is the snapshot.
     await pubsub.subscribe(key)
+    await pubsub.subscribe(answers_channel(username))
 
     if isinstance(val, bytes):
         val = val.decode()
@@ -146,6 +152,7 @@ async def _redis_unsubscribe_online(
 ) -> None:
     key = FMT_KEY.format(username=username)
     await pubsub.unsubscribe(key)
+    await pubsub.unsubscribe(answers_channel(username))
 
 async def redis_publish_online(
     redis_client: redis.Redis,

--- a/backend/service/api/chat/questioncard/__init__.py
+++ b/backend/service/api/chat/questioncard/__init__.py
@@ -1,12 +1,14 @@
 """
 Card data for chat messages that reply to a quiz question. This is the choke
 point for what each participant may see: the viewer's own answer is returned
-unfiltered (it's theirs), the partner's only while it's public -- the same
-filter `Q_SELECT_MESSAGE` applies on the MAM fetch path.
+unfiltered (it's theirs), the partner's only through the shared
+`ANSWER_VISIBLE_TO_OTHERS` predicate -- the same one the MAM fetch path
+(`Q_SELECT_MESSAGE`) and the feed apply.
 """
 from async_lru_cache import AsyncLruCache
 from dataclasses import dataclass
 from database import api_tx
+from qanda import ANSWER_VISIBLE_TO_OTHERS
 
 
 Q_FETCH_QUESTION = """
@@ -20,7 +22,7 @@ WHERE
 """
 
 
-Q_FETCH_CARD_ANSWERS = """
+Q_FETCH_CARD_ANSWERS = f"""
 SELECT
     viewer_answer.answer AS viewer_answer,
     viewer_answer.public_ AS viewer_answer_public,
@@ -50,9 +52,7 @@ LEFT JOIN LATERAL (
     AND
         answer.question_id = %(question_id)s
     AND
-        answer.public_
-    AND
-        answer.answer IS NOT NULL
+        {ANSWER_VISIBLE_TO_OTHERS}
 ) AS partner_answer
 ON
     TRUE

--- a/backend/service/api/chat/questioncard/__init__.py
+++ b/backend/service/api/chat/questioncard/__init__.py
@@ -1,0 +1,104 @@
+"""
+Card data for chat messages that reply to a quiz question. This is the choke
+point for what each participant may see: the viewer's own answer is returned
+unfiltered (it's theirs), the partner's only while it's public -- the same
+filter `Q_SELECT_MESSAGE` applies on the MAM fetch path.
+"""
+from async_lru_cache import AsyncLruCache
+from dataclasses import dataclass
+from database import api_tx
+
+
+Q_FETCH_QUESTION = """
+SELECT
+    question,
+    topic
+FROM
+    question
+WHERE
+    id = %(question_id)s
+"""
+
+
+Q_FETCH_CARD_ANSWERS = """
+SELECT
+    viewer_answer.answer AS viewer_answer,
+    viewer_answer.public_ AS viewer_answer_public,
+    partner_answer.answer AS partner_answer
+FROM
+    (SELECT 1) AS _
+LEFT JOIN LATERAL (
+    SELECT
+        answer.answer,
+        answer.public_
+    FROM
+        answer
+    WHERE
+        answer.person_id = %(viewer_id)s
+    AND
+        answer.question_id = %(question_id)s
+) AS viewer_answer
+ON
+    TRUE
+LEFT JOIN LATERAL (
+    SELECT
+        answer.answer
+    FROM
+        answer
+    WHERE
+        answer.person_id = %(partner_id)s
+    AND
+        answer.question_id = %(question_id)s
+    AND
+        answer.public_
+    AND
+        answer.answer IS NOT NULL
+) AS partner_answer
+ON
+    TRUE
+"""
+
+
+@dataclass(frozen=True)
+class Card:
+    question: str
+    topic: str
+    viewer_answer: bool | None
+    viewer_answer_public: bool | None
+    partner_answer: bool | None
+
+
+# Question text and topic never change, so a hit can be cached forever; a miss
+# isn't cached in case the question is created later.
+@AsyncLruCache(cache_condition=bool)
+async def fetch_question(question_id: int) -> dict | None:
+    async with api_tx('read committed') as tx:
+        await tx.execute(Q_FETCH_QUESTION, dict(question_id=question_id))
+        return await tx.fetchone()
+
+
+async def fetch_card(
+    question_id: int,
+    viewer_id: int,
+    partner_id: int,
+) -> Card | None:
+    question_row = await fetch_question(question_id)
+
+    if question_row is None:
+        return None
+
+    async with api_tx('read committed') as tx:
+        await tx.execute(Q_FETCH_CARD_ANSWERS, dict(
+            question_id=question_id,
+            viewer_id=viewer_id,
+            partner_id=partner_id,
+        ))
+        row = await tx.fetchone()
+
+    return Card(
+        question=question_row['question'],
+        topic=question_row['topic'],
+        viewer_answer=row['viewer_answer'] if row else None,
+        viewer_answer_public=row['viewer_answer_public'] if row else None,
+        partner_answer=row['partner_answer'] if row else None,
+    )

--- a/backend/service/api/chat/questioncard/__init__.py
+++ b/backend/service/api/chat/questioncard/__init__.py
@@ -4,6 +4,9 @@ point for what each participant may see: the viewer's own answer is returned
 unfiltered (it's theirs), the partner's only through the shared
 `ANSWER_VISIBLE_TO_OTHERS` predicate -- the same one the MAM fetch path
 (`Q_SELECT_MESSAGE`) and the feed apply.
+
+Question text and topic never change, so `fetch_question` caches hits forever;
+misses aren't cached, in case the question is created later.
 """
 from async_lru_cache import AsyncLruCache
 from dataclasses import dataclass
@@ -68,8 +71,6 @@ class Card:
     partner_answer: bool | None
 
 
-# Question text and topic never change, so a hit can be cached forever; a miss
-# isn't cached in case the question is created later.
 @AsyncLruCache(cache_condition=bool)
 async def fetch_question(question_id: int) -> dict | None:
     async with api_tx('read committed') as tx:

--- a/backend/test/functionality1/feed-v2.sh
+++ b/backend/test/functionality1/feed-v2.sh
@@ -633,16 +633,18 @@ answered_question_feed_items () {
 
 expected_answered_question_item () {
   local name=$1
-  local count_yes_members=$2
-  local count_no_members=$3
-  local count_yes=$4
-  local count_no=$5
-  local viewer_answer=$6
-  local viewer_public=$7
-  local match_percentage=$8
+  local subject_answer=$2
+  local count_yes_members=$3
+  local count_no_members=$4
+  local count_yes=$5
+  local count_no=$6
+  local viewer_answer=$7
+  local viewer_public=$8
+  local match_percentage=$9
 
   jq -nS \
     --arg name "$name" \
+    --argjson subject_answer "$subject_answer" \
     --argjson question_id "$question_id" \
     --arg question_text "$question_text" \
     --arg question_topic "$question_topic" \
@@ -674,6 +676,7 @@ expected_answered_question_item () {
       "question_count_no": $count_no,
       "question_yes_members": members($count_yes_members),
       "question_no_members": members($count_no_members),
+      "question_subject_answer": $subject_answer,
       "question_viewer": {
         "person_uuid": "redacted_nonnull_value",
         "url_slug": "redacted_nonnull_value",
@@ -758,8 +761,8 @@ test_answered_question () {
   response=$(answered_question_feed_items)
   expected=$(
     jq -sS . \
-      <(expected_answered_question_item user2 1 1 2 1 null null 50) \
-      <(expected_answered_question_item user3 1 1 2 1 null null 50)
+      <(expected_answered_question_item user2 true 1 1 2 1 null null 50) \
+      <(expected_answered_question_item user3 false 1 1 2 1 null null 50)
   )
   diff -u --color <(echo "$response") <(echo "$expected")
 
@@ -778,9 +781,9 @@ test_answered_question () {
   response=$(answered_question_feed_items)
   expected=$(
     jq -sS . \
-      <(expected_answered_question_item user1 2 1 3 1 null null 50) \
-      <(expected_answered_question_item user2 2 1 3 1 null null 50) \
-      <(expected_answered_question_item user3 2 1 3 1 null null 50)
+      <(expected_answered_question_item user1 true 2 1 3 1 null null 50) \
+      <(expected_answered_question_item user2 true 2 1 3 1 null null 50) \
+      <(expected_answered_question_item user3 false 2 1 3 1 null null 50)
   )
   diff -u --color <(echo "$response") <(echo "$expected")
 
@@ -860,9 +863,9 @@ test_answered_question () {
   response=$(answered_question_feed_items)
   expected=$(
     jq -sS . \
-      <(expected_answered_question_item user1 2 1 3 2 false true "$match_user1") \
-      <(expected_answered_question_item user2 2 1 3 2 false true "$match_user2") \
-      <(expected_answered_question_item user3 2 1 3 2 false true "$match_user3")
+      <(expected_answered_question_item user1 true 2 1 3 2 false true "$match_user1") \
+      <(expected_answered_question_item user2 true 2 1 3 2 false true "$match_user2") \
+      <(expected_answered_question_item user3 false 2 1 3 2 false true "$match_user3")
   )
   diff -u --color <(echo "$response") <(echo "$expected")
 
@@ -879,9 +882,9 @@ test_answered_question () {
   response=$(answered_question_feed_items)
   expected=$(
     jq -sS . \
-      <(expected_answered_question_item user1 2 1 3 3 false false "$match_user1") \
-      <(expected_answered_question_item user2 2 1 3 3 false false "$match_user2") \
-      <(expected_answered_question_item user3 2 1 3 3 false false "$match_user3")
+      <(expected_answered_question_item user1 true 2 1 3 3 false false "$match_user1") \
+      <(expected_answered_question_item user2 true 2 1 3 3 false false "$match_user2") \
+      <(expected_answered_question_item user3 false 2 1 3 3 false false "$match_user3")
   )
   diff -u --color <(echo "$response") <(echo "$expected")
 
@@ -901,8 +904,8 @@ test_answered_question () {
   response=$(answered_question_feed_items)
   expected=$(
     jq -sS . \
-      <(expected_answered_question_item user1 2 0 3 4 false false "$match_user1") \
-      <(expected_answered_question_item user2 2 0 3 4 false false "$match_user2")
+      <(expected_answered_question_item user1 true 2 0 3 4 false false "$match_user1") \
+      <(expected_answered_question_item user2 true 2 0 3 4 false false "$match_user2")
   )
   diff -u --color <(echo "$response") <(echo "$expected")
 
@@ -921,7 +924,7 @@ test_answered_question () {
   response=$(answered_question_feed_items)
   expected=$(
     jq -sS . \
-      <(expected_answered_question_item user1 1 0 3 4 false false "$match_user1")
+      <(expected_answered_question_item user1 true 1 0 3 4 false false "$match_user1")
   )
   diff -u --color <(echo "$response") <(echo "$expected")
 

--- a/backend/test/functionality1/feed-v2.sh
+++ b/backend/test/functionality1/feed-v2.sh
@@ -588,9 +588,10 @@ test_joined_club () {
   q "delete from banned_club where name = 'cats'"
 }
 
-# Answer events and yes/no counts land via one-second batchers in the API,
-# not in the POST /answer transaction, so give them a moment to flush before
-# asserting on them
+# A question's yes/no counts land via a one-second batcher in the API, not in
+# the POST /answer transaction, so give it a moment to flush before asserting
+# on the feed's counts. (The answered-question event itself is now written in
+# the POST /answer transaction, so it needs no wait.)
 flush_answer_batchers () {
   sleep 2
 }

--- a/backend/test/functionality6/xmpp-question-card.sh
+++ b/backend/test/functionality6/xmpp-question-card.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+
+# Purpose: chat messages can reply to a quiz card via `@question_id`. The id
+# is stored on both archive copies, the server serves the card (question text
+# plus both participants' answers) on delivery and MAM fetches, the partner's
+# answer is only ever served while it's public, and answer changes are pushed
+# live as `duo_answer_update` to online-status subscribers -- but only when
+# the publicly visible state changes, so private activity never leaks.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "$script_dir"
+
+source ../util/setup.sh
+
+set -xe
+
+sleep 3 # The chat service takes some time to flush messages to the DB
+
+q "delete from person"
+q "delete from banned_person"
+q "delete from banned_person_admin_token"
+q "delete from duo_session"
+q "delete from mam_message"
+q "delete from inbox"
+q "delete from intro_hash"
+
+../util/create-user.sh user1 0 0
+../util/create-user.sh user2 0 0
+
+# Age the accounts so the intro spam heuristic treats them as trusted
+q "update person set sign_up_time = now() - interval '7 days'"
+
+assume_role user1 ; user1token=$SESSION_TOKEN
+assume_role user2 ; user2token=$SESSION_TOKEN
+
+user1uuid=$(get_uuid 'user1@example.com')
+user2uuid=$(get_uuid 'user2@example.com')
+
+user1id=$(get_id 'user1@example.com')
+user2id=$(get_id 'user2@example.com')
+
+question_id=10
+question_text=$(q "select question from question where id = ${question_id}")
+question_topic=$(q "select topic from question where id = ${question_id}")
+
+query_id () {
+  local _query_id=$(cat /tmp/duo_query_id 2> /dev/null)
+
+  if [[ -z "$_query_id" ]]
+  then
+    echo 0
+  else
+    echo "$_query_id"
+  fi
+}
+
+next_query_id () {
+  local _next_query_id=$(( "$(query_id)" + 1 ))
+
+  printf "%s" "$_next_query_id" > /tmp/duo_query_id
+  printf "%s" "$_next_query_id"
+}
+
+# Like setup.sh's chat_auth, but on a named harness connection so both users
+# can be online at once.
+chat_auth_as () {
+  local connectionId=$1
+  local fromUuid=$2
+  local fromToken=$3
+
+  local auth64=$(printf '\0%s\0%s' "$fromUuid" "$fromToken" | base64 -w 0)
+
+  read -r -d '' authJson <<EOF || true
+{
+  "auth": {
+    "@xmlns": "urn:ietf:params:xml:ns:xmpp-sasl",
+    "@mechanism": "PLAIN",
+    "#text": "${auth64}"
+  }
+}
+EOF
+
+  curl -sX POST "http://localhost:3001/config?id=${connectionId}" \
+    -H "Content-Type: application/json" \
+    -d '{ "server": "ws://api:5000/chat" }'
+
+  sleep 0.2
+
+  curl -sX POST "http://localhost:3001/send?id=${connectionId}" \
+    -H "Content-Type: application/json" \
+    -d "$authJson"
+
+  sleep 1
+
+  curl -sX GET "http://localhost:3001/pop?id=${connectionId}" > /dev/null
+}
+
+pop_connection () {
+  local connectionId=$1
+  curl -sX GET "http://localhost:3001/pop?id=${connectionId}"
+}
+
+# Send a chat message on a named connection, optionally with a @question_id.
+send_message_as () {
+  local connectionId=$1
+  local fromUuid=$2
+  local toUuid=$3
+  local body=$4
+  local questionId=${5:-}
+
+  local questionAttr=""
+  if [[ -n "$questionId" ]]
+  then
+    questionAttr="\"@question_id\": \"${questionId}\","
+  fi
+
+  read -r -d '' payload <<EOF || true
+{
+  "message": {
+    "@type": "chat",
+    "@from": "${fromUuid}@duolicious.app",
+    "@to": "${toUuid}@duolicious.app",
+    "@id": "id-$(next_query_id)",
+    "@xmlns": "jabber:client",
+    ${questionAttr}
+    "body": "${body}",
+    "request": {
+      "@xmlns": "urn:xmpp:receipts"
+    }
+  }
+}
+EOF
+
+  curl -sX POST "http://localhost:3001/send?id=${connectionId}" \
+    -H "Content-Type: application/json" -d "$payload"
+  sleep 2
+}
+
+# Fetch a single page of a conversation on a named connection and return the
+# raw (newline-delimited JSON) response.
+get_conversation_as () {
+  local connectionId=$1
+  local otherPersonUuid=$2
+  local queryId=$(next_query_id)
+
+  curl -sX GET "http://localhost:3001/pop?id=${connectionId}" > /dev/null
+  sleep 0.5
+
+  read -r -d '' query <<EOF || true
+{
+  "iq": {
+    "@type": "set",
+    "@id": "${queryId}",
+    "query": {
+      "@xmlns": "urn:xmpp:mam:2",
+      "@queryid": "${queryId}",
+      "x": {
+        "@xmlns": "jabber:x:data",
+        "@type": "submit",
+        "field": [
+          { "@var": "FORM_TYPE", "value": "urn:xmpp:mam:2" },
+          { "@var": "with", "value": "${otherPersonUuid}@duolicious.app" }
+        ]
+      },
+      "set": {
+        "@xmlns": "http://jabber/protocol/rsm",
+        "max": "50",
+        "before": ""
+      }
+    }
+  }
+}
+EOF
+
+  curl -sX POST "http://localhost:3001/send?id=${connectionId}" \
+    -H "Content-Type: application/json" -d "$query"
+  sleep 0.5
+
+  curl -sX GET "http://localhost:3001/pop?id=${connectionId}"
+}
+
+# Extract an attribute of the MAM message with the given body. Prints the
+# empty string when the attribute is absent.
+mam_attr_by_body () {
+  local body=$1
+  local attr=$2
+  jq -rs '[ .[]
+    | select(.message.result.forwarded.message.body == "'"$body"'")
+    | .message.result.forwarded.message["'"$attr"'"]
+  ] | .[0] // ""'
+}
+
+# Extract an attribute of a live-delivered message with the given body.
+live_attr_by_body () {
+  local body=$1
+  local attr=$2
+  jq -rs '[ .[]
+    | select(.message.body == "'"$body"'")
+    | .message["'"$attr"'"]
+  ] | .[0] // ""'
+}
+
+
+echo "Setup: user2 answers publicly, user1 answers privately"
+
+assume_role user2
+jc POST /answer \
+  -d "{ \"question_id\": ${question_id}, \"answer\": true, \"public\": true }"
+
+assume_role user1
+jc POST /answer \
+  -d "{ \"question_id\": ${question_id}, \"answer\": false, \"public\": false }"
+
+chat_auth_as user1 "$user1uuid" "$user1token"
+chat_auth_as user2 "$user2uuid" "$user2token"
+
+
+echo "A quiz-card reply is stored with its question_id on both archive copies"
+
+body1="replying to your quiz card"
+send_message_as user1 "$user1uuid" "$user2uuid" "$body1" "$question_id"
+
+[[ "$(q "select question_id from mam_message where person_id = ${user1id}")" == "$question_id" ]] \
+  || { echo "Expected question_id on the sender's copy"; exit 1; }
+[[ "$(q "select question_id from mam_message where person_id = ${user2id}")" == "$question_id" ]] \
+  || { echo "Expected question_id on the recipient's copy"; exit 1; }
+
+
+echo "The recipient's live delivery carries the card, minus private answers"
+
+user2_received=$(pop_connection user2)
+
+[[ "$(live_attr_by_body "$body1" '@question_id' <<< "$user2_received")" == "$question_id" ]] \
+  || { echo "Expected @question_id on the delivered message"; exit 1; }
+[[ "$(live_attr_by_body "$body1" '@question' <<< "$user2_received")" == "$question_text" ]] \
+  || { echo "Expected @question on the delivered message"; exit 1; }
+[[ "$(live_attr_by_body "$body1" '@question_topic' <<< "$user2_received")" == "$question_topic" ]] \
+  || { echo "Expected @question_topic on the delivered message"; exit 1; }
+# The recipient's own answer, public or not, is theirs to see
+[[ "$(live_attr_by_body "$body1" '@viewer_answer' <<< "$user2_received")" == "yes" ]] \
+  || { echo "Expected the recipient's own answer on the delivered message"; exit 1; }
+[[ "$(live_attr_by_body "$body1" '@viewer_answer_public' <<< "$user2_received")" == "true" ]] \
+  || { echo "Expected the recipient's answer to be flagged public"; exit 1; }
+# The sender answered privately, so their answer must be absent
+[[ "$(live_attr_by_body "$body1" '@partner_answer' <<< "$user2_received")" == "" ]] \
+  || { echo "Expected the sender's private answer to be hidden"; exit 1; }
+
+
+echo "MAM serves the card with the partner's answer filtered by publicness"
+
+user1_convo=$(get_conversation_as user1 "$user2uuid")
+
+[[ "$(mam_attr_by_body "$body1" '@question_id' <<< "$user1_convo")" == "$question_id" ]] \
+  || { echo "Expected @question_id in user1's MAM result"; exit 1; }
+[[ "$(mam_attr_by_body "$body1" '@question' <<< "$user1_convo")" == "$question_text" ]] \
+  || { echo "Expected @question in user1's MAM result"; exit 1; }
+# user1's own private answer is served to them, flagged private
+[[ "$(mam_attr_by_body "$body1" '@viewer_answer' <<< "$user1_convo")" == "no" ]] \
+  || { echo "Expected user1's own answer in their MAM result"; exit 1; }
+[[ "$(mam_attr_by_body "$body1" '@viewer_answer_public' <<< "$user1_convo")" == "false" ]] \
+  || { echo "Expected user1's answer to be flagged private"; exit 1; }
+# user2's answer is public, so user1 sees it
+[[ "$(mam_attr_by_body "$body1" '@partner_answer' <<< "$user1_convo")" == "yes" ]] \
+  || { echo "Expected user2's public answer in user1's MAM result"; exit 1; }
+
+
+echo "Making an answer private removes it from the partner's MAM results"
+
+assume_role user2
+jc POST /answer \
+  -d "{ \"question_id\": ${question_id}, \"answer\": true, \"public\": false }"
+
+user1_convo=$(get_conversation_as user1 "$user2uuid")
+[[ "$(mam_attr_by_body "$body1" '@partner_answer' <<< "$user1_convo")" == "" ]] \
+  || { echo "Expected user2's now-private answer to be hidden from user1"; exit 1; }
+
+# user2 still sees their own answer, now flagged private
+user2_convo=$(get_conversation_as user2 "$user1uuid")
+[[ "$(mam_attr_by_body "$body1" '@viewer_answer' <<< "$user2_convo")" == "yes" ]] \
+  || { echo "Expected user2 to still see their own answer"; exit 1; }
+[[ "$(mam_attr_by_body "$body1" '@viewer_answer_public' <<< "$user2_convo")" == "false" ]] \
+  || { echo "Expected user2's answer to be flagged private"; exit 1; }
+
+
+echo "Answer changes are pushed live to online-status subscribers"
+
+curl -sX GET "http://localhost:3001/pop?id=user1" > /dev/null
+curl -sX POST "http://localhost:3001/send?id=user1" \
+  -H "Content-Type: application/json" \
+  -d "{ \"duo_subscribe_online\": { \"@uuid\": \"${user2uuid}\" } }"
+sleep 1
+curl -sX GET "http://localhost:3001/pop?id=user1" > /dev/null
+
+# private -> public: pushed with the answer
+assume_role user2
+jc POST /answer \
+  -d "{ \"question_id\": ${question_id}, \"answer\": true, \"public\": true }"
+sleep 1
+
+update=$(pop_connection user1)
+[[ "$(jq -rs '[ .[] | .duo_answer_update["@answer"] // empty ] | .[0]' <<< "$update")" == "yes" ]] \
+  || { echo "Expected a duo_answer_update with the new public answer, got: $update"; exit 1; }
+[[ "$(jq -rs '[ .[] | .duo_answer_update["@uuid"] // empty ] | .[0]' <<< "$update")" == "$user2uuid" ]] \
+  || { echo "Expected the update to name user2"; exit 1; }
+[[ "$(jq -rs '[ .[] | .duo_answer_update["@question_id"] // empty ] | .[0]' <<< "$update")" == "$question_id" ]] \
+  || { echo "Expected the update to name the question"; exit 1; }
+
+# public -> private: pushed as hidden (no @answer)
+jc POST /answer \
+  -d "{ \"question_id\": ${question_id}, \"answer\": true, \"public\": false }"
+sleep 1
+
+update=$(pop_connection user1)
+[[ "$(jq -rs '[ .[] | select(.duo_answer_update) ] | length' <<< "$update")" == "1" ]] \
+  || { echo "Expected exactly one duo_answer_update, got: $update"; exit 1; }
+[[ "$(jq -rs '[ .[] | select(.duo_answer_update) | .duo_answer_update | has("@answer") ] | .[0]' <<< "$update")" == "false" ]] \
+  || { echo "Expected the update to carry no answer, got: $update"; exit 1; }
+
+# private -> private: never pushed, so private activity can't leak
+jc POST /answer \
+  -d "{ \"question_id\": ${question_id}, \"answer\": false, \"public\": false }"
+sleep 1
+
+update=$(pop_connection user1)
+[[ "$(jq -rs '[ .[] | select(.duo_answer_update) ] | length' <<< "$update")" == "0" ]] \
+  || { echo "Expected no duo_answer_update for a private edit, got: $update"; exit 1; }
+
+# deleting an already-hidden answer: nothing visible changed, so no event
+jc DELETE /answer -d "{ \"question_id\": ${question_id} }"
+sleep 1
+
+update=$(pop_connection user1)
+[[ "$(jq -rs '[ .[] | select(.duo_answer_update) ] | length' <<< "$update")" == "0" ]] \
+  || { echo "Expected no duo_answer_update for a hidden delete, got: $update"; exit 1; }
+
+
+echo "An invalid question_id degrades to a plain text message"
+
+q "delete from mam_message"
+q "delete from intro_hash"
+
+body2="a reply with a nonexistent question"
+send_message_as user1 "$user1uuid" "$user2uuid" "$body2" "32000"
+
+body3="a reply with a zero question"
+send_message_as user1 "$user1uuid" "$user2uuid" "$body3" "0"
+
+body4="a reply with a junk question"
+send_message_as user1 "$user1uuid" "$user2uuid" "$body4" "junk"
+
+[[ "$(q "select count(*) from mam_message where question_id is not null")" -eq 0 ]] \
+  || { echo "Expected no question_id to be stored for invalid references"; exit 1; }
+[[ "$(q "select count(*) from mam_message")" -eq 6 ]] \
+  || { echo "Expected the messages to be delivered as plain text"; exit 1; }
+
+user2_received=$(pop_connection user2)
+[[ "$(live_attr_by_body "$body2" '@question_id' <<< "$user2_received")" == "" ]] \
+  || { echo "Expected no card attributes on an invalid reference"; exit 1; }

--- a/frontend/chat/application-layer/hooks/message.tsx
+++ b/frontend/chat/application-layer/hooks/message.tsx
@@ -17,6 +17,8 @@ import {
 } from '../index';
 import { getRandomString } from '../../../random/string';
 import { assertNever } from '../../../util/util';
+import { seedPartnerAnswer } from './partner-answer';
+import { QuoteCard } from '../../../components/conversation-screen/quote';
 
 type UseMessage =
   | { status: 'not unique', message: Message, usedCount: number }
@@ -55,6 +57,7 @@ const sendMessageAndNotify = (
   content: {
     type: 'chat-text',
     text: string,
+    questionCard?: QuoteCard,
   } | {
     type: 'chat-audio',
     audioBase64: string,
@@ -68,6 +71,17 @@ const sendMessageAndNotify = (
 ): string => {
   const id = getRandomString(40);
 
+  if (content.type === 'chat-text' && content.questionCard !== undefined) {
+    // The feed item's copy of the recipient's answer, so the sender's own
+    // card renders immediately; the server's copy takes over from the next
+    // fetch or live update
+    seedPartnerAnswer(
+      recipientPersonUuid,
+      content.questionCard.questionId,
+      content.questionCard.subjectAnswer,
+    );
+  }
+
   const initialMessage: Message = (() => {
     switch (content.type) {
       case 'chat-text':
@@ -79,6 +93,11 @@ const sendMessageAndNotify = (
           text: content.text,
           timestamp: new Date(),
           fromCurrentUser: true,
+          ...(content.questionCard !== undefined ? {
+            questionId: content.questionCard.questionId,
+            question: content.questionCard.question,
+            questionTopic: content.questionCard.topic,
+          } : {}),
         };
       case 'chat-audio':
         return {

--- a/frontend/chat/application-layer/hooks/message.tsx
+++ b/frontend/chat/application-layer/hooks/message.tsx
@@ -17,7 +17,7 @@ import {
 } from '../index';
 import { getRandomString } from '../../../random/string';
 import { assertNever } from '../../../util/util';
-import { seedPartnerAnswer } from './partner-answer';
+import { seedPartnerAnswer, questionCardToFields } from './partner-answer';
 import { QuoteCard } from '../../../components/conversation-screen/quote';
 
 type UseMessage =
@@ -93,11 +93,8 @@ const sendMessageAndNotify = (
           text: content.text,
           timestamp: new Date(),
           fromCurrentUser: true,
-          ...(content.questionCard !== undefined ? {
-            questionId: content.questionCard.questionId,
-            question: content.questionCard.question,
-            questionTopic: content.questionCard.topic,
-          } : {}),
+          ...(content.questionCard !== undefined
+            ? questionCardToFields(content.questionCard) : {}),
         };
       case 'chat-audio':
         return {

--- a/frontend/chat/application-layer/hooks/partner-answer.tsx
+++ b/frontend/chat/application-layer/hooks/partner-answer.tsx
@@ -1,0 +1,106 @@
+// The store for what a conversation partner has publicly answered, keyed by
+// person and question. Values arrive from the server: seeded from card
+// attributes on fetched/received messages, then kept fresh by
+// `duo_answer_update` events on the channel joined via the online-status
+// subscription. `null` means hidden or unanswered -- the server never sends
+// private state.
+
+import { listen, lastEvent, notify } from '../../../events/events';
+import { useRetained } from '../../../events/use-retained';
+import { EV_CHAT_WS_RECEIVE } from '../../websocket-layer';
+import { seedViewerAnswer } from '../../../api/answer';
+
+const eventKey = (personUuid: string, questionId: number) =>
+  `partner-answer-${personUuid}-${questionId}`;
+
+const answerFromWire = (answer: unknown): boolean | null => {
+  if (answer === 'yes') return true;
+  if (answer === 'no') return false;
+  return null;
+};
+
+const setPartnerAnswer = (
+  personUuid: string,
+  questionId: number,
+  answer: boolean | null,
+) => {
+  notify<boolean | null>(eventKey(personUuid, questionId), answer);
+};
+
+// Set-if-absent, for the send path: the feed item's copy of the partner's
+// answer shows the card immediately, but must never clobber a fresher value
+// from the server
+const seedPartnerAnswer = (
+  personUuid: string,
+  questionId: number,
+  answer: boolean | null,
+) => {
+  if (lastEvent(eventKey(personUuid, questionId)) === undefined) {
+    setPartnerAnswer(personUuid, questionId, answer);
+  }
+};
+
+type CardAttributes = {
+  '@question_id'?: unknown
+  '@viewer_answer'?: unknown
+  '@viewer_answer_public'?: unknown
+  '@partner_answer'?: unknown
+};
+
+// The single place server-sent card state on a message enters the client
+// stores. The partner's answer is authoritative (the server computed it just
+// now); the viewer's own answer only seeds their store, which is fresher than
+// any fetch once they've written in this session.
+const ingestCardAttributes = (
+  partnerUuid: string,
+  attrs: CardAttributes,
+): void => {
+  const questionId = Number(attrs['@question_id']);
+
+  if (!questionId) {
+    return;
+  }
+
+  setPartnerAnswer(
+    partnerUuid,
+    questionId,
+    answerFromWire(attrs['@partner_answer']),
+  );
+
+  seedViewerAnswer(questionId, {
+    answer: answerFromWire(attrs['@viewer_answer']),
+    public_: attrs['@viewer_answer_public'] !== 'false',
+  });
+};
+
+const usePartnerAnswer = (
+  personUuid: string,
+  questionId: number | undefined,
+): boolean | null =>
+  useRetained<boolean>(
+    questionId === undefined ? undefined : eventKey(personUuid, questionId));
+
+const onReceiveAnswerUpdate = (doc: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
+  const update = doc?.duo_answer_update;
+
+  if (!update) {
+    return;
+  }
+
+  const personUuid = update['@uuid'];
+  const questionId = Number(update['@question_id']);
+
+  if (!personUuid || !questionId) {
+    return;
+  }
+
+  setPartnerAnswer(personUuid, questionId, answerFromWire(update['@answer']));
+};
+
+listen(EV_CHAT_WS_RECEIVE, onReceiveAnswerUpdate);
+
+export {
+  ingestCardAttributes,
+  seedPartnerAnswer,
+  usePartnerAnswer,
+};

--- a/frontend/chat/application-layer/hooks/partner-answer.tsx
+++ b/frontend/chat/application-layer/hooks/partner-answer.tsx
@@ -9,6 +9,7 @@ import { listen, lastEvent, notify } from '../../../events/events';
 import { useRetained } from '../../../events/use-retained';
 import { EV_CHAT_WS_RECEIVE } from '../../websocket-layer';
 import { seedViewerAnswer } from '../../../api/answer';
+import { QuoteCard } from '../../../components/conversation-screen/quote';
 
 const eventKey = (personUuid: string, questionId: number) =>
   `partner-answer-${personUuid}-${questionId}`;
@@ -73,6 +74,46 @@ const ingestCardAttributes = (
   });
 };
 
+// The quiz-card display fields on a chat-text message. The current answers
+// aren't among them -- they live in the answer stores so they can update live.
+// One shape shared by the live-receive, MAM-fetch, and send paths so they
+// can't drift apart.
+type QuestionCardFields = {
+  questionId: number
+  question: string
+  questionTopic: string
+};
+
+// Parse the card fields off a message's wire attributes, or undefined when the
+// message isn't a quiz-card reply. The server always sends the three together
+// or none.
+const questionCardFromWire = (attrs: {
+  '@question_id'?: unknown
+  '@question'?: unknown
+  '@question_topic'?: unknown
+}): QuestionCardFields | undefined => {
+  const questionId = attrs['@question_id'];
+  const question = attrs['@question'];
+  const questionTopic = attrs['@question_topic'];
+
+  if (!questionId || !question || !questionTopic) {
+    return undefined;
+  }
+
+  return {
+    questionId: Number(questionId),
+    question: String(question),
+    questionTopic: String(questionTopic),
+  };
+};
+
+// The same fields off a composer quote card, for the outgoing-message path.
+const questionCardToFields = (card: QuoteCard): QuestionCardFields => ({
+  questionId: card.questionId,
+  question: card.question,
+  questionTopic: card.topic,
+});
+
 const usePartnerAnswer = (
   personUuid: string,
   questionId: number | undefined,
@@ -100,7 +141,10 @@ const onReceiveAnswerUpdate = (doc: any) => { // eslint-disable-line @typescript
 listen(EV_CHAT_WS_RECEIVE, onReceiveAnswerUpdate);
 
 export {
+  QuestionCardFields,
   ingestCardAttributes,
+  questionCardFromWire,
+  questionCardToFields,
   seedPartnerAnswer,
   usePartnerAnswer,
 };

--- a/frontend/chat/application-layer/index.tsx
+++ b/frontend/chat/application-layer/index.tsx
@@ -14,6 +14,8 @@ import {
 } from '../websocket-layer';
 import { notifyOwnLastMessageAt } from './hooks/read-receipt';
 import { ingestMamReaction } from './hooks/reaction';
+import { ingestCardAttributes } from './hooks/partner-answer';
+import { QuoteCard } from '../../components/conversation-screen/quote';
 import {
   awaitFocusedConversationFetch,
   markConversationFetchDispatched,
@@ -121,6 +123,12 @@ type ChatAudioMessage = ChatBaseMessage & {
 type ChatTextMessage = ChatBaseMessage & {
   type: 'chat-text'
   text: string
+  // Set when the message replies to a quiz card. The current answers aren't
+  // stored on the message; they live in the answer stores so they can update
+  // in real time.
+  questionId?: number
+  question?: string
+  questionTopic?: string
 };
 
 type ChatMessage = ChatAudioMessage | ChatTextMessage;
@@ -469,6 +477,7 @@ const sendMessage = async (
   content: {
     type: 'chat-text',
     text: string,
+    questionCard?: QuoteCard,
   } | {
     type: 'chat-audio',
     audioBase64: string,
@@ -517,6 +526,11 @@ const sendMessage = async (
           '@from': personUuidToJid(credentials.username),
           '@to': personUuidToJid(recipientPersonUuid),
           '@id': id,
+          // Only the id goes on the wire; the server derives the question
+          // text and both answers itself
+          ...(content.questionCard !== undefined ? {
+            '@question_id': String(content.questionCard.questionId),
+          } : {}),
           body: content.text,
         },
       };
@@ -641,6 +655,8 @@ const sendMessage = async (
     };
   } else if (response.status === 'sent') {
     const text = content.type === 'chat-text' ? content.text : '';
+    const questionCard =
+      content.type === 'chat-text' ? content.questionCard : undefined;
     const timestamp = response.stamp ? new Date(response.stamp) : new Date();
 
     setInboxSent(recipientPersonUuid, text);
@@ -661,6 +677,11 @@ const sendMessage = async (
         text,
         timestamp,
         fromCurrentUser: true,
+        ...(questionCard !== undefined ? {
+          questionId: questionCard.questionId,
+          question: questionCard.question,
+          questionTopic: questionCard.topic,
+        } : {}),
       },
       status: response.status
     };
@@ -765,6 +786,9 @@ const onReceiveMessage = (
           '@id': id,
           '@audio_uuid': audioUuid,
           '@mam_id': mamId,
+          '@question_id': questionId,
+          '@question': question,
+          '@question_topic': questionTopic,
           body: text,
         }
       } = doc;
@@ -785,10 +809,19 @@ const onReceiveMessage = (
       }
 
       if (type === 'chat' && text){
+        if (questionId && question && questionTopic) {
+          ingestCardAttributes(jidToBareJid(from), doc.message);
+        }
+
         return {
           ...base,
           type: 'chat-text' as 'chat-text',
           text: text as string,
+          ...(questionId && question && questionTopic ? {
+            questionId: Number(questionId),
+            question: question as string,
+            questionTopic: questionTopic as string,
+          } : {}),
         };
       }
 
@@ -918,6 +951,9 @@ const fetchConversation = async (
                 '@audio_uuid': audioUuid,
                 '@reaction': reaction,
                 '@reaction_from': reactionFrom,
+                '@question_id': questionId,
+                '@question': question,
+                '@question_topic': questionTopic,
                 'body': text,
               }
             }
@@ -928,6 +964,13 @@ const fetchConversation = async (
       assert(receivedQueryId === queryId);
 
       ingestMamReaction(mamId, reaction, reactionFrom);
+
+      if (questionId && question && questionTopic) {
+        ingestCardAttributes(
+          withPersonUuid,
+          doc.message.result.forwarded.message,
+        );
+      }
 
       if (audioUuid) {
         return {
@@ -950,6 +993,11 @@ const fetchConversation = async (
           mamId: mamId || undefined,
           timestamp: new Date(timestamp),
           fromCurrentUser: jidMatchesSignedInUser(from),
+          ...(questionId && question && questionTopic ? {
+            questionId: Number(questionId),
+            question: question as string,
+            questionTopic: questionTopic as string,
+          } : {}),
         };
       }
     } catch {

--- a/frontend/chat/application-layer/index.tsx
+++ b/frontend/chat/application-layer/index.tsx
@@ -14,7 +14,11 @@ import {
 } from '../websocket-layer';
 import { notifyOwnLastMessageAt } from './hooks/read-receipt';
 import { ingestMamReaction } from './hooks/reaction';
-import { ingestCardAttributes } from './hooks/partner-answer';
+import {
+  ingestCardAttributes,
+  questionCardFromWire,
+  questionCardToFields,
+} from './hooks/partner-answer';
 import { QuoteCard } from '../../components/conversation-screen/quote';
 import {
   awaitFocusedConversationFetch,
@@ -677,11 +681,7 @@ const sendMessage = async (
         text,
         timestamp,
         fromCurrentUser: true,
-        ...(questionCard !== undefined ? {
-          questionId: questionCard.questionId,
-          question: questionCard.question,
-          questionTopic: questionCard.topic,
-        } : {}),
+        ...(questionCard !== undefined ? questionCardToFields(questionCard) : {}),
       },
       status: response.status
     };
@@ -786,9 +786,6 @@ const onReceiveMessage = (
           '@id': id,
           '@audio_uuid': audioUuid,
           '@mam_id': mamId,
-          '@question_id': questionId,
-          '@question': question,
-          '@question_topic': questionTopic,
           body: text,
         }
       } = doc;
@@ -809,19 +806,14 @@ const onReceiveMessage = (
       }
 
       if (type === 'chat' && text){
-        if (questionId && question && questionTopic) {
-          ingestCardAttributes(jidToBareJid(from), doc.message);
-        }
+        // No-ops unless the message is a card reply; self-guards on the id.
+        ingestCardAttributes(jidToBareJid(from), doc.message);
 
         return {
           ...base,
           type: 'chat-text' as 'chat-text',
           text: text as string,
-          ...(questionId && question && questionTopic ? {
-            questionId: Number(questionId),
-            question: question as string,
-            questionTopic: questionTopic as string,
-          } : {}),
+          ...(questionCardFromWire(doc.message) ?? {}),
         };
       }
 
@@ -951,9 +943,6 @@ const fetchConversation = async (
                 '@audio_uuid': audioUuid,
                 '@reaction': reaction,
                 '@reaction_from': reactionFrom,
-                '@question_id': questionId,
-                '@question': question,
-                '@question_topic': questionTopic,
                 'body': text,
               }
             }
@@ -965,12 +954,11 @@ const fetchConversation = async (
 
       ingestMamReaction(mamId, reaction, reactionFrom);
 
-      if (questionId && question && questionTopic) {
-        ingestCardAttributes(
-          withPersonUuid,
-          doc.message.result.forwarded.message,
-        );
-      }
+      // No-ops unless the message is a card reply; self-guards on the id.
+      ingestCardAttributes(
+        withPersonUuid,
+        doc.message.result.forwarded.message,
+      );
 
       if (audioUuid) {
         return {
@@ -993,11 +981,7 @@ const fetchConversation = async (
           mamId: mamId || undefined,
           timestamp: new Date(timestamp),
           fromCurrentUser: jidMatchesSignedInUser(from),
-          ...(questionId && question && questionTopic ? {
-            questionId: Number(questionId),
-            question: question as string,
-            questionTopic: questionTopic as string,
-          } : {}),
+          ...(questionCardFromWire(doc.message.result.forwarded.message) ?? {}),
         };
       }
     } catch {

--- a/frontend/components/conversation-screen/chat-message.tsx
+++ b/frontend/components/conversation-screen/chat-message.tsx
@@ -36,7 +36,15 @@ import Animated, {
   withSequence,
   withTiming,
 } from 'react-native-reanimated';
-import { setQuote, parseMarkdown, QuoteBlock, TextBlock } from './quote';
+import {
+  setQuote,
+  parseMarkdown,
+  QuoteBlock,
+  stripLeadingQuoteBlock,
+  TextBlock,
+} from './quote';
+import { usePartnerAnswer } from '../../chat/application-layer/hooks/partner-answer';
+import { AnsweredQuizCard } from '../quiz-card';
 import * as Haptics from 'expo-haptics';
 import { useSignedInUser } from '../../events/signed-in-user';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
@@ -305,10 +313,12 @@ const MessageStatusComponent = ({
 
 const ChatMessage = ({
   messageId,
+  personUuid,
   name,
   avatarUuid,
 }: {
   messageId: string
+  personUuid: string
   name: string | undefined
   avatarUuid: string | null | undefined
 }) => {
@@ -338,6 +348,29 @@ const ChatMessage = ({
   const mamId = chatMessage?.mamId;
 
   const reaction = useReaction(mamId);
+
+  const questionCard =
+    chatMessage?.type === 'chat-text' &&
+    chatMessage.questionId !== undefined &&
+    chatMessage.question !== undefined &&
+    chatMessage.questionTopic !== undefined
+      ? {
+          questionId: chatMessage.questionId,
+          question: chatMessage.question,
+          topic: chatMessage.questionTopic,
+        }
+      : undefined;
+
+  // The conversation partner's answer, regardless of who sent the message;
+  // updates live via `duo_answer_update`
+  const partnerAnswer = usePartnerAnswer(personUuid, questionCard?.questionId);
+
+  // When the quiz card renders, it replaces the message's leading blockquote
+  // (the card's fallback presentation), leaving just the typed text
+  const bubbleText =
+    chatMessage?.type !== 'chat-text' ? '' :
+    questionCard === undefined ? chatMessage.text :
+    stripLeadingQuoteBlock(chatMessage.text);
 
   const canReact = !!chatMessage && !chatMessage.fromCurrentUser && !!mamId;
 
@@ -402,7 +435,7 @@ const ChatMessage = ({
       return 'transparent';
     } else if (doRenderUrlAsImage) {
       return 'transparent';
-    } else if (isEmojiOnly(message.message.text)) {
+    } else if (isEmojiOnly(bubbleText)) {
       return 'transparent';
     } else if (message.message.fromCurrentUser) {
       return currentUserBackgroundColor;
@@ -544,6 +577,25 @@ const ChatMessage = ({
         },
       ]}
     >
+      {questionCard &&
+        <View
+          style={{
+            width: '100%',
+            maxWidth: 450,
+            alignSelf: fromCurrentUser ? 'flex-end' : 'flex-start',
+          }}
+        >
+          <AnsweredQuizCard
+            questionNumber={questionCard.questionId}
+            topic={questionCard.topic}
+            user1={name ?? 'They'}
+            answer1={partnerAnswer}
+            user2="You"
+          >
+            {questionCard.question}
+          </AnsweredQuizCard>
+        </View>
+      }
       <View
         style={{
           position: 'relative',
@@ -592,7 +644,7 @@ const ChatMessage = ({
             {shownAvatarUuid &&
               <Avatar avatarUuid={shownAvatarUuid} />
             }
-            {message.message.type === 'chat-text' &&
+            {message.message.type === 'chat-text' && bubbleText.length > 0 &&
               <View
                 style={{
                   borderRadius: 10,
@@ -629,9 +681,9 @@ const ChatMessage = ({
                 }
                 {!doRenderUrlAsImage &&
                   <FormattedText
-                    text={message.message.text}
+                    text={bubbleText}
                     color={textColor}
-                    fontSize={isEmojiOnly(message.message.text) ? 50 : defaultFontSize}
+                    fontSize={isEmojiOnly(bubbleText) ? 50 : defaultFontSize}
                   />
                 }
                 {!doRenderUrlAsImage && !isMobile() &&

--- a/frontend/components/conversation-screen/conversation-screen.tsx
+++ b/frontend/components/conversation-screen/conversation-screen.tsx
@@ -60,6 +60,7 @@ import {
 } from '@react-navigation/native-stack';
 import type { RootParamList } from '../../navigation/linking';
 import { useDraftMessage } from '../../chat/application-layer/hooks/draft-message';
+import { QuoteCard } from './quote';
 import { GifPickedEvent } from '../../components/modal/gif-picker-modal';
 import { useSkipped } from '../../hide-and-block/hide-and-block';
 import { OnlineIndicator } from '../online-indicator';
@@ -545,10 +546,10 @@ const ConversationScreen = ({navigation, route}: NativeStackScreenProps<RootPara
 
   const listRef = useRef<ScrollView>(null);
 
-  const onPressSend = useCallback((messageBody: string): void => {
+  const onPressSend = useCallback((messageBody: string, card?: QuoteCard): void => {
     const messageId = sendMessageAndNotify(
       personUuid,
-      { type: 'chat-text', text: messageBody }
+      { type: 'chat-text', text: messageBody, questionCard: card }
     );
 
     setMessageIds(messageIds => [...(messageIds ?? []), messageId]);
@@ -916,6 +917,7 @@ const ConversationScreen = ({navigation, route}: NativeStackScreenProps<RootPara
                 }
                 <ChatMessage
                   messageId={messageId}
+                  personUuid={personUuid}
                   name={name}
                   avatarUuid={photoUuid}
                 />

--- a/frontend/components/conversation-screen/input.tsx
+++ b/frontend/components/conversation-screen/input.tsx
@@ -58,6 +58,7 @@ import { FormattedText } from './chat-message';
 import { X } from 'react-native-feather';
 import {
   Quote as QuoteType,
+  QuoteCard,
   quoteToMessageMarkdown,
   quoteToPreviewMarkdown,
   setQuote,
@@ -478,7 +479,7 @@ const Input = ({
   onFocus,
 }: {
   initialValue?: string
-  onPressSend: (text: string) => void
+  onPressSend: (text: string, card?: QuoteCard) => void
   onChange: (s: string) => void
   onPressGif: () => void
   onAudioComplete: (audioBase64: string) => void
@@ -704,6 +705,7 @@ const Input = ({
   const handleSendPress = () => {
     const trimmedText = text.trim();
     const quoteAsMarkdown = quoteToMessageMarkdown(quote);
+    const card = quote?.card;
 
     if (trimmedText.length === 0) {
       return;
@@ -713,7 +715,7 @@ const Input = ({
     setQuote(null);
 
     if (trimmedText.length > 0 && quoteAsMarkdown.length > 0) {
-      onPressSend(quoteAsMarkdown + '\n' + trimmedText);
+      onPressSend(quoteAsMarkdown + '\n' + trimmedText, card);
     } else if (trimmedText.length > 0) {
       onPressSend(trimmedText);
     }

--- a/frontend/components/conversation-screen/quote.tsx
+++ b/frontend/components/conversation-screen/quote.tsx
@@ -60,6 +60,17 @@ type QuoteCard = {
 
 type Quote = { text: string; attribution: string; card?: QuoteCard };
 
+// The fallback markdown text a quiz-card reply quotes: the question, plus the
+// subject's answer when they have a visible one. Shared by every surface that
+// starts such a reply so the blockquote old clients see reads the same.
+const quizCardQuoteText = (
+  question: string,
+  subjectAnswer: boolean | null,
+): string =>
+  subjectAnswer === null
+    ? question
+    : `${question} — ${subjectAnswer ? 'Yes' : 'No'}`;
+
 // ──────────────────────────────────────────────────────────────────────────
 // Constants / Regexes
 // ──────────────────────────────────────────────────────────────────────────
@@ -277,6 +288,7 @@ export {
   Quote,
   QuoteBlock,
   QuoteCard,
+  quizCardQuoteText,
   quoteToMessageMarkdown,
   quoteToPreviewMarkdown,
   setQuote,

--- a/frontend/components/conversation-screen/quote.tsx
+++ b/frontend/components/conversation-screen/quote.tsx
@@ -60,9 +60,6 @@ type QuoteCard = {
 
 type Quote = { text: string; attribution: string; card?: QuoteCard };
 
-// The fallback markdown text a quiz-card reply quotes: the question, plus the
-// subject's answer when they have a visible one. Shared by every surface that
-// starts such a reply so the blockquote old clients see reads the same.
 const quizCardQuoteText = (
   question: string,
   subjectAnswer: boolean | null,

--- a/frontend/components/conversation-screen/quote.tsx
+++ b/frontend/components/conversation-screen/quote.tsx
@@ -48,7 +48,17 @@ type MarkdownBlock = QuoteBlock | TextBlock;
 
 // Domain entities --------------------------------------------------------
 
-type Quote = { text: string; attribution: string };
+// The quiz card a reply is about. Travels with the quote from the feed to the
+// composer, then onto the message as `@question_id`; the quote's markdown is
+// only the fallback for clients that can't render the card.
+type QuoteCard = {
+  questionId: number
+  question: string
+  topic: string
+  subjectAnswer: boolean | null
+};
+
+type Quote = { text: string; attribution: string; card?: QuoteCard };
 
 // ──────────────────────────────────────────────────────────────────────────
 // Constants / Regexes
@@ -214,6 +224,26 @@ const quoteToMessageMarkdown = (quote: Quote | null) => {
   return _quoteToMarkdown({ text: portion, attribution: quote!.attribution }, false);
 };
 
+/**
+ * The typed part of a message whose leading blockquote is rendered some other
+ * way (e.g. as a live quiz card): everything after the message's first quote
+ * block.
+ */
+const stripLeadingQuoteBlock = (markdown: string): string => {
+  const lines = markdown.split(/\r?\n/);
+
+  let i = 0;
+  while (i < lines.length && lines[i].trim().startsWith('>')) {
+    i++;
+  }
+
+  if (i === 0) {
+    return markdown;
+  }
+
+  return lines.slice(i).join('\n').trim();
+};
+
 // ──────────────────────────────────────────────────────────────────────────
 // Event‑based Quote store (unchanged)
 // ──────────────────────────────────────────────────────────────────────────
@@ -246,9 +276,11 @@ export {
   parseMarkdown,
   Quote,
   QuoteBlock,
+  QuoteCard,
   quoteToMessageMarkdown,
   quoteToPreviewMarkdown,
   setQuote,
+  stripLeadingQuoteBlock,
   TextBlock,
   TextToken,
   tokenizeInline,

--- a/frontend/components/feed-tab.tsx
+++ b/frontend/components/feed-tab.tsx
@@ -52,7 +52,7 @@ import { Flag } from "react-native-feather";
 import { AudioPlayer } from './audio-player';
 import { useSkipped } from '../hide-and-block/hide-and-block';
 import { TopNavBarButton } from './top-nav-bar-button';
-import { setQuote } from './conversation-screen/quote';
+import { QuoteCard, setQuote } from './conversation-screen/quote';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faReply } from '@fortawesome/free-solid-svg-icons/faReply';
 import { OnlineIndicator } from './online-indicator';
@@ -155,6 +155,9 @@ const AnsweredQuestionFieldsSchema = DataItemBaseSchema.extend({
   question_count_no: z.number(),
   question_yes_members: z.array(FacepileMemberSchema),
   question_no_members: z.array(FacepileMemberSchema),
+  // The feed subject's answer while it's publicly visible, so replying can
+  // quote it
+  question_subject_answer: z.boolean().nullable(),
   // The viewer's own answer, private or not; `public_` is null when they
   // haven't answered
   question_viewer: FacepileViewerSchema.extend({
@@ -347,17 +350,18 @@ const useNavigationToConversation = (
   photoUuid: string | null,
   photoBlurhash: string | null,
   quote: string,
+  card?: QuoteCard,
 ) => {
   const navigation = useNavigation<NativeStackNavigationProp<RootParamList>>();
 
   return useCallback((e: GestureResponderEvent) => {
     e.preventDefault();
 
-    setQuote({ text: quote, attribution: name });
+    setQuote({ text: quote, attribution: name, card });
 
     setProspectHint(personUuid, { name, photoUuid, photoBlurhash });
     navigation.navigate('Conversation Screen', { personUuid });
-  }, [personUuid, name, photoUuid, photoBlurhash, quote]);
+  }, [personUuid, name, photoUuid, photoBlurhash, quote, card]);
 };
 
 const AgeGenderLocation = ({
@@ -1149,6 +1153,41 @@ const QuestionFacepiles = ({
   );
 };
 
+const ReplyFooter = ({
+  onPress,
+}: {
+  onPress: (e: GestureResponderEvent) => void,
+}) => {
+  const { appTheme } = useAppTheme();
+
+  return (
+    <View style={{ alignItems: 'flex-end' }} >
+      <Pressable
+        style={{
+          flexDirection: 'row',
+          gap: 6,
+          paddingRight: 5,
+        }}
+        hitSlop={20}
+        onPress={onPress}
+      >
+        <DefaultText style={{ fontWeight: 700 }}>
+          Reply
+        </DefaultText>
+        <FontAwesomeIcon
+          icon={faReply}
+          size={16}
+          color={appTheme.secondaryColor}
+          style={{
+            /* @ts-ignore */
+            outline: 'none',
+          }}
+        />
+      </Pressable>
+    </View>
+  );
+};
+
 const FeedItemAnsweredQuestion = ({
   fields
 }: {
@@ -1179,6 +1218,24 @@ const FeedItemAnsweredQuestion = ({
     (public_: boolean) => setAnswerPublicly(
       fields.answered_question_id, public_),
     [fields.answered_question_id],
+  );
+
+  const quoteText = fields.question_subject_answer === null
+    ? fields.question_text
+    : `${fields.question_text} — ${fields.question_subject_answer ? 'Yes' : 'No'}`;
+
+  const onPressReply = useNavigationToConversation(
+    fields.person_uuid,
+    fields.name,
+    fields.photo_uuid,
+    fields.photo_blurhash,
+    quoteText,
+    {
+      questionId: fields.answered_question_id,
+      question: fields.question_text,
+      topic: fields.question_topic,
+      subjectAnswer: fields.question_subject_answer,
+    },
   );
 
   const props = isMobile() ? {
@@ -1260,6 +1317,7 @@ const FeedItemAnsweredQuestion = ({
         >
           {fields.question_text}
         </NonInteractiveQuizCard>
+        <ReplyFooter onPress={onPressReply} />
       </Animated.View>
     </View>
   );
@@ -1496,30 +1554,7 @@ const FeedItemUpdatedBio = ({
               {fields.added_text}
             </DefaultText>
           </View>
-          <View style={{ alignItems: 'flex-end' }} >
-            <Pressable
-              style={{
-                flexDirection: 'row',
-                gap: 6,
-                paddingRight: 5,
-              }}
-              hitSlop={20}
-              onPress={onPressReply}
-            >
-              <DefaultText style={{ fontWeight: 700 }}>
-                Reply
-              </DefaultText>
-              <FontAwesomeIcon
-                icon={faReply}
-                size={16}
-                color={appTheme.secondaryColor}
-                style={{
-                  /* @ts-ignore */
-                  outline: 'none',
-                }}
-              />
-            </Pressable>
-          </View>
+          <ReplyFooter onPress={onPressReply} />
         </View>
       </Animated.View>
     </Pressable>

--- a/frontend/components/feed-tab.tsx
+++ b/frontend/components/feed-tab.tsx
@@ -52,9 +52,9 @@ import { Flag } from "react-native-feather";
 import { AudioPlayer } from './audio-player';
 import { useSkipped } from '../hide-and-block/hide-and-block';
 import { TopNavBarButton } from './top-nav-bar-button';
-import { QuoteCard, setQuote } from './conversation-screen/quote';
-import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
-import { faReply } from '@fortawesome/free-solid-svg-icons/faReply';
+import { quizCardQuoteText } from './conversation-screen/quote';
+import { useNavigationToConversation } from '../navigation/use-navigation-to-conversation';
+import { ReplyButton } from './reply-button';
 import { OnlineIndicator } from './online-indicator';
 import { useAppTheme } from '../app-theme/app-theme';
 import { usePressableAnimation } from '../animation/animation';
@@ -342,26 +342,6 @@ const useNavigationToProfileGallery = (photoUuid: string) => {
       }
     );
   }, [photoUuid]);
-};
-
-const useNavigationToConversation = (
-  personUuid: string,
-  name: string,
-  photoUuid: string | null,
-  photoBlurhash: string | null,
-  quote: string,
-  card?: QuoteCard,
-) => {
-  const navigation = useNavigation<NativeStackNavigationProp<RootParamList>>();
-
-  return useCallback((e: GestureResponderEvent) => {
-    e.preventDefault();
-
-    setQuote({ text: quote, attribution: name, card });
-
-    setProspectHint(personUuid, { name, photoUuid, photoBlurhash });
-    navigation.navigate('Conversation Screen', { personUuid });
-  }, [personUuid, name, photoUuid, photoBlurhash, quote, card]);
 };
 
 const AgeGenderLocation = ({
@@ -1153,41 +1133,6 @@ const QuestionFacepiles = ({
   );
 };
 
-const ReplyFooter = ({
-  onPress,
-}: {
-  onPress: (e: GestureResponderEvent) => void,
-}) => {
-  const { appTheme } = useAppTheme();
-
-  return (
-    <View style={{ alignItems: 'flex-end' }} >
-      <Pressable
-        style={{
-          flexDirection: 'row',
-          gap: 6,
-          paddingRight: 5,
-        }}
-        hitSlop={20}
-        onPress={onPress}
-      >
-        <DefaultText style={{ fontWeight: 700 }}>
-          Reply
-        </DefaultText>
-        <FontAwesomeIcon
-          icon={faReply}
-          size={16}
-          color={appTheme.secondaryColor}
-          style={{
-            /* @ts-ignore */
-            outline: 'none',
-          }}
-        />
-      </Pressable>
-    </View>
-  );
-};
-
 const FeedItemAnsweredQuestion = ({
   fields
 }: {
@@ -1220,9 +1165,8 @@ const FeedItemAnsweredQuestion = ({
     [fields.answered_question_id],
   );
 
-  const quoteText = fields.question_subject_answer === null
-    ? fields.question_text
-    : `${fields.question_text} — ${fields.question_subject_answer ? 'Yes' : 'No'}`;
+  const quoteText = quizCardQuoteText(
+    fields.question_text, fields.question_subject_answer);
 
   const onPressReply = useNavigationToConversation(
     fields.person_uuid,
@@ -1314,10 +1258,10 @@ const FeedItemAnsweredQuestion = ({
           }}
           maxFontSize={18}
           extraChildren={extraChildren}
+          onPressReply={onPressReply}
         >
           {fields.question_text}
         </NonInteractiveQuizCard>
-        <ReplyFooter onPress={onPressReply} />
       </Animated.View>
     </View>
   );
@@ -1554,7 +1498,7 @@ const FeedItemUpdatedBio = ({
               {fields.added_text}
             </DefaultText>
           </View>
-          <ReplyFooter onPress={onPressReply} />
+          <ReplyButton onPress={onPressReply} />
         </View>
       </Animated.View>
     </Pressable>

--- a/frontend/components/in-depth-screen.tsx
+++ b/frontend/components/in-depth-screen.tsx
@@ -296,8 +296,6 @@ const InDepthAnswer = ({
     },
   );
 
-  // No reply affordance when viewing your own answers, or before a deep-link
-  // has resolved who the prospect is.
   const canReply = !isViewingSelf && !!personUuid;
 
   return (
@@ -363,8 +361,6 @@ const CurredInDepthScreen = ({navigationRef, navigation, route}: NativeStackScre
   const personUuid: string | undefined = route?.params?.personUuid;
   const initialHint = getProspectHint(personUuid) ?? {};
 
-  // Optimistic avatar data for the reply flow's prospect hint; the conversation
-  // screen fetches the authoritative copy either way.
   const photoUuid = initialHint.photoUuid ?? null;
   const photoBlurhash = initialHint.photoBlurhash ?? null;
 

--- a/frontend/components/in-depth-screen.tsx
+++ b/frontend/components/in-depth-screen.tsx
@@ -24,6 +24,8 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { ProspectParamList } from '../navigation/linking';
 import { useSignedInUser } from '../events/signed-in-user';
 import { getProspectHint, setProspectHint } from '../navigation/prospect-cache';
+import { useNavigationToConversation } from '../navigation/use-navigation-to-conversation';
+import { quizCardQuoteText } from './conversation-screen/quote';
 
 type CompareAnswer = {
   question_id: number,
@@ -257,7 +259,19 @@ const InDepthScreen = (navigationRef: ProspectNavigationRef) => {
   />;
 }
 
-const InDepthAnswer = ({personId, item}: {personId: number, item: CompareAnswer}) => {
+const InDepthAnswer = ({
+  personId,
+  personUuid,
+  photoUuid,
+  photoBlurhash,
+  item,
+}: {
+  personId: number,
+  personUuid: string | undefined,
+  photoUuid: string | null,
+  photoBlurhash: string | null,
+  item: CompareAnswer,
+}) => {
   const [signedInUser] = useSignedInUser();
   const isViewingSelf = personId === signedInUser?.personId;
 
@@ -268,6 +282,24 @@ const InDepthAnswer = ({personId, item}: {personId: number, item: CompareAnswer}
   const prospectAnswer =
     isViewingSelf ? viewerAnswer.answer : item.prospect_answer;
 
+  const onPressReply = useNavigationToConversation(
+    personUuid ?? '',
+    item.prospect_name,
+    photoUuid,
+    photoBlurhash,
+    quizCardQuoteText(item.question, prospectAnswer),
+    {
+      questionId: item.question_id,
+      question: item.question,
+      topic: item.topic,
+      subjectAnswer: prospectAnswer,
+    },
+  );
+
+  // No reply affordance when viewing your own answers, or before a deep-link
+  // has resolved who the prospect is.
+  const canReply = !isViewingSelf && !!personUuid;
+
   return (
     <AnsweredQuizCard
       questionNumber={item.question_id}
@@ -275,16 +307,35 @@ const InDepthAnswer = ({personId, item}: {personId: number, item: CompareAnswer}
       user1={item.prospect_name}
       answer1={prospectAnswer}
       user2="You"
+      onPressReply={canReply ? onPressReply : undefined}
     >
       {item.question}
     </AnsweredQuizCard>
   );
 };
 
-const InDepthItem = ({personId, item}: {personId: number, item: InDepthListItem}) => {
+const InDepthItem = ({
+  personId,
+  personUuid,
+  photoUuid,
+  photoBlurhash,
+  item,
+}: {
+  personId: number,
+  personUuid: string | undefined,
+  photoUuid: string | null,
+  photoBlurhash: string | null,
+  item: InDepthListItem,
+}) => {
   switch (item.kind) {
     case 'answer':
-      return <InDepthAnswer personId={personId} item={item.item} />;
+      return <InDepthAnswer
+        personId={personId}
+        personUuid={personUuid}
+        photoUuid={photoUuid}
+        photoBlurhash={photoBlurhash}
+        item={item.item}
+      />;
     case 'mbti':
     case 'big5':
     case 'politics':
@@ -311,6 +362,11 @@ const CurredInDepthScreen = ({navigationRef, navigation, route}: NativeStackScre
   // to fetching `/prospect-profile/:personUuid` here.
   const personUuid: string | undefined = route?.params?.personUuid;
   const initialHint = getProspectHint(personUuid) ?? {};
+
+  // Optimistic avatar data for the reply flow's prospect hint; the conversation
+  // screen fetches the authoritative copy either way.
+  const photoUuid = initialHint.photoUuid ?? null;
+  const photoBlurhash = initialHint.photoBlurhash ?? null;
 
   const [personId, setPersonId] = useState<number | undefined>(
     initialHint.personId);
@@ -437,7 +493,13 @@ const CurredInDepthScreen = ({navigationRef, navigation, route}: NativeStackScre
             />
           }
           renderItem={({item}) =>
-            <InDepthItemMemo personId={personId} item={item} />
+            <InDepthItemMemo
+              personId={personId}
+              personUuid={personUuid}
+              photoUuid={photoUuid}
+              photoBlurhash={photoBlurhash}
+              item={item}
+            />
           }
           disableRefresh={true}
         />

--- a/frontend/components/quiz-card.tsx
+++ b/frontend/components/quiz-card.tsx
@@ -1,6 +1,7 @@
 import {
   Animated,
   Dimensions,
+  GestureResponderEvent,
   ImageBackground,
   Pressable,
   View,
@@ -31,6 +32,7 @@ import {
 import { IndeterminateProgressBar } from './indeterminate-progress-bar';
 import { Logo14 } from './logo';
 import { useAppTheme } from '../app-theme/app-theme';
+import { ReplyButton } from './reply-button';
 import { formatCount } from '../util/util';
 import { SearchFilterAnswer } from '../navigation/search-filter-state';
 
@@ -265,6 +267,10 @@ const NonInteractiveQuizCard = ({children, ...props}: {
   imageBackgroundStyle?: ViewStyle,
   showAnswerPubliclyCheckBox?: boolean,
   showTutorial?: boolean,
+  // When set, a "Reply" button is rendered inside the card, so replying to a
+  // quiz card works the same wherever the card appears (the feed, the In-Depth
+  // screen). Omitted where a reply makes no sense, e.g. inside a conversation.
+  onPressReply?: (e: GestureResponderEvent) => void,
 }) => {
   const {
     extraChildren,
@@ -279,6 +285,7 @@ const NonInteractiveQuizCard = ({children, ...props}: {
     imageBackgroundStyle,
     showAnswerPubliclyCheckBox = true,
     showTutorial = false,
+    onPressReply,
   } = props;
 
   const { appTheme } = useAppTheme();
@@ -502,6 +509,11 @@ const NonInteractiveQuizCard = ({children, ...props}: {
             </StatelessCheckBox>
           }
           {extraChildren}
+          {onPressReply &&
+            <View style={{ paddingRight: 10, paddingBottom: 14 }}>
+              <ReplyButton onPress={onPressReply} />
+            </View>
+          }
           {!extraChildren &&
             <LinearGradient
               locations={[
@@ -631,6 +643,7 @@ const AnsweredQuizCard = ({
   user1,
   answer1,
   user2,
+  onPressReply,
 }: {
   children: string,
   questionNumber: number
@@ -638,6 +651,7 @@ const AnsweredQuizCard = ({
   user1: string,
   answer1: boolean | null,
   user2: string,
+  onPressReply?: (e: GestureResponderEvent) => void,
 }) => {
   const viewerAnswer = useViewerAnswer(questionNumber);
 
@@ -731,6 +745,7 @@ const AnsweredQuizCard = ({
       }}
       maxFontSize={18}
       extraChildren={extraChildren}
+      onPressReply={onPressReply}
     >
       {children}
     </NonInteractiveQuizCard>

--- a/frontend/components/quiz-card.tsx
+++ b/frontend/components/quiz-card.tsx
@@ -267,9 +267,6 @@ const NonInteractiveQuizCard = ({children, ...props}: {
   imageBackgroundStyle?: ViewStyle,
   showAnswerPubliclyCheckBox?: boolean,
   showTutorial?: boolean,
-  // When set, a "Reply" button is rendered inside the card, so replying to a
-  // quiz card works the same wherever the card appears (the feed, the In-Depth
-  // screen). Omitted where a reply makes no sense, e.g. inside a conversation.
   onPressReply?: (e: GestureResponderEvent) => void,
 }) => {
   const {

--- a/frontend/components/reply-button.tsx
+++ b/frontend/components/reply-button.tsx
@@ -1,3 +1,8 @@
+/**
+ * The right-aligned "Reply" affordance shared by every surface that lets you
+ * quote something into a conversation: bio-update feed items and quiz cards
+ * (which render it inside the card via `NonInteractiveQuizCard`).
+ */
 import {
   GestureResponderEvent,
   Pressable,
@@ -8,9 +13,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
 import { faReply } from '@fortawesome/free-solid-svg-icons/faReply';
 import { useAppTheme } from '../app-theme/app-theme';
 
-// The right-aligned "Reply" affordance shared by every surface that lets you
-// quote something into a conversation: bio-update feed items and quiz cards
-// (which render it inside the card via `NonInteractiveQuizCard`).
 const ReplyButton = ({
   onPress,
 }: {

--- a/frontend/components/reply-button.tsx
+++ b/frontend/components/reply-button.tsx
@@ -1,0 +1,51 @@
+import {
+  GestureResponderEvent,
+  Pressable,
+  View,
+} from 'react-native';
+import { DefaultText } from './default-text';
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import { faReply } from '@fortawesome/free-solid-svg-icons/faReply';
+import { useAppTheme } from '../app-theme/app-theme';
+
+// The right-aligned "Reply" affordance shared by every surface that lets you
+// quote something into a conversation: bio-update feed items and quiz cards
+// (which render it inside the card via `NonInteractiveQuizCard`).
+const ReplyButton = ({
+  onPress,
+}: {
+  onPress: (e: GestureResponderEvent) => void,
+}) => {
+  const { appTheme } = useAppTheme();
+
+  return (
+    <View style={{ alignItems: 'flex-end' }} >
+      <Pressable
+        style={{
+          flexDirection: 'row',
+          gap: 6,
+          paddingRight: 5,
+        }}
+        hitSlop={20}
+        onPress={onPress}
+      >
+        <DefaultText style={{ fontWeight: 700 }}>
+          Reply
+        </DefaultText>
+        <FontAwesomeIcon
+          icon={faReply}
+          size={16}
+          color={appTheme.secondaryColor}
+          style={{
+            /* @ts-ignore */
+            outline: 'none',
+          }}
+        />
+      </Pressable>
+    </View>
+  );
+};
+
+export {
+  ReplyButton,
+};

--- a/frontend/navigation/use-navigation-to-conversation.tsx
+++ b/frontend/navigation/use-navigation-to-conversation.tsx
@@ -1,3 +1,10 @@
+/**
+ * Stages a quote (optionally carrying a quiz card) and opens the conversation
+ * with `personUuid`. Shared by every "Reply" affordance -- the feed and the
+ * In-Depth screen -- so they can't drift on how a reply is set up. The target
+ * route lives in the root navigator, which `navigate` resolves from any nested
+ * screen, so this works from the prospect navigator too.
+ */
 import { useCallback } from 'react';
 import { GestureResponderEvent } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
@@ -6,11 +13,6 @@ import type { RootParamList } from './linking';
 import { QuoteCard, setQuote } from '../components/conversation-screen/quote';
 import { setProspectHint } from './prospect-cache';
 
-// Stages a quote (optionally carrying a quiz card) and opens the conversation
-// with `personUuid`. Shared by every "Reply" affordance -- the feed and the
-// In-Depth screen -- so they can't drift on how a reply is set up. The target
-// route lives in the root navigator, which `navigate` resolves from any nested
-// screen, so this works from the prospect navigator too.
 const useNavigationToConversation = (
   personUuid: string,
   name: string,

--- a/frontend/navigation/use-navigation-to-conversation.tsx
+++ b/frontend/navigation/use-navigation-to-conversation.tsx
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+import { GestureResponderEvent } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RootParamList } from './linking';
+import { QuoteCard, setQuote } from '../components/conversation-screen/quote';
+import { setProspectHint } from './prospect-cache';
+
+// Stages a quote (optionally carrying a quiz card) and opens the conversation
+// with `personUuid`. Shared by every "Reply" affordance -- the feed and the
+// In-Depth screen -- so they can't drift on how a reply is set up. The target
+// route lives in the root navigator, which `navigate` resolves from any nested
+// screen, so this works from the prospect navigator too.
+const useNavigationToConversation = (
+  personUuid: string,
+  name: string,
+  photoUuid: string | null,
+  photoBlurhash: string | null,
+  quote: string,
+  card?: QuoteCard,
+) => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootParamList>>();
+
+  return useCallback((e: GestureResponderEvent) => {
+    e.preventDefault();
+
+    setQuote({ text: quote, attribution: name, card });
+
+    setProspectHint(personUuid, { name, photoUuid, photoBlurhash });
+    navigation.navigate('Conversation Screen', { personUuid });
+  }, [personUuid, name, photoUuid, photoBlurhash, quote, card]);
+};
+
+export {
+  useNavigationToConversation,
+};


### PR DESCRIPTION
Closes #1092

## What this does

- **Reply button on quiz-card feed items**, identical to the bio one (extracted into a shared `ReplyFooter`). The feed payload gains `question_subject_answer` so the reply can quote what the person answered.
- **The answered quiz card appears as part of the conversation.** The reply carries a new optional `@question_id` attribute, stored on both `mam_message` copies (nullable column, idempotent migration, no FK — the chat server validates ids at a choke point instead, and invalid references degrade to plain text). The server serves the card on live delivery and MAM fetches: question text/topic, the viewer's own answer unfiltered (it seeds the client answer store, including its private flag), and the partner's answer only while `public_`.
- **Real-time answer updates.** Answer writes in `qanda` compute a visible-state transition and publish `duo_answer_update` on a per-user `answers-{uuid}` Redis channel (new `answerspush` module, mirroring `visitorspush`). Chat connections join that channel automatically alongside the existing `duo_subscribe_online` subscription, so the conversation screen gets updates for free. Only publicly visible transitions are published — private→private edits produce no event at all, so privacy is respected by construction.
- **Backwards compatible.** The message body still carries the same markdown blockquote a bio reply produces today, so old clients render a normal quoted reply; inbox previews, push notifications, and intro gating (spam/robot9000/rate limits) are unchanged. New clients strip the leading blockquote and render a live `AnsweredQuizCard` instead: the partner's side updates in place (and hides if they make their answer private), and the viewer's side is tappable through the existing `answer.tsx` write choke point.

## Tests

- New `backend/test/functionality6/xmpp-question-card.sh`: storage on both archive copies, card attributes on live delivery and MAM, publicness filtering (including making an answer private mid-conversation), live `duo_answer_update` semantics (public transitions push, private activity never does), and invalid-id degradation.
- `backend/test/functionality1/feed-v2.sh` updated for `question_subject_answer`.
- `tsc --noEmit` and `py_compile` pass.

## Deploy notes

Backend before frontend: the client's zod schema requires `question_subject_answer`, so old backends would make new clients drop quiz-card feed items. The migration is instant (nullable column, no index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)