### PR TITLE
Make `docker compose up` start without an OpenAI key

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ The frontend's default API URLs already point at the backend's published
 localhost ports, so the web app talks to your local backend with no extra
 configuration.
 
+The stack runs without any secrets. `OPENAI_API_KEY` is optional: leave it
+unset for local development and the app still starts, but the OpenAI-backed
+features (account verification and club SEO descriptions) stay disabled until
+you export a key before `docker compose up`. See
+[`backend/DEVELOPER.md`](backend/DEVELOPER.md) for the full list of environment
+variables.
+
 To seed a test user once the API is healthy:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -87,10 +87,13 @@ The frontend's default API URLs already point at the backend's published
 localhost ports, so the web app talks to your local backend with no extra
 configuration.
 
-The stack runs without any secrets. `OPENAI_API_KEY` is optional: leave it
-unset for local development and the app still starts, but the OpenAI-backed
-features (account verification and club SEO descriptions) stay disabled until
-you export a key before `docker compose up`. See
+The local `docker compose up` stack runs without any secrets — it mocks the
+OpenAI-backed features (account verification and club SEO descriptions), so you
+don't need a key for development.
+
+A real deployment **requires** `OPENAI_API_KEY`: the cron container fails fast
+at startup with a clear error if it's unset, so a misconfigured deploy is
+obvious immediately rather than silently shipping broken verification. See
 [`backend/DEVELOPER.md`](backend/DEVELOPER.md) for the full list of environment
 variables.
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,10 @@ The local `docker compose up` stack runs without any secrets — it mocks the
 OpenAI-backed features (account verification and club SEO descriptions), so you
 don't need a key for development.
 
-A real deployment **requires** `OPENAI_API_KEY`: the cron container fails fast
-at startup with a clear error if it's unset, so a misconfigured deploy is
-obvious immediately rather than silently shipping broken verification. See
-[`backend/DEVELOPER.md`](backend/DEVELOPER.md) for the full list of environment
-variables.
+A real deployment **requires** `OPENAI_API_KEY`: the cron container won't start
+without it, so a misconfigured deploy fails fast instead of silently shipping
+broken verification. See [`backend/DEVELOPER.md`](backend/DEVELOPER.md) for the
+full list of environment variables.
 
 To seed a test user once the API is healthy:
 

--- a/backend/DEVELOPER.md
+++ b/backend/DEVELOPER.md
@@ -142,7 +142,7 @@ These environment variables specify where user-uploaded content is stored:
 
 These env vars get passed to the `boto3` library, so they're compatible with AWS S3 despite containing `R2` in their names. The `api` container needs to have permissions to upload files to these buckets. Deletion is handled by the `cron` container.
 
-* `OPENAI_API_KEY` - The OpenAI API key used to query ChatGPT while verifying accounts.
+* `OPENAI_API_KEY` - The OpenAI API key used to query ChatGPT while verifying accounts and generating club SEO descriptions. Required by the `cron` container, which fails fast at startup if it's unset (unless `DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION` is set, as it is in the dev and test stacks).
 
 #### Redis
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -150,6 +150,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       DUO_VERIFICATION_IMAGE_BASE_URL: http://s3mock:9090/s3-mock-bucket
       DUO_VERIFICATION_MOCK_RESPONSE_FILE: test/input/verification-mock-response-file
+      DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION: 'A friendly description for this club.'
 
       DUO_CRON_GARBAGE_RECORDS_POLL_SECONDS: '1'
 

--- a/backend/service/cron/clubseo/__init__.py
+++ b/backend/service/cron/clubseo/__init__.py
@@ -103,7 +103,11 @@ CLUB_OVERLAP_POLL_SECONDS = int(os.environ.get(
 # exercise the cron without an API key.
 CLUB_SEO_MOCK_DESCRIPTION = os.environ.get('DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION')
 
-_openai_client = AsyncOpenAI() if not CLUB_SEO_MOCK_DESCRIPTION else None
+_openai_client = (
+    AsyncOpenAI()
+    if not CLUB_SEO_MOCK_DESCRIPTION and os.environ.get('OPENAI_API_KEY')
+    else None
+)
 
 
 async def refresh_club_stats_once() -> None:
@@ -359,6 +363,8 @@ async def _process_club_seo_row(
 
 
 async def refresh_club_seo_once() -> None:
+    if _openai_client is None and not CLUB_SEO_MOCK_DESCRIPTION:
+        return
     if not is_offpeak(CLUB_SEO_MAX_LOAD_PCT, 'refresh_club_seo_once'):
         return
 

--- a/backend/service/cron/clubseo/__init__.py
+++ b/backend/service/cron/clubseo/__init__.py
@@ -103,14 +103,6 @@ CLUB_OVERLAP_POLL_SECONDS = int(os.environ.get(
 # exercise the cron without an API key.
 CLUB_SEO_MOCK_DESCRIPTION = os.environ.get('DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION')
 
-if not CLUB_SEO_MOCK_DESCRIPTION and not os.environ.get('OPENAI_API_KEY'):
-    raise RuntimeError(
-        'OPENAI_API_KEY is not set. The cron container needs it to generate '
-        'club SEO descriptions. Set OPENAI_API_KEY, or set '
-        'DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION to run without OpenAI, as the dev '
-        'and test stacks do.'
-    )
-
 _openai_client = AsyncOpenAI() if not CLUB_SEO_MOCK_DESCRIPTION else None
 
 

--- a/backend/service/cron/clubseo/__init__.py
+++ b/backend/service/cron/clubseo/__init__.py
@@ -103,11 +103,15 @@ CLUB_OVERLAP_POLL_SECONDS = int(os.environ.get(
 # exercise the cron without an API key.
 CLUB_SEO_MOCK_DESCRIPTION = os.environ.get('DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION')
 
-_openai_client = (
-    AsyncOpenAI()
-    if not CLUB_SEO_MOCK_DESCRIPTION and os.environ.get('OPENAI_API_KEY')
-    else None
-)
+if not CLUB_SEO_MOCK_DESCRIPTION and not os.environ.get('OPENAI_API_KEY'):
+    raise RuntimeError(
+        'OPENAI_API_KEY is not set. The cron container needs it to generate '
+        'club SEO descriptions. Set OPENAI_API_KEY, or set '
+        'DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION to run without OpenAI, as the dev '
+        'and test stacks do.'
+    )
+
+_openai_client = AsyncOpenAI() if not CLUB_SEO_MOCK_DESCRIPTION else None
 
 
 async def refresh_club_stats_once() -> None:
@@ -363,8 +367,6 @@ async def _process_club_seo_row(
 
 
 async def refresh_club_seo_once() -> None:
-    if _openai_client is None and not CLUB_SEO_MOCK_DESCRIPTION:
-        return
     if not is_offpeak(CLUB_SEO_MAX_LOAD_PCT, 'refresh_club_seo_once'):
         return
 


### PR DESCRIPTION
Fixes #1319

## Background

Running `docker compose up` from a fresh checkout failed to bring up the app. The `cron` container exited immediately because `service/cron/clubseo` creates an OpenAI client at import time:

```python
_openai_client = AsyncOpenAI() if not CLUB_SEO_MOCK_DESCRIPTION else None
```

`AsyncOpenAI()` raises when `OPENAI_API_KEY` is not set, so any environment without a key — including a new contributor's laptop — crashes on startup. On top of that, the README never mentioned that a key was needed, so the failure was hard to diagnose.

## Goal

Two requirements that pull in opposite directions:

1. **Local development should be easy.** A new contributor should be able to run `docker compose up` and have the app start, without signing up for an OpenAI account or setting any secrets.
2. **Production should fail fast.** If the app is deployed without an OpenAI key, verification and club-SEO generation would be silently broken. It's better for the deploy to crash loudly at startup than to ship a subtly broken app.

Both are satisfied without making the container behave differently in dev vs. prod: the code is unchanged, and the only difference is the configuration each environment supplies.

## Changes

- **`backend/docker-compose.yml`** (the local dev stack): the `cron` service now sets `DUO_CRON_CLUB_SEO_MOCK_DESCRIPTION`. This existing option makes club-SEO generation return a fixed string instead of calling OpenAI, so `AsyncOpenAI()` is never constructed and the container starts without a key. This mirrors `DUO_VERIFICATION_MOCK_RESPONSE_FILE`, which already mocks account verification in the same service.
- **`README.md`** and **`backend/DEVELOPER.md`**: document that `OPENAI_API_KEY` is required for real deployments (the container won't start without it) and that local development doesn't need it because the dev stack mocks the OpenAI-backed features.

No application code changes — `service/cron/clubseo` is untouched, so a real deployment without a key still fails fast exactly as before.

## Resulting behavior

| Context | Result |
| --- | --- |
| `docker compose up` (local dev) | Starts with no configuration; OpenAI features are mocked |
| Automated test suite | Starts with the same mock; no key needed |
| Production deploy **with** a key | Unchanged |
| Production deploy **without** a key | Fails fast at cron startup |

🤖 Generated with [Claude Code](https://claude.com/claude-code)