### PR TITLE
Fix weird facepiles for clubs with one member

### DIFF
--- a/backend/search/sql/__init__.py
+++ b/backend/search/sql/__init__.py
@@ -83,8 +83,6 @@ def _facepile(pool: str, member_condition: str = 'TRUE') -> str:
                     photo
                 WHERE
                     photo.person_id = member.id
-                AND
-                    COALESCE(photo.nsfw_score, 0) <= 0.2
                 ORDER BY
                     photo.position
                 LIMIT 1

--- a/frontend/components/feed-tab.tsx
+++ b/frontend/components/feed-tab.tsx
@@ -610,11 +610,11 @@ const facepileSpreadWidth = (slotCount: number) =>
 
 const FacepileAvatar = ({
   member,
-  spread,
+  navigatesOnPress,
   onRequestSpread,
 }: {
   member: FacepileMember
-  spread: boolean
+  navigatesOnPress: boolean
   onRequestSpread: () => void
 }) => {
   const handle = member.url_slug || member.person_uuid;
@@ -627,14 +627,14 @@ const FacepileAvatar = ({
   );
 
   const onPress = useCallback((e: GestureResponderEvent) => {
-    if (spread) {
+    if (navigatesOnPress) {
       navigateToProfile(e);
     } else {
       // Stop the web link navigating; the first press only spreads the pile
       e.preventDefault();
       onRequestSpread();
     }
-  }, [spread, navigateToProfile, onRequestSpread]);
+  }, [navigatesOnPress, navigateToProfile, onRequestSpread]);
 
   return (
     <Pressable onPress={onPress} {...makeLinkProps(`/${handle}`)}>
@@ -665,12 +665,12 @@ const FacepileAvatar = ({
 const ViewerFacepileAvatar = ({
   viewer,
   visible,
-  spread,
+  navigatesOnPress,
   onRequestSpread,
 }: {
   viewer: FacepileViewer
   visible: boolean
-  spread: boolean
+  navigatesOnPress: boolean
   onRequestSpread: () => void
 }) => {
   const { appTheme } = useAppTheme();
@@ -683,13 +683,13 @@ const ViewerFacepileAvatar = ({
   );
 
   const onPress = useCallback((e: GestureResponderEvent) => {
-    if (spread) {
+    if (navigatesOnPress) {
       navigateToProfile(e);
     } else {
       e.preventDefault();
       onRequestSpread();
     }
-  }, [spread, navigateToProfile, onRequestSpread]);
+  }, [navigatesOnPress, navigateToProfile, onRequestSpread]);
 
   const opacity = useSharedValue(visible ? 1 : 0);
 
@@ -787,9 +787,12 @@ const FacepileSlot = ({
 
 // While the pile is collapsed the avatars overlap, which makes them hard to
 // make out and to press, so the pile spreads on hover (desktop) or on a first
-// press (mobile) before individual avatars navigate anywhere. The avatar
-// beside `viewerPosition` is the anchor: the pile spreads away from it, so a
-// pile can sit against that edge of its container.
+// press (mobile) before individual avatars navigate anywhere. A pile showing a
+// single avatar has nothing to separate, so it never spreads and its avatar
+// navigates on the first press: spreading it would only nudge the lone avatar,
+// which reads as the press having done nothing. The avatar beside
+// `viewerPosition` is the anchor: the pile spreads away from it, so a pile can
+// sit against that edge of its container.
 const Facepile = ({
   members,
   viewer,
@@ -812,6 +815,12 @@ const Facepile = ({
   // The viewer slot is always rendered, so it always occupies layout width
   const slotCount = members.length + 1;
 
+  const isSpreadable = members.length + (viewerVisible ? 1 : 0) > 1;
+
+  const isSpread = spread && isSpreadable;
+
+  const navigatesOnPress = isSpread || !isSpreadable;
+
   const anchorDistanceOf = (documentOrder: number) =>
     viewerPosition === 'start'
       ? members.length - documentOrder
@@ -820,7 +829,7 @@ const Facepile = ({
   const offsetOf = (documentOrder: number) =>
     spreadDirection
       * anchorDistanceOf(documentOrder)
-      * (spread ? FACEPILE_SPREAD_STEP : 0);
+      * (isSpread ? FACEPILE_SPREAD_STEP : 0);
 
   const zIndexOf = (documentOrder: number) =>
     viewerPosition === 'start'
@@ -836,7 +845,7 @@ const Facepile = ({
       <ViewerFacepileAvatar
         viewer={viewer}
         visible={viewerVisible}
-        spread={spread}
+        navigatesOnPress={navigatesOnPress}
         onRequestSpread={onRequestSpread}
       />
     </FacepileSlot>
@@ -849,7 +858,7 @@ const Facepile = ({
         // Spread grows away from the anchor; keep the anchored edge fixed so
         // the collapsed cluster stays put and only the reserved side widens
         justifyContent: viewerPosition === 'start' ? 'flex-end' : 'flex-start',
-        width: spread
+        width: isSpread
           ? facepileSpreadWidth(slotCount)
           : facepileCollapsedWidth(slotCount),
       }}
@@ -881,7 +890,7 @@ const Facepile = ({
           >
             <FacepileAvatar
               member={member}
-              spread={spread}
+              navigatesOnPress={navigatesOnPress}
               onRequestSpread={onRequestSpread}
             />
           </FacepileSlot>

--- a/frontend/components/feed-tab.tsx
+++ b/frontend/components/feed-tab.tsx
@@ -787,15 +787,9 @@ const FacepileSlot = ({
 
 // While the pile is collapsed the avatars overlap, which makes them hard to
 // make out and to press, so the pile spreads on hover (desktop) or on a first
-// press (mobile) before individual avatars navigate anywhere. Spreading a pile
-// of one would only nudge its lone avatar, which reads as the press having done
-// nothing, so such a pile stays put and navigates on the first press instead.
-// The avatar beside `viewerPosition` is the anchor: the pile spreads away from
-// it, so a pile can sit against that edge of its container. The pile is a press
-// and hover region rather than a button, so it keeps the default cursor: the
-// avatars are the only things in it worth advertising as clickable, and they
-// bring their own. Without that, the invisible viewer slot would look pressable
-// even though the pointer falls straight through it to the pile.
+// press (mobile) before individual avatars navigate anywhere. The avatar
+// beside `viewerPosition` is the anchor: the pile spreads away from it, so a
+// pile can sit against that edge of its container.
 const Facepile = ({
   members,
   viewer,

--- a/frontend/components/feed-tab.tsx
+++ b/frontend/components/feed-tab.tsx
@@ -787,12 +787,15 @@ const FacepileSlot = ({
 
 // While the pile is collapsed the avatars overlap, which makes them hard to
 // make out and to press, so the pile spreads on hover (desktop) or on a first
-// press (mobile) before individual avatars navigate anywhere. A pile showing a
-// single avatar has nothing to separate, so it never spreads and its avatar
-// navigates on the first press: spreading it would only nudge the lone avatar,
-// which reads as the press having done nothing. The avatar beside
-// `viewerPosition` is the anchor: the pile spreads away from it, so a pile can
-// sit against that edge of its container.
+// press (mobile) before individual avatars navigate anywhere. Spreading a pile
+// of one would only nudge its lone avatar, which reads as the press having done
+// nothing, so such a pile stays put and navigates on the first press instead.
+// The avatar beside `viewerPosition` is the anchor: the pile spreads away from
+// it, so a pile can sit against that edge of its container. The pile is a press
+// and hover region rather than a button, so it keeps the default cursor: the
+// avatars are the only things in it worth advertising as clickable, and they
+// bring their own. Without that, the invisible viewer slot would look pressable
+// even though the pointer falls straight through it to the pile.
 const Facepile = ({
   members,
   viewer,
@@ -861,6 +864,7 @@ const Facepile = ({
         width: isSpread
           ? facepileSpreadWidth(slotCount)
           : facepileCollapsedWidth(slotCount),
+        cursor: 'auto',
       }}
       onPress={onRequestSpread}
       // Raw DOM events rather than onHoverIn/onHoverOut: Pressable's


### PR DESCRIPTION
Fixes #1324.

**The pile showed the wrong avatar.** It picked each member's first photo scoring under the NSFW threshold, so a member whose main photo scored over it appeared as their second photo. Nowhere else does the same person get that treatment: the feed item's hero avatar and the viewer's own facepile avatar both take the first photo unconditionally, so the pile disagreed with the face right next to it. The filter is dropped; members with no photo at all are still left out of the pile, as before.

**A one-avatar pile now navigates on the first press.** Spreading exists to separate overlapping avatars, so with only one there's nothing to separate — the press just nudged the avatar a few pixels and read as having done nothing. Piles with a single visible avatar no longer spread (on press or on hover), and that avatar goes straight to the profile. Both counts are of *visible* avatars, so a club with one member spreads normally once the viewer joins and their own avatar fades in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)