### PR TITLE
Clear the quote when `AboutText` unmounts

### DIFF
--- a/frontend/components/prospect-profile-screen/about-reply.tsx
+++ b/frontend/components/prospect-profile-screen/about-reply.tsx
@@ -152,6 +152,10 @@ const AboutText = ({
     }
   }, [isFocused]);
 
+  useEffect(() => {
+    return () => setQuote(null);
+  }, []);
+
   return (
     <View style={{ position: 'relative', zIndex: 1000, marginBottom: 20 }}>
       {


### PR DESCRIPTION
Fixes #1325.

## The bug

Highlighting text on a profile sets a quote in the global quote store (`setQuote`). Backing out of the profile never cleared it, and the floating message button picks its icon from that store:

https://github.com/duolicious/duolicious-backend/blob/main/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx#L403

So a stale quote left the reply icon showing on every profile opened afterwards.

## The fix

`AboutText` now calls `setQuote(null)` on unmount. This mirrors the existing cleanup the conversation screen's input already does when it unmounts.

The cleanup lives on the outer `AboutText`, not on `WebAboutText` / `NativeAboutText` — those remount on every focus change via `remountKey`, which would clear the quote when returning to a profile from a conversation.

This doesn't disturb the reply flow: the Conversation Screen is pushed on top of the profile, which stays mounted underneath (the same assumption the `isFocused` logic in this file already relies on), so the cleanup doesn't fire while a quote is staged for sending.

## Testing

Typechecks clean (`npx tsc --noEmit`). Not verified in the running app — the repo's frontend tests are pure-logic unit tests with no component-render tooling, so the unmount effect isn't testable in that style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)