### PR TITLE
Make profile photos expand like on Instagram, X, and other popular social media apps

### DIFF
--- a/backend/commonsql/__init__.py
+++ b/backend/commonsql/__init__.py
@@ -6,6 +6,21 @@ EXISTS (SELECT 1 FROM person WHERE normalized_email = %(normalized_email)s)
 """
 
 
+# The JSON geometry describing how a photo's square renditions were cropped from
+# its original, or NULL when it hasn't been recorded (clients read NULL as
+# "don't animate the crop"). The row must be aliased `photo`. Interpolated into
+# the profile and feed queries rather than kept as a Postgres function, so the
+# shaping lives in the application instead of the database.
+PHOTO_GEOMETRY = """
+    CASE WHEN photo.width IS NOT NULL THEN json_build_object(
+        'width',     photo.width,
+        'height',    photo.height,
+        'crop_top',  photo.crop_top,
+        'crop_left', photo.crop_left
+    ) END
+"""
+
+
 Q_UPDATE_VERIFICATION_LEVEL_ASSIGN = """
     verification_level_id = CASE
         WHEN EXISTS (

--- a/backend/commonsql/__init__.py
+++ b/backend/commonsql/__init__.py
@@ -6,11 +6,9 @@ EXISTS (SELECT 1 FROM person WHERE normalized_email = %(normalized_email)s)
 """
 
 
-# The JSON geometry describing how a photo's square renditions were cropped from
-# its original, or NULL when it hasn't been recorded (clients read NULL as
-# "don't animate the crop"). The row must be aliased `photo`. Interpolated into
-# the profile and feed queries rather than kept as a Postgres function, so the
-# shaping lives in the application instead of the database.
+# How a photo's square renditions were cropped from the original, or NULL when
+# unrecorded (clients read NULL as "don't animate the crop"). The row must be
+# aliased `photo`.
 PHOTO_GEOMETRY = """
     CASE WHEN photo.width IS NOT NULL THEN json_build_object(
         'width',     photo.width,

--- a/backend/duophoto/__init__.py
+++ b/backend/duophoto/__init__.py
@@ -1,11 +1,10 @@
 from dataclasses import dataclass
-from PIL import Image
+from PIL import Image, ImageOps
 import numpy
 
-# How a photo's square renditions (`900-{uuid}.jpg`, `450-{uuid}.jpg`) relate to
-# the original it was cut from (`original-{uuid}.jpg`). Lives here rather than
-# in `person` so the crop backfill (`service/cron/photocrop`) can share the
-# definition without importing the API.
+# How a photo's square renditions relate to the original they were cut from.
+# Lives here rather than in `person` so the crop backfill
+# (`service/cron/photocrop`) can share the definition without importing the API.
 
 @dataclass
 class CropSize:
@@ -22,46 +21,10 @@ class PhotoGeometry:
     crop_left: int
 
 def orient_image(image: Image.Image) -> Image.Image:
-    # Rotate the image according to EXIF data
-    try:
-        exif = image.getexif()
-        orientation = exif[274] # 274 is the exif code for the orientation tag
-    except:
-        orientation = None
+    return ImageOps.exif_transpose(image) or image
 
-    if orientation is None:
-        pass
-    elif orientation == 1:
-        # Normal, no changes needed
-        pass
-    elif orientation == 2:
-        # Mirrored horizontally
-        pass
-    elif orientation == 3:
-        # Rotated 180 degrees
-        image = image.rotate(180, expand=True)
-    elif orientation == 4:
-        # Mirrored vertically
-        pass
-    elif orientation == 5:
-        # Transposed
-        image = image.rotate(-90, expand=True)
-    elif orientation == 6:
-        # Rotated -90 degrees
-        image = image.rotate(-90, expand=True)
-    elif orientation == 7:
-        # Transverse
-        image = image.rotate(90, expand=True)
-    elif orientation == 8:
-        # Rotated 90 degrees
-        image = image.rotate(90, expand=True)
-
-    return image
-
-# The single source of truth for how a square rendition relates to the oriented
-# original. The renditions are cut with it and it's persisted alongside them, so
-# the two can't drift. `width` and `height` must be the dimensions of an
-# already-oriented image, i.e. `orient_image(...).size`.
+# The renditions are cut with this and it's persisted alongside them, so the
+# two can't drift. `width` and `height` must be `orient_image(...).size`.
 def photo_geometry(
     width: int,
     height: int,
@@ -73,15 +36,14 @@ def photo_geometry(
         top = (height - min_dim) // 2
         left = (width - min_dim) // 2
     else:
-        # Ensure the top left point is within range
         top = min(height - min_dim, max(0, crop_size.top))
         left = min(width - min_dim, max(0, crop_size.left))
 
     return PhotoGeometry(width=width, height=height, crop_top=top, crop_left=left)
 
-# Progressively finer widths (px) to match at, for `find_crop`. The first pass
-# scans the whole range coarsely; each subsequent one re-checks a narrow window
-# around the previous winner, so the cost stays flat as the photo gets bigger.
+# Progressively finer widths (px) for `find_crop`: a coarse scan of the whole
+# range, then narrow windows around the previous winner, so the cost stays flat
+# as the photo gets bigger.
 MATCH_SCALES = (64, 256, 1024)
 
 def _greyscale(image: Image.Image, size: tuple[int, int]) -> numpy.ndarray:
@@ -107,13 +69,10 @@ def _difference(
 
     return float(numpy.abs(window - square).mean())
 
-# The inverse of `photo_geometry`: recovers where `square` was cut from
-# `original`, for photos uploaded before the crop was recorded. Returns the
-# geometry and the mean per-pixel difference (0-255) it achieved, which callers
-# should check before trusting the result.
-#
-# The square is always `min(width, height)` on a side, so it can only slide
-# along the longer axis: a one-dimensional search, not a two-dimensional one.
+# The inverse of `photo_geometry`, for photos uploaded before the crop was
+# recorded. Returns the geometry and the mean per-pixel difference (0-255) it
+# achieved, which callers should check before trusting the result. The square
+# can only slide along the longer axis, so the search is one-dimensional.
 def find_crop(
     original: Image.Image,
     square: Image.Image,

--- a/backend/duophoto/__init__.py
+++ b/backend/duophoto/__init__.py
@@ -6,7 +6,7 @@ import numpy
 # Lives here rather than in `person` so the crop backfill
 # (`service/cron/photocrop`) can share the definition without importing the API.
 
-@dataclass
+@dataclass(frozen=True)
 class CropSize:
     top: int
     left: int
@@ -40,6 +40,16 @@ def photo_geometry(
         left = min(width - min_dim, max(0, crop_size.left))
 
     return PhotoGeometry(width=width, height=height, crop_top=top, crop_left=left)
+
+# The only way to turn a geometry into query params, so the four columns are
+# always written together: a row can have all of them or none.
+def photo_geometry_params(geometry: PhotoGeometry) -> dict[str, int]:
+    return dict(
+        width=geometry.width,
+        height=geometry.height,
+        crop_top=geometry.crop_top,
+        crop_left=geometry.crop_left,
+    )
 
 # Progressively finer widths (px) for `find_crop`: a coarse scan of the whole
 # range, then narrow windows around the previous winner, so the cost stays flat

--- a/backend/duophoto/__init__.py
+++ b/backend/duophoto/__init__.py
@@ -1,0 +1,178 @@
+from dataclasses import dataclass
+from PIL import Image
+import numpy
+
+# How a photo's square renditions (`900-{uuid}.jpg`, `450-{uuid}.jpg`) relate to
+# the original it was cut from (`original-{uuid}.jpg`). Lives here rather than
+# in `person` so the crop backfill (`service/cron/photocrop`) can share the
+# definition without importing the API.
+
+@dataclass
+class CropSize:
+    top: int
+    left: int
+
+# Where the square renditions were cut out of the oriented original, in that
+# image's coordinates. The crop is always `min(width, height)` on a side.
+@dataclass(frozen=True)
+class PhotoGeometry:
+    width: int
+    height: int
+    crop_top: int
+    crop_left: int
+
+def orient_image(image: Image.Image) -> Image.Image:
+    # Rotate the image according to EXIF data
+    try:
+        exif = image.getexif()
+        orientation = exif[274] # 274 is the exif code for the orientation tag
+    except:
+        orientation = None
+
+    if orientation is None:
+        pass
+    elif orientation == 1:
+        # Normal, no changes needed
+        pass
+    elif orientation == 2:
+        # Mirrored horizontally
+        pass
+    elif orientation == 3:
+        # Rotated 180 degrees
+        image = image.rotate(180, expand=True)
+    elif orientation == 4:
+        # Mirrored vertically
+        pass
+    elif orientation == 5:
+        # Transposed
+        image = image.rotate(-90, expand=True)
+    elif orientation == 6:
+        # Rotated -90 degrees
+        image = image.rotate(-90, expand=True)
+    elif orientation == 7:
+        # Transverse
+        image = image.rotate(90, expand=True)
+    elif orientation == 8:
+        # Rotated 90 degrees
+        image = image.rotate(90, expand=True)
+
+    return image
+
+# The single source of truth for how a square rendition relates to the oriented
+# original. The renditions are cut with it and it's persisted alongside them, so
+# the two can't drift. `width` and `height` must be the dimensions of an
+# already-oriented image, i.e. `orient_image(...).size`.
+def photo_geometry(
+    width: int,
+    height: int,
+    crop_size: CropSize | None = None,
+) -> PhotoGeometry:
+    min_dim = min(width, height)
+
+    if crop_size is None:
+        top = (height - min_dim) // 2
+        left = (width - min_dim) // 2
+    else:
+        # Ensure the top left point is within range
+        top = min(height - min_dim, max(0, crop_size.top))
+        left = min(width - min_dim, max(0, crop_size.left))
+
+    return PhotoGeometry(width=width, height=height, crop_top=top, crop_left=left)
+
+# Progressively finer widths (px) to match at, for `find_crop`. The first pass
+# scans the whole range coarsely; each subsequent one re-checks a narrow window
+# around the previous winner, so the cost stays flat as the photo gets bigger.
+MATCH_SCALES = (64, 256, 1024)
+
+def _greyscale(image: Image.Image, size: tuple[int, int]) -> numpy.ndarray:
+    resized = image.convert('L').resize(size, Image.Resampling.BILINEAR)
+    return numpy.asarray(resized, dtype=numpy.float32)
+
+def _difference(
+    original: numpy.ndarray,
+    square: numpy.ndarray,
+    offset: int,
+    horizontal: bool,
+) -> float | None:
+    size = square.shape[0]
+
+    window = (
+        original[:, offset:offset + size]
+        if horizontal
+        else original[offset:offset + size, :]
+    )
+
+    if window.shape != square.shape:
+        return None
+
+    return float(numpy.abs(window - square).mean())
+
+# The inverse of `photo_geometry`: recovers where `square` was cut from
+# `original`, for photos uploaded before the crop was recorded. Returns the
+# geometry and the mean per-pixel difference (0-255) it achieved, which callers
+# should check before trusting the result.
+#
+# The square is always `min(width, height)` on a side, so it can only slide
+# along the longer axis: a one-dimensional search, not a two-dimensional one.
+def find_crop(
+    original: Image.Image,
+    square: Image.Image,
+) -> tuple[PhotoGeometry, float]:
+    width, height = original.size
+
+    min_dim = min(width, height)
+    span = max(width, height) - min_dim
+
+    horizontal = width > height
+
+    def geometry_at(offset: int) -> PhotoGeometry:
+        return PhotoGeometry(
+            width=width,
+            height=height,
+            crop_top=0 if horizontal else offset,
+            crop_left=offset if horizontal else 0,
+        )
+
+    if span == 0:
+        return geometry_at(0), 0.0
+
+    lo, hi = 0, span
+    best_offset = 0
+    best_difference = float('inf')
+
+    for scale_size in MATCH_SCALES:
+        size = min(scale_size, min_dim)
+        scale = size / min_dim
+
+        scaled = (
+            max(size, round(width * scale)),
+            max(size, round(height * scale)),
+        )
+
+        original_pixels = _greyscale(original, scaled)
+        square_pixels = _greyscale(square, (size, size))
+
+        limit = (scaled[0] if horizontal else scaled[1]) - size
+
+        # Don't sample the range more finely than the pixels can distinguish.
+        stride = max(1, int(1 / scale))
+
+        best_offset = lo
+        best_difference = float('inf')
+
+        for offset in range(lo, hi + 1, stride):
+            difference = _difference(
+                original_pixels,
+                square_pixels,
+                min(limit, max(0, round(offset * scale))),
+                horizontal,
+            )
+
+            if difference is not None and difference < best_difference:
+                best_offset = offset
+                best_difference = difference
+
+        lo = max(0, best_offset - stride)
+        hi = min(span, best_offset + stride)
+
+    return geometry_at(best_offset), best_difference

--- a/backend/duophoto/__init__.py
+++ b/backend/duophoto/__init__.py
@@ -46,6 +46,12 @@ def photo_geometry(
 # as the photo gets bigger.
 MATCH_SCALES = (64, 256, 1024)
 
+# Mean per-pixel difference (0-255) above which `find_crop`'s best offset isn't
+# believable. Callers that act on the result should treat anything worse as "no
+# match" rather than record a crop that would make the photo jump when
+# expanded.
+DEFAULT_MAX_MATCH_DIFFERENCE = 24.0
+
 def _greyscale(image: Image.Image, size: tuple[int, int]) -> numpy.ndarray:
     resized = image.convert('L').resize(size, Image.Resampling.BILINEAR)
     return numpy.asarray(resized, dtype=numpy.float32)
@@ -68,6 +74,44 @@ def _difference(
         return None
 
     return float(numpy.abs(window - square).mean())
+
+# The scan quantises offsets to the match resolution, so above the finest
+# `MATCH_SCALES` entry the winner is only exact to `1 / scale` original px.
+# Fitting a parabola through the difference at the winning scaled offset and
+# its neighbours places the minimum between scaled pixels, taking the error
+# back down to about a pixel however big the photo is.
+def _refined_offset(
+    original: numpy.ndarray,
+    square: numpy.ndarray,
+    scale: float,
+    limit: int,
+    horizontal: bool,
+    best_offset: int,
+    span: int,
+) -> int:
+    if scale >= 1:
+        return best_offset
+
+    scaled = min(limit, max(0, round(best_offset * scale)))
+
+    if scaled <= 0 or scaled >= limit:
+        return best_offset
+
+    below = _difference(original, square, scaled - 1, horizontal)
+    at = _difference(original, square, scaled, horizontal)
+    above = _difference(original, square, scaled + 1, horizontal)
+
+    if below is None or at is None or above is None:
+        return best_offset
+
+    curvature = below - 2 * at + above
+
+    if curvature <= 0:
+        return best_offset
+
+    vertex = min(1.0, max(-1.0, 0.5 * (below - above) / curvature))
+
+    return min(span, max(0, round((scaled + vertex) / scale)))
 
 # The inverse of `photo_geometry`, for photos uploaded before the crop was
 # recorded. Returns the geometry and the mean per-pixel difference (0-255) it
@@ -133,5 +177,15 @@ def find_crop(
 
         lo = max(0, best_offset - stride)
         hi = min(span, best_offset + stride)
+
+    best_offset = _refined_offset(
+        original_pixels,
+        square_pixels,
+        scale,
+        limit,
+        horizontal,
+        best_offset,
+        span,
+    )
 
     return geometry_at(best_offset), best_difference

--- a/backend/duophoto/fixtures.py
+++ b/backend/duophoto/fixtures.py
@@ -1,0 +1,42 @@
+from PIL import Image, ImageDraw
+import io
+import random
+
+# Synthetic photos for the crop tests. Busy and non-repeating, so the crop
+# offset is unambiguous - a flat or tiled image would leave it genuinely
+# ambiguous, which is a property of the photo, not the search.
+
+def photo(width: int, height: int, seed: int) -> Image.Image:
+    rng = random.Random(seed)
+    image = Image.new('RGB', (width, height), (12, 12, 30))
+    draw = ImageDraw.Draw(image)
+
+    for _ in range(160):
+        x, y = rng.randint(0, width), rng.randint(0, height)
+        draw.ellipse(
+            [x, y, x + rng.randint(15, 90), y + rng.randint(15, 90)],
+            fill=(rng.randint(0, 255), rng.randint(0, 255), rng.randint(0, 255)),
+        )
+
+    return image
+
+def jpeg(image: Image.Image) -> bytes:
+    buffer = io.BytesIO()
+    image.save(buffer, format='jpeg', quality=85, subsampling=2)
+    return buffer.getvalue()
+
+# The original and its 450 square crop, as the object store holds them.
+def renditions(
+    original: Image.Image,
+    crop_left: int,
+    crop_top: int,
+) -> tuple[bytes, bytes]:
+    min_dim = min(original.size)
+    square = original.crop((
+        crop_left,
+        crop_top,
+        crop_left + min_dim,
+        crop_top + min_dim,
+    )).resize((450, 450))
+
+    return jpeg(original), jpeg(square)

--- a/backend/duophoto/test_init.py
+++ b/backend/duophoto/test_init.py
@@ -5,60 +5,22 @@ from duophoto import (
     orient_image,
     photo_geometry,
 )
-from PIL import Image, ImageDraw
+from duophoto.fixtures import jpeg, photo, renditions
+from PIL import Image
 import io
-import random
 import unittest
 
-def _photo(width: int, height: int, seed: int) -> Image.Image:
-    # Busy and non-repeating: a flat or tiled image would leave the crop offset
-    # genuinely ambiguous, which is a property of the photo, not the search.
-    rng = random.Random(seed)
-    image = Image.new('RGB', (width, height), (12, 12, 30))
-    draw = ImageDraw.Draw(image)
-
-    for _ in range(160):
-        x, y = rng.randint(0, width), rng.randint(0, height)
-        draw.ellipse(
-            [x, y, x + rng.randint(15, 90), y + rng.randint(15, 90)],
-            fill=(rng.randint(0, 255), rng.randint(0, 255), rng.randint(0, 255)),
-        )
-
-    return image
-
-def _jpeg(image: Image.Image) -> Image.Image:
-    buffer = io.BytesIO()
-    image.save(buffer, format='jpeg', quality=85, subsampling=2)
-    buffer.seek(0)
-    return Image.open(buffer)
-
-# What the upload path leaves in the object store for a given crop.
-def _renditions(
-    original: Image.Image,
-    crop_left: int,
-    crop_top: int,
-) -> tuple[Image.Image, Image.Image]:
-    min_dim = min(original.size)
-    square = original.crop((
-        crop_left,
-        crop_top,
-        crop_left + min_dim,
-        crop_top + min_dim,
-    )).resize((450, 450))
-
-    return _jpeg(original), _jpeg(square)
+def _image(jpeg_bytes: bytes) -> Image.Image:
+    return Image.open(io.BytesIO(jpeg_bytes))
 
 class TestPhotoGeometry(unittest.TestCase):
     def test_centres_the_crop_when_none_is_given(self) -> None:
-        # 500x500 out of the middle of a 1000x500.
         self.assertEqual(
             photo_geometry(1000, 500),
             PhotoGeometry(width=1000, height=500, crop_top=0, crop_left=250),
         )
 
     def test_clamps_a_crop_that_runs_off_the_edge(self) -> None:
-        # The only freedom is along the longer axis, and only as far as the
-        # square still fits.
         self.assertEqual(
             photo_geometry(1000, 500, CropSize(top=99, left=9999)).crop_left,
             500,
@@ -77,9 +39,8 @@ class TestPhotoGeometry(unittest.TestCase):
         self.assertEqual((geometry.crop_top, geometry.crop_left), (0, 0))
 
 class TestFindCrop(unittest.TestCase):
-    # Recovering the offset to within a pixel or two is plenty: a couple of
-    # pixels of a multi-thousand-pixel photo is a fraction of a screen pixel
-    # once the preview is drawn.
+    # A couple of pixels of a multi-thousand-pixel photo is a fraction of a
+    # screen pixel once the preview is drawn.
     TOLERANCE_PX = 2
 
     def assert_recovers(
@@ -89,10 +50,13 @@ class TestFindCrop(unittest.TestCase):
         crop_left: int,
         crop_top: int,
     ) -> None:
-        original = _photo(width, height, seed=width * 7 + height + crop_left)
-        original_jpeg, square_jpeg = _renditions(original, crop_left, crop_top)
+        original = photo(width, height, seed=width * 7 + height + crop_left)
+        original_bytes, square_bytes = renditions(original, crop_left, crop_top)
 
-        geometry, difference = find_crop(original_jpeg, square_jpeg)
+        geometry, difference = find_crop(
+            _image(original_bytes),
+            _image(square_bytes),
+        )
 
         self.assertEqual((geometry.width, geometry.height), (width, height))
         self.assertLessEqual(abs(geometry.crop_left - crop_left), self.TOLERANCE_PX)
@@ -118,10 +82,13 @@ class TestFindCrop(unittest.TestCase):
         self.assert_recovers(3000, 2000, crop_left=731, crop_top=0)
 
     def test_reports_a_square_photo_as_uncropped(self) -> None:
-        original = _photo(900, 900, seed=1)
-        original_jpeg, square_jpeg = _renditions(original, 0, 0)
+        original = photo(900, 900, seed=1)
+        original_bytes, square_bytes = renditions(original, 0, 0)
 
-        geometry, difference = find_crop(original_jpeg, square_jpeg)
+        geometry, difference = find_crop(
+            _image(original_bytes),
+            _image(square_bytes),
+        )
 
         self.assertEqual((geometry.crop_top, geometry.crop_left), (0, 0))
         self.assertEqual(difference, 0.0)
@@ -130,12 +97,12 @@ class TestFindCrop(unittest.TestCase):
         # The forward and backward directions have to describe the same crop,
         # otherwise backfilled photos would animate differently to new ones.
         crop = CropSize(top=0, left=317)
-        original = _photo(1400, 900, seed=99)
+        original = photo(1400, 900, seed=99)
 
         expected = photo_geometry(*orient_image(original).size, crop)
 
-        original_jpeg, square_jpeg = _renditions(original, crop.left, crop.top)
-        recovered, _ = find_crop(original_jpeg, square_jpeg)
+        original_bytes, square_bytes = renditions(original, crop.left, crop.top)
+        recovered, _ = find_crop(_image(original_bytes), _image(square_bytes))
 
         self.assertEqual(recovered.width, expected.width)
         self.assertEqual(recovered.height, expected.height)
@@ -145,11 +112,11 @@ class TestFindCrop(unittest.TestCase):
         )
 
     def test_reports_a_bad_match_rather_than_guessing(self) -> None:
-        # A square that isn't from this photo at all. The reported difference is
-        # what stops the backfill recording a crop that would make the photo
-        # jump when expanded.
-        original = _jpeg(_photo(1200, 800, seed=1))
-        unrelated = _jpeg(_photo(800, 800, seed=2).resize((450, 450)))
+        # A square that isn't from this photo at all. The reported difference
+        # is what stops the backfill recording a crop that would make the
+        # photo jump when expanded.
+        original = _image(jpeg(photo(1200, 800, seed=1)))
+        unrelated = _image(jpeg(photo(800, 800, seed=2).resize((450, 450))))
 
         _, difference = find_crop(original, unrelated)
 

--- a/backend/duophoto/test_init.py
+++ b/backend/duophoto/test_init.py
@@ -1,4 +1,5 @@
 from duophoto import (
+    DEFAULT_MAX_MATCH_DIFFERENCE,
     CropSize,
     PhotoGeometry,
     find_crop,
@@ -39,7 +40,9 @@ class TestPhotoGeometry(unittest.TestCase):
         self.assertEqual((geometry.crop_top, geometry.crop_left), (0, 0))
 
 class TestFindCrop(unittest.TestCase):
-    # A couple of pixels of a multi-thousand-pixel photo is a fraction of a
+    # The parabolic refinement keeps the error to about a pixel of the
+    # original whatever its size; the slack covers JPEG artifacts. Even at the
+    # bound, two pixels of a multi-thousand-pixel photo is a fraction of a
     # screen pixel once the preview is drawn.
     TOLERANCE_PX = 2
 
@@ -61,7 +64,7 @@ class TestFindCrop(unittest.TestCase):
         self.assertEqual((geometry.width, geometry.height), (width, height))
         self.assertLessEqual(abs(geometry.crop_left - crop_left), self.TOLERANCE_PX)
         self.assertLessEqual(abs(geometry.crop_top - crop_top), self.TOLERANCE_PX)
-        self.assertLess(difference, 24.0)
+        self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
 
     def test_recovers_a_centred_landscape_crop(self) -> None:
         self.assert_recovers(1200, 800, crop_left=200, crop_top=0)
@@ -80,6 +83,13 @@ class TestFindCrop(unittest.TestCase):
 
     def test_recovers_a_crop_from_a_large_photo(self) -> None:
         self.assert_recovers(3000, 2000, crop_left=731, crop_top=0)
+
+    def test_recovers_a_crop_from_a_photo_coarser_than_the_finest_scale(
+        self,
+    ) -> None:
+        # min(width, height) is over triple the finest MATCH_SCALES entry, so
+        # without sub-pixel refinement the scan alone could be off by 3px.
+        self.assert_recovers(5000, 3400, crop_left=1237, crop_top=0)
 
     def test_reports_a_square_photo_as_uncropped(self) -> None:
         original = photo(900, 900, seed=1)
@@ -120,7 +130,7 @@ class TestFindCrop(unittest.TestCase):
 
         _, difference = find_crop(original, unrelated)
 
-        self.assertGreater(difference, 24.0)
+        self.assertGreater(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
 
 if __name__ == '__main__':
     unittest.main()

--- a/backend/duophoto/test_init.py
+++ b/backend/duophoto/test_init.py
@@ -1,0 +1,159 @@
+from duophoto import (
+    CropSize,
+    PhotoGeometry,
+    find_crop,
+    orient_image,
+    photo_geometry,
+)
+from PIL import Image, ImageDraw
+import io
+import random
+import unittest
+
+def _photo(width: int, height: int, seed: int) -> Image.Image:
+    # Busy and non-repeating: a flat or tiled image would leave the crop offset
+    # genuinely ambiguous, which is a property of the photo, not the search.
+    rng = random.Random(seed)
+    image = Image.new('RGB', (width, height), (12, 12, 30))
+    draw = ImageDraw.Draw(image)
+
+    for _ in range(160):
+        x, y = rng.randint(0, width), rng.randint(0, height)
+        draw.ellipse(
+            [x, y, x + rng.randint(15, 90), y + rng.randint(15, 90)],
+            fill=(rng.randint(0, 255), rng.randint(0, 255), rng.randint(0, 255)),
+        )
+
+    return image
+
+def _jpeg(image: Image.Image) -> Image.Image:
+    buffer = io.BytesIO()
+    image.save(buffer, format='jpeg', quality=85, subsampling=2)
+    buffer.seek(0)
+    return Image.open(buffer)
+
+# What the upload path leaves in the object store for a given crop.
+def _renditions(
+    original: Image.Image,
+    crop_left: int,
+    crop_top: int,
+) -> tuple[Image.Image, Image.Image]:
+    min_dim = min(original.size)
+    square = original.crop((
+        crop_left,
+        crop_top,
+        crop_left + min_dim,
+        crop_top + min_dim,
+    )).resize((450, 450))
+
+    return _jpeg(original), _jpeg(square)
+
+class TestPhotoGeometry(unittest.TestCase):
+    def test_centres_the_crop_when_none_is_given(self) -> None:
+        # 500x500 out of the middle of a 1000x500.
+        self.assertEqual(
+            photo_geometry(1000, 500),
+            PhotoGeometry(width=1000, height=500, crop_top=0, crop_left=250),
+        )
+
+    def test_clamps_a_crop_that_runs_off_the_edge(self) -> None:
+        # The only freedom is along the longer axis, and only as far as the
+        # square still fits.
+        self.assertEqual(
+            photo_geometry(1000, 500, CropSize(top=99, left=9999)).crop_left,
+            500,
+        )
+        self.assertEqual(
+            photo_geometry(1000, 500, CropSize(top=99, left=-50)).crop_left,
+            0,
+        )
+        self.assertEqual(
+            photo_geometry(1000, 500, CropSize(top=99, left=100)).crop_top,
+            0,
+        )
+
+    def test_leaves_a_square_photo_uncropped(self) -> None:
+        geometry = photo_geometry(600, 600, CropSize(top=10, left=10))
+        self.assertEqual((geometry.crop_top, geometry.crop_left), (0, 0))
+
+class TestFindCrop(unittest.TestCase):
+    # Recovering the offset to within a pixel or two is plenty: a couple of
+    # pixels of a multi-thousand-pixel photo is a fraction of a screen pixel
+    # once the preview is drawn.
+    TOLERANCE_PX = 2
+
+    def assert_recovers(
+        self,
+        width: int,
+        height: int,
+        crop_left: int,
+        crop_top: int,
+    ) -> None:
+        original = _photo(width, height, seed=width * 7 + height + crop_left)
+        original_jpeg, square_jpeg = _renditions(original, crop_left, crop_top)
+
+        geometry, difference = find_crop(original_jpeg, square_jpeg)
+
+        self.assertEqual((geometry.width, geometry.height), (width, height))
+        self.assertLessEqual(abs(geometry.crop_left - crop_left), self.TOLERANCE_PX)
+        self.assertLessEqual(abs(geometry.crop_top - crop_top), self.TOLERANCE_PX)
+        self.assertLess(difference, 24.0)
+
+    def test_recovers_a_centred_landscape_crop(self) -> None:
+        self.assert_recovers(1200, 800, crop_left=200, crop_top=0)
+
+    def test_recovers_a_crop_dragged_to_either_edge(self) -> None:
+        self.assert_recovers(1200, 800, crop_left=0, crop_top=0)
+        self.assert_recovers(1200, 800, crop_left=400, crop_top=0)
+
+    def test_recovers_an_arbitrary_landscape_crop(self) -> None:
+        self.assert_recovers(1200, 800, crop_left=137, crop_top=0)
+
+    def test_recovers_portrait_crops_which_slide_vertically(self) -> None:
+        self.assert_recovers(800, 1200, crop_left=0, crop_top=0)
+        self.assert_recovers(800, 1200, crop_left=0, crop_top=213)
+        self.assert_recovers(800, 1200, crop_left=0, crop_top=400)
+
+    def test_recovers_a_crop_from_a_large_photo(self) -> None:
+        self.assert_recovers(3000, 2000, crop_left=731, crop_top=0)
+
+    def test_reports_a_square_photo_as_uncropped(self) -> None:
+        original = _photo(900, 900, seed=1)
+        original_jpeg, square_jpeg = _renditions(original, 0, 0)
+
+        geometry, difference = find_crop(original_jpeg, square_jpeg)
+
+        self.assertEqual((geometry.crop_top, geometry.crop_left), (0, 0))
+        self.assertEqual(difference, 0.0)
+
+    def test_agrees_with_the_geometry_the_upload_path_would_have_recorded(self) -> None:
+        # The forward and backward directions have to describe the same crop,
+        # otherwise backfilled photos would animate differently to new ones.
+        crop = CropSize(top=0, left=317)
+        original = _photo(1400, 900, seed=99)
+
+        expected = photo_geometry(*orient_image(original).size, crop)
+
+        original_jpeg, square_jpeg = _renditions(original, crop.left, crop.top)
+        recovered, _ = find_crop(original_jpeg, square_jpeg)
+
+        self.assertEqual(recovered.width, expected.width)
+        self.assertEqual(recovered.height, expected.height)
+        self.assertLessEqual(
+            abs(recovered.crop_left - expected.crop_left),
+            self.TOLERANCE_PX,
+        )
+
+    def test_reports_a_bad_match_rather_than_guessing(self) -> None:
+        # A square that isn't from this photo at all. The reported difference is
+        # what stops the backfill recording a crop that would make the photo
+        # jump when expanded.
+        original = _jpeg(_photo(1200, 800, seed=1))
+        unrelated = _jpeg(_photo(800, 800, seed=2).resize((450, 450)))
+
+        _, difference = find_crop(original, unrelated)
+
+        self.assertGreater(difference, 24.0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/init-api.sql
+++ b/backend/init-api.sql
@@ -471,18 +471,6 @@ CREATE TABLE IF NOT EXISTS photo (
     PRIMARY KEY (person_id, position)
 );
 
--- NULL for a photo whose geometry isn't known yet, which clients read as "don't
--- animate the crop".
-CREATE OR REPLACE FUNCTION photo_geometry(p photo)
-RETURNS JSON AS $$
-    SELECT CASE WHEN p.width IS NOT NULL THEN json_build_object(
-        'width',     p.width,
-        'height',    p.height,
-        'crop_top',  p.crop_top,
-        'crop_left', p.crop_left
-    ) END;
-$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE;
-
 CREATE TABLE IF NOT EXISTS undeleted_photo (
     uuid TEXT PRIMARY KEY
 );

--- a/backend/init-api.sql
+++ b/backend/init-api.sql
@@ -443,6 +443,17 @@ CREATE TABLE IF NOT EXISTS social_identity (
 CREATE INDEX IF NOT EXISTS social_identity__person_id__idx
     ON social_identity (person_id);
 
+-- `width`, `height`, `crop_top` and `crop_left` describe how the square
+-- renditions (`900-{uuid}.jpg`, `450-{uuid}.jpg`) were cut out of
+-- `original-{uuid}.jpg`, so clients can animate between the two. All four are
+-- in the coordinates of `original-{uuid}.jpg`, i.e. after EXIF rotation was
+-- applied. The crop is always `min(width, height)` on a side, so only its
+-- origin varies. They're NULL for photos uploaded before the columns existed
+-- and not yet backfilled; see `service/cron/photocrop`.
+--
+-- `crop_attempted_at` is when that backfill last tried this photo, and is what
+-- stops it retrying one it can't recover (a missing rendition, say) on every
+-- pass forever. Clear it to have another go.
 CREATE TABLE IF NOT EXISTS photo (
     person_id INT NOT NULL REFERENCES person(id) ON DELETE CASCADE ON UPDATE CASCADE,
     position SMALLINT NOT NULL,
@@ -452,8 +463,25 @@ CREATE TABLE IF NOT EXISTS photo (
     nsfw_score FLOAT4,
     extra_exts TEXT[] NOT NULL DEFAULT '{}',
     hash TEXT NOT NULL,
+    width INT,
+    height INT,
+    crop_top INT,
+    crop_left INT,
+    crop_attempted_at TIMESTAMP,
     PRIMARY KEY (person_id, position)
 );
+
+-- NULL for a photo whose geometry isn't known yet, which clients read as "don't
+-- animate the crop".
+CREATE OR REPLACE FUNCTION photo_geometry(p photo)
+RETURNS JSON AS $$
+    SELECT CASE WHEN p.width IS NOT NULL THEN json_build_object(
+        'width',     p.width,
+        'height',    p.height,
+        'crop_top',  p.crop_top,
+        'crop_left', p.crop_left
+    ) END;
+$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE;
 
 CREATE TABLE IF NOT EXISTS undeleted_photo (
     uuid TEXT PRIMARY KEY

--- a/backend/init-api.sql
+++ b/backend/init-api.sql
@@ -946,6 +946,11 @@ CREATE INDEX IF NOT EXISTS idx__deleted_photo_admin_token__expires_at
 CREATE INDEX IF NOT EXISTS idx__photo__uuid
     ON photo(uuid);
 
+-- The photocrop backfill's queue: tiny, and empties as the backlog drains.
+CREATE INDEX IF NOT EXISTS idx__photo__crop_backlog
+    ON photo(uuid)
+    WHERE width IS NULL AND crop_attempted_at IS NULL;
+
 CREATE INDEX IF NOT EXISTS idx__photo__nsfw_score
     ON photo(nsfw_score);
 

--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -77,14 +77,7 @@ ALTER TABLE photo
     ADD COLUMN IF NOT EXISTS crop_left INT,
     ADD COLUMN IF NOT EXISTS crop_attempted_at TIMESTAMP;
 
--- Must come after the ALTER TABLE above: the argument is the `photo` row type,
--- so the columns it reads have to exist first.
-CREATE OR REPLACE FUNCTION photo_geometry(p photo)
-RETURNS JSON AS $$
-    SELECT CASE WHEN p.width IS NOT NULL THEN json_build_object(
-        'width',     p.width,
-        'height',    p.height,
-        'crop_top',  p.crop_top,
-        'crop_left', p.crop_left
-    ) END;
-$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE;
+-- The geometry JSON is now shaped in the application (`commonsql.PHOTO_GEOMETRY`)
+-- rather than by a database function; drop the function this migration used to
+-- create so already-migrated databases shed it too.
+DROP FUNCTION IF EXISTS photo_geometry(photo);

--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -64,3 +64,27 @@ CREATE INDEX IF NOT EXISTS
     ON person
     USING ivfflat (personality vector_ip_ops)
     WITH (lists = 100);
+
+-- How the square renditions were cut out of `original-{uuid}.jpg`, in that
+-- image's (post-EXIF-rotation) coordinates. Lets clients expand a cropped
+-- preview into the uncropped original. NULL until `service/cron/photocrop`
+-- backfills photos uploaded before these columns existed; `crop_attempted_at`
+-- records that it tried, so photos it can't recover don't get retried forever.
+ALTER TABLE photo
+    ADD COLUMN IF NOT EXISTS width INT,
+    ADD COLUMN IF NOT EXISTS height INT,
+    ADD COLUMN IF NOT EXISTS crop_top INT,
+    ADD COLUMN IF NOT EXISTS crop_left INT,
+    ADD COLUMN IF NOT EXISTS crop_attempted_at TIMESTAMP;
+
+-- Must come after the ALTER TABLE above: the argument is the `photo` row type,
+-- so the columns it reads have to exist first.
+CREATE OR REPLACE FUNCTION photo_geometry(p photo)
+RETURNS JSON AS $$
+    SELECT CASE WHEN p.width IS NOT NULL THEN json_build_object(
+        'width',     p.width,
+        'height',    p.height,
+        'crop_top',  p.crop_top,
+        'crop_left', p.crop_left
+    ) END;
+$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE;

--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -77,6 +77,11 @@ ALTER TABLE photo
     ADD COLUMN IF NOT EXISTS crop_left INT,
     ADD COLUMN IF NOT EXISTS crop_attempted_at TIMESTAMP;
 
+-- The photocrop backfill's queue: tiny, and empties as the backlog drains.
+CREATE INDEX IF NOT EXISTS idx__photo__crop_backlog
+    ON photo(uuid)
+    WHERE width IS NULL AND crop_attempted_at IS NULL;
+
 -- The geometry JSON is now shaped in the application (`commonsql.PHOTO_GEOMETRY`)
 -- rather than by a database function; drop the function this migration used to
 -- create so already-migrated databases shed it too.

--- a/backend/person/__init__.py
+++ b/backend/person/__init__.py
@@ -47,6 +47,7 @@ from async_lru_cache import AsyncLruCache
 from datetime import datetime, timezone
 from urllib.parse import quote
 from duoaudio import put_audio_in_object_store
+from duophoto import CropSize, orient_image, photo_geometry
 from person.aboutdiff import diff_addition_with_context
 from auth.session import sign_out, enforce_session_limit
 from auth.social import (
@@ -82,84 +83,28 @@ s3 = boto3.resource(
 
 bucket = s3.Bucket(R2_BUCKET_NAME)
 
-@dataclass
-class CropSize:
-    top: int
-    left: int
-
 def process_image_as_image(
     image: Image.Image,
     output_size: int | None = None,
     crop_size: CropSize | None = None,
 ) -> Image.Image:
-    # Rotate the image according to EXIF data
-    try:
-        exif = image.getexif()
-        orientation = exif[274] # 274 is the exif code for the orientation tag
-    except:
-        orientation = None
+    image = orient_image(image)
 
-    if orientation is None:
-        pass
-    elif orientation == 1:
-        # Normal, no changes needed
-        pass
-    elif orientation == 2:
-        # Mirrored horizontally
-        pass
-    elif orientation == 3:
-        # Rotated 180 degrees
-        image = image.rotate(180, expand=True)
-    elif orientation == 4:
-        # Mirrored vertically
-        pass
-    elif orientation == 5:
-        # Transposed
-        image = image.rotate(-90, expand=True)
-    elif orientation == 6:
-        # Rotated -90 degrees
-        image = image.rotate(-90, expand=True)
-    elif orientation == 7:
-        # Transverse
-        image = image.rotate(90, expand=True)
-    elif orientation == 8:
-        # Rotated 90 degrees
-        image = image.rotate(90, expand=True)
+    if output_size is None:
+        return image.convert('RGB')
 
-    # Crop the image to be square
-    if output_size is not None:
-        # Get the dimensions of the image
-        width, height = image.size
+    g = photo_geometry(*image.size, crop_size)
 
-        # Find the smaller dimension
-        min_dim = min(width, height)
+    min_dim = min(g.width, g.height)
 
-        # Compute the area to crop
-        if crop_size is None:
-            left = (width - min_dim) // 2
-            top = (height - min_dim) // 2
-            right = (width + min_dim) // 2
-            bottom = (height + min_dim) // 2
-        else:
-            # Ensure the top left point is within range
-            crop_size.top  = max(0, crop_size.top)
-            crop_size.left = max(0, crop_size.left)
+    image = image.crop((
+        g.crop_left,
+        g.crop_top,
+        g.crop_left + min_dim,
+        g.crop_top + min_dim,
+    ))
 
-            crop_size.top  = min(height - min_dim, crop_size.top)
-            crop_size.left = min(width  - min_dim, crop_size.left)
-
-            # Compute the area to crop
-            left = crop_size.left
-            top = crop_size.top
-            right = crop_size.left + min_dim
-            bottom = crop_size.top + min_dim
-
-        # Crop the image to be square
-        crop_box = (left, top, right, bottom)
-        image = image.crop(crop_box)
-
-    # Scale the image to the desired size
-    if output_size is not None and output_size != min_dim:
+    if output_size != min_dim:
         image = image.resize((output_size, output_size))
 
     return image.convert('RGB')
@@ -1185,6 +1130,10 @@ async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> objec
         uuid = secrets.token_hex(32)
         blurhash_ = compute_blurhash(base64_file.image, crop_size=crop_size)
         extra_exts = ['gif'] if base64_file.image.format == 'GIF' else []
+        geometry = photo_geometry(
+            *orient_image(base64_file.image).size,
+            crop_size,
+        )
 
         params = dict(
             person_id=s.person_id,
@@ -1193,6 +1142,10 @@ async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> objec
             blurhash=blurhash_,
             extra_exts=extra_exts,
             hash=base64_file.md5_hash,
+            width=geometry.width,
+            height=geometry.height,
+            crop_top=geometry.crop_top,
+            crop_left=geometry.crop_left,
         )
 
         q1 = """
@@ -1220,19 +1173,31 @@ async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> objec
                 uuid,
                 blurhash,
                 extra_exts,
-                hash
+                hash,
+                width,
+                height,
+                crop_top,
+                crop_left
             ) VALUES (
                 %(person_id)s,
                 %(position)s,
                 %(uuid)s,
                 %(blurhash)s,
                 %(extra_exts)s,
-                %(hash)s
+                %(hash)s,
+                %(width)s,
+                %(height)s,
+                %(crop_top)s,
+                %(crop_left)s
             ) ON CONFLICT (person_id, position) DO UPDATE SET
                 uuid = EXCLUDED.uuid,
                 blurhash = EXCLUDED.blurhash,
                 extra_exts = EXCLUDED.extra_exts,
                 hash = EXCLUDED.hash,
+                width = EXCLUDED.width,
+                height = EXCLUDED.height,
+                crop_top = EXCLUDED.crop_top,
+                crop_left = EXCLUDED.crop_left,
                 verified = FALSE
         ), updated_person AS (
             UPDATE person

--- a/backend/person/__init__.py
+++ b/backend/person/__init__.py
@@ -47,7 +47,12 @@ from async_lru_cache import AsyncLruCache
 from datetime import datetime, timezone
 from urllib.parse import quote
 from duoaudio import put_audio_in_object_store
-from duophoto import CropSize, orient_image, photo_geometry
+from duophoto import (
+    CropSize,
+    orient_image,
+    photo_geometry,
+    photo_geometry_params,
+)
 from person.aboutdiff import diff_addition_with_context
 from auth.session import sign_out, enforce_session_limit
 from auth.social import (
@@ -1142,10 +1147,7 @@ async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> objec
             blurhash=blurhash_,
             extra_exts=extra_exts,
             hash=base64_file.md5_hash,
-            width=geometry.width,
-            height=geometry.height,
-            crop_top=geometry.crop_top,
-            crop_left=geometry.crop_left,
+            **photo_geometry_params(geometry),
         )
 
         q1 = """

--- a/backend/person/sql/__init__.py
+++ b/backend/person/sql/__init__.py
@@ -969,6 +969,7 @@ SELECT
         'photo_extra_exts',          (SELECT extra_exts                FROM photos),
         'photo_blurhashes',          (SELECT blurhashes                FROM photos),
         'photo_verifications',       (SELECT verifications             FROM photos),
+        'photo_geometries',          (SELECT geometries                FROM photos),
         'audio_bio_uuid',            (SELECT j                         FROM audio_bio_uuid),
         'name',                      (SELECT name                      FROM prospect),
         'url_slug',                  (SELECT url_slug                  FROM prospect),

--- a/backend/person/sql/__init__.py
+++ b/backend/person/sql/__init__.py
@@ -817,7 +817,8 @@ WITH prospect_base AS (
         COALESCE(json_agg(photo.uuid       ORDER BY position), '[]'::json) AS uuids,
         COALESCE(json_agg(photo.extra_exts ORDER BY position), '[]'::json) AS extra_exts,
         COALESCE(json_agg(photo.blurhash   ORDER BY position), '[]'::json) AS blurhashes,
-        COALESCE(json_agg(photo.verified   ORDER BY position), '[]'::json) AS verifications
+        COALESCE(json_agg(photo.verified   ORDER BY position), '[]'::json) AS verifications,
+        COALESCE(json_agg(PHOTO_GEOMETRY(photo) ORDER BY position), '[]'::json) AS geometries
     FROM photo
     JOIN prospect
     ON   prospect.id = photo.person_id

--- a/backend/person/sql/__init__.py
+++ b/backend/person/sql/__init__.py
@@ -6,6 +6,7 @@ from constants import (
     MIN_CLUB_PAGE_MEMBERS,
 )
 from commonsql import (
+    PHOTO_GEOMETRY,
     Q_COMPUTED_FLAIR,
     Q_IS_ALLOWED_CLUB_NAME,
     Q_IS_REGISTERED_BY_NORMALIZED_EMAIL,
@@ -818,7 +819,7 @@ WITH prospect_base AS (
         COALESCE(json_agg(photo.extra_exts ORDER BY position), '[]'::json) AS extra_exts,
         COALESCE(json_agg(photo.blurhash   ORDER BY position), '[]'::json) AS blurhashes,
         COALESCE(json_agg(photo.verified   ORDER BY position), '[]'::json) AS verifications,
-        COALESCE(json_agg(PHOTO_GEOMETRY(photo) ORDER BY position), '[]'::json) AS geometries
+        COALESCE(json_agg(({PHOTO_GEOMETRY}) ORDER BY position), '[]'::json) AS geometries
     FROM photo
     JOIN prospect
     ON   prospect.id = photo.person_id

--- a/backend/search/sql/feed.py
+++ b/backend/search/sql/feed.py
@@ -637,9 +637,25 @@ SELECT
         'gender', gender,
         'location', location,
         'advertiser_friendly', advertiser_friendly
-    ) || mapped_last_event_data AS j
+    )
+    || mapped_last_event_data
+    || COALESCE(added_photo_geometry.j, '{{}}'::jsonb)
+    AS j
 FROM
     filtered_by_club
+LEFT JOIN LATERAL (
+    -- Read from `photo` rather than `last_event_data` so items whose event
+    -- predates the geometry columns still animate. Probes idx__photo__uuid.
+    SELECT
+        jsonb_build_object('added_photo_geometry', PHOTO_GEOMETRY(photo)) AS j
+    FROM
+        photo
+    WHERE
+        photo.uuid = filtered_by_club.mapped_last_event_data ->> 'added_photo_uuid'
+    AND
+        photo.width IS NOT NULL
+) AS added_photo_geometry
+ON TRUE
 ORDER BY
     last_event_time DESC
 """
@@ -1145,11 +1161,25 @@ SELECT
     || mapped_last_event_data
     || COALESCE(joined_club_data.j, '{{}}'::jsonb)
     || COALESCE(answered_question_data.j, '{{}}'::jsonb)
+    || COALESCE(added_photo_geometry.j, '{{}}'::jsonb)
     AS j
 FROM
     feed_page
 CROSS JOIN
     searcher
+LEFT JOIN LATERAL (
+    -- Read from `photo` rather than `last_event_data` so items whose event
+    -- predates the geometry columns still animate. Probes idx__photo__uuid.
+    SELECT
+        jsonb_build_object('added_photo_geometry', PHOTO_GEOMETRY(photo)) AS j
+    FROM
+        photo
+    WHERE
+        photo.uuid = feed_page.mapped_last_event_data ->> 'added_photo_uuid'
+    AND
+        photo.width IS NOT NULL
+) AS added_photo_geometry
+ON TRUE
 LEFT JOIN LATERAL (
     SELECT
         jsonb_build_object(

--- a/backend/search/sql/feed.py
+++ b/backend/search/sql/feed.py
@@ -1,5 +1,5 @@
 from constants import ONLINE_RECENTLY_SECONDS
-from commonsql import Q_COMPUTED_FLAIR
+from commonsql import PHOTO_GEOMETRY, Q_COMPUTED_FLAIR
 from qanda import ANSWER_VISIBLE_TO_OTHERS
 
 # How many feed results to send to the client per request
@@ -647,7 +647,7 @@ LEFT JOIN LATERAL (
     -- Read from `photo` rather than `last_event_data` so items whose event
     -- predates the geometry columns still animate. Probes idx__photo__uuid.
     SELECT
-        jsonb_build_object('added_photo_geometry', PHOTO_GEOMETRY(photo)) AS j
+        jsonb_build_object('added_photo_geometry', ({PHOTO_GEOMETRY})) AS j
     FROM
         photo
     WHERE
@@ -1171,7 +1171,7 @@ LEFT JOIN LATERAL (
     -- Read from `photo` rather than `last_event_data` so items whose event
     -- predates the geometry columns still animate. Probes idx__photo__uuid.
     SELECT
-        jsonb_build_object('added_photo_geometry', PHOTO_GEOMETRY(photo)) AS j
+        jsonb_build_object('added_photo_geometry', ({PHOTO_GEOMETRY})) AS j
     FROM
         photo
     WHERE

--- a/backend/service/cron/__init__.py
+++ b/backend/service/cron/__init__.py
@@ -9,6 +9,7 @@ from service.cron.garbagerecords import delete_garbage_records_forever
 from service.cron.notifications import send_notifications_forever
 from service.cron.nsfwphotorunner import predict_nsfw_photos_forever
 from service.cron.photocleaner import clean_photos_forever
+from service.cron.photocrop import backfill_photo_crops_forever
 from service.cron.audiocleaner import clean_audio_forever
 from service.cron.verificationjobrunner import verify_forever
 from service.cron.profilereporter import report_profiles_forever
@@ -46,6 +47,10 @@ async def main() -> None:
 
             # Fetched: 0.1k, returned: 100k
             clean_photos_forever(),
+
+            # Backfills photos uploaded before `photo.width` and friends
+            # existed. Runs itself out of work once the backlog is done.
+            backfill_photo_crops_forever(),
 
             clean_audio_forever(),
 

--- a/backend/service/cron/cronutil/__init__.py
+++ b/backend/service/cron/cronutil/__init__.py
@@ -145,6 +145,13 @@ async def download_450_images(
     uuids: list[str],
     max_workers: int = 5,
 ) -> list[io.BytesIO | None]:
+    return await download_images(uuids, '450-', max_workers)
+
+async def download_images(
+    uuids: list[str],
+    prefix: str,
+    max_workers: int = 5,
+) -> list[io.BytesIO | None]:
     if not uuids:
         return []
 
@@ -159,7 +166,7 @@ async def download_450_images(
 
     def download_one(uuid: str) -> io.BytesIO | None:
         buffer = io.BytesIO()
-        key = f'450-{uuid}.jpg'
+        key = f'{prefix}{uuid}.jpg'
         retries = 3
         for attempt in range(retries):
             try:

--- a/backend/service/cron/photocrop/__init__.py
+++ b/backend/service/cron/photocrop/__init__.py
@@ -1,0 +1,141 @@
+from database import api_tx
+from duophoto import PhotoGeometry, find_crop
+from service.cron.photocrop.sql import *
+from service.cron.cronutil import (
+    MAX_RANDOM_START_DELAY,
+    download_images,
+    print_stacktrace,
+)
+from PIL import Image
+import asyncio
+import io
+import os
+import random
+
+# Recovers the geometry of photos uploaded before `photo.width` and friends
+# existed. The crop offset the uploader chose wasn't recorded at the time, but
+# both renditions are still in the object store, so `find_crop` can work out
+# where the square one sits inside the original.
+#
+# New uploads record their geometry directly (see `duophoto.photo_geometry`), so
+# this only has the backlog to get through, and stops finding work once it has.
+
+DRY_RUN = os.environ.get(
+    'DUO_CRON_PHOTO_CROP_DRY_RUN',
+    'true',
+).lower() not in ['false', 'f', '0', 'no']
+
+PHOTO_CROP_POLL_SECONDS = int(os.environ.get(
+    'DUO_CRON_PHOTO_CROP_POLL_SECONDS',
+    str(60), # 1 minute
+))
+
+PHOTO_CROP_BATCH_SIZE = int(os.environ.get(
+    'DUO_CRON_PHOTO_CROP_BATCH_SIZE',
+    str(50),
+))
+
+# Mean per-pixel difference (0-255) above which the best offset found isn't
+# believable - the renditions probably aren't of the same photo. Recording a
+# wrong crop would make the photo visibly jump when expanded, which is worse
+# than not animating it at all, so those are left alone.
+MAX_MATCH_DIFFERENCE = float(os.environ.get(
+    'DUO_CRON_PHOTO_CROP_MAX_MATCH_DIFFERENCE',
+    str(24.0),
+))
+
+print(f'Hello from cron module: {__name__}')
+
+def _open(image_bytes: io.BytesIO | None) -> Image.Image | None:
+    if image_bytes is None:
+        return None
+    try:
+        return Image.open(image_bytes)
+    except Exception as e:
+        print('photocrop: could not open image:', e)
+        return None
+
+def _geometry_of(
+    uuid: str,
+    original_bytes: io.BytesIO | None,
+    square_bytes: io.BytesIO | None,
+) -> PhotoGeometry | None:
+    original = _open(original_bytes)
+    square = _open(square_bytes)
+
+    if original is None or square is None:
+        print(f'photocrop: {uuid} is missing a rendition; skipping')
+        return None
+
+    geometry, difference = find_crop(original, square)
+
+    if difference > MAX_MATCH_DIFFERENCE:
+        print(f'photocrop: {uuid} matched too poorly ({difference:.1f}); skipping')
+        return None
+
+    return geometry
+
+async def _backfill(uuids: list[str]) -> None:
+    # `original-` is the uncropped upload; `450-` is the same square crop as
+    # `900-`, and a quarter of the pixels to fetch.
+    originals, squares = await asyncio.gather(
+        download_images(uuids, 'original-'),
+        download_images(uuids, '450-'),
+    )
+
+    def compute() -> list[dict[str, object]]:
+        return [
+            dict(
+                uuid=uuid,
+                width=geometry.width,
+                height=geometry.height,
+                crop_top=geometry.crop_top,
+                crop_left=geometry.crop_left,
+            )
+            for uuid, original, square in zip(uuids, originals, squares)
+            for geometry in [_geometry_of(uuid, original, square)]
+            if geometry is not None
+        ]
+
+    # Decoding and matching is CPU-bound; keep it off the event loop.
+    params_seq = await asyncio.to_thread(compute)
+
+    if DRY_RUN:
+        print(
+            'DUO_CRON_PHOTO_CROP_DRY_RUN env var prevented geometry update:',
+            params_seq,
+        )
+        return
+
+    # Mark the whole batch, not just the photos that worked, so the ones that
+    # didn't stop coming back.
+    async with api_tx() as tx:
+        await tx.execute(Q_MARK_PHOTO_CROP_ATTEMPTED, dict(uuids=uuids))
+        if params_seq:
+            await tx.executemany(Q_SET_PHOTO_GEOMETRY, params_seq)
+
+    print(
+        f'photocrop: recorded geometry for {len(params_seq)} '
+        f'of {len(uuids)} photos'
+    )
+
+async def backfill_photo_crops_once() -> None:
+    async with api_tx() as tx:
+        cur = await tx.execute(
+            Q_PHOTOS_WITHOUT_GEOMETRY,
+            dict(limit=PHOTO_CROP_BATCH_SIZE),
+        )
+        rows = await cur.fetchall()
+
+    uuids = [row['uuid'] for row in rows]
+
+    if not uuids:
+        return
+
+    await _backfill(uuids)
+
+async def backfill_photo_crops_forever() -> None:
+    await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
+    while True:
+        await print_stacktrace(backfill_photo_crops_once)
+        await asyncio.sleep(PHOTO_CROP_POLL_SECONDS)

--- a/backend/service/cron/photocrop/__init__.py
+++ b/backend/service/cron/photocrop/__init__.py
@@ -1,5 +1,5 @@
 from database import api_tx
-from duophoto import PhotoGeometry, find_crop
+from duophoto import DEFAULT_MAX_MATCH_DIFFERENCE, PhotoGeometry, find_crop
 from service.cron.photocrop.sql import *
 from service.cron.cronutil import (
     MAX_RANDOM_START_DELAY,
@@ -40,12 +40,9 @@ PHOTO_CROP_DOWNLOAD_CHUNK = int(os.environ.get(
     str(5),
 ))
 
-# Mean per-pixel difference (0-255) above which the best offset found isn't
-# believable. Recording a wrong crop would make the photo visibly jump when
-# expanded, which is worse than not animating it at all.
 MAX_MATCH_DIFFERENCE = float(os.environ.get(
     'DUO_CRON_PHOTO_CROP_MAX_MATCH_DIFFERENCE',
-    str(24.0),
+    str(DEFAULT_MAX_MATCH_DIFFERENCE),
 ))
 
 print(f'Hello from cron module: {__name__}')

--- a/backend/service/cron/photocrop/__init__.py
+++ b/backend/service/cron/photocrop/__init__.py
@@ -85,12 +85,17 @@ async def _backfill(uuids: list[str]) -> None:
         originals: list[io.BytesIO | None],
         squares: list[io.BytesIO | None],
     ) -> list[dict[str, str | int]]:
-        return [
-            dict(uuid=uuid, **photo_geometry_params(geometry))
-            for uuid, original, square in zip(chunk, originals, squares)
-            for geometry in [_geometry_of(uuid, original, square)]
-            if geometry is not None
-        ]
+        params: list[dict[str, str | int]] = []
+
+        for uuid, original, square in zip(chunk, originals, squares):
+            geometry = _geometry_of(uuid, original, square)
+
+            if geometry is None:
+                continue
+
+            params.append(dict(uuid=uuid, **photo_geometry_params(geometry)))
+
+        return params
 
     params_seq: list[dict[str, str | int]] = []
 

--- a/backend/service/cron/photocrop/__init__.py
+++ b/backend/service/cron/photocrop/__init__.py
@@ -1,5 +1,10 @@
 from database import api_tx
-from duophoto import DEFAULT_MAX_MATCH_DIFFERENCE, PhotoGeometry, find_crop
+from duophoto import (
+    DEFAULT_MAX_MATCH_DIFFERENCE,
+    PhotoGeometry,
+    find_crop,
+    photo_geometry_params,
+)
 from service.cron.photocrop.sql import *
 from service.cron.cronutil import (
     MAX_RANDOM_START_DELAY,
@@ -81,13 +86,7 @@ async def _backfill(uuids: list[str]) -> None:
         squares: list[io.BytesIO | None],
     ) -> list[dict[str, str | int]]:
         return [
-            dict(
-                uuid=uuid,
-                width=geometry.width,
-                height=geometry.height,
-                crop_top=geometry.crop_top,
-                crop_left=geometry.crop_left,
-            )
+            dict(uuid=uuid, **photo_geometry_params(geometry))
             for uuid, original, square in zip(chunk, originals, squares)
             for geometry in [_geometry_of(uuid, original, square)]
             if geometry is not None

--- a/backend/service/cron/photocrop/__init__.py
+++ b/backend/service/cron/photocrop/__init__.py
@@ -13,12 +13,9 @@ import os
 import random
 
 # Recovers the geometry of photos uploaded before `photo.width` and friends
-# existed. The crop offset the uploader chose wasn't recorded at the time, but
-# both renditions are still in the object store, so `find_crop` can work out
-# where the square one sits inside the original.
-#
-# New uploads record their geometry directly (see `duophoto.photo_geometry`), so
-# this only has the backlog to get through, and stops finding work once it has.
+# existed, by finding where the square rendition sits inside the original. New
+# uploads record their geometry directly, so this only has the backlog to get
+# through.
 
 DRY_RUN = os.environ.get(
     'DUO_CRON_PHOTO_CROP_DRY_RUN',
@@ -35,10 +32,17 @@ PHOTO_CROP_BATCH_SIZE = int(os.environ.get(
     str(50),
 ))
 
+# How many photos' renditions are downloaded and held in memory at once. The
+# originals are full-size uploads, so a whole batch of them at once is easily
+# hundreds of megabytes.
+PHOTO_CROP_DOWNLOAD_CHUNK = int(os.environ.get(
+    'DUO_CRON_PHOTO_CROP_DOWNLOAD_CHUNK',
+    str(5),
+))
+
 # Mean per-pixel difference (0-255) above which the best offset found isn't
-# believable - the renditions probably aren't of the same photo. Recording a
-# wrong crop would make the photo visibly jump when expanded, which is worse
-# than not animating it at all, so those are left alone.
+# believable. Recording a wrong crop would make the photo visibly jump when
+# expanded, which is worse than not animating it at all.
 MAX_MATCH_DIFFERENCE = float(os.environ.get(
     'DUO_CRON_PHOTO_CROP_MAX_MATCH_DIFFERENCE',
     str(24.0),
@@ -46,28 +50,26 @@ MAX_MATCH_DIFFERENCE = float(os.environ.get(
 
 print(f'Hello from cron module: {__name__}')
 
-def _open(image_bytes: io.BytesIO | None) -> Image.Image | None:
-    if image_bytes is None:
-        return None
-    try:
-        return Image.open(image_bytes)
-    except Exception as e:
-        print('photocrop: could not open image:', e)
-        return None
-
 def _geometry_of(
     uuid: str,
     original_bytes: io.BytesIO | None,
     square_bytes: io.BytesIO | None,
 ) -> PhotoGeometry | None:
-    original = _open(original_bytes)
-    square = _open(square_bytes)
-
-    if original is None or square is None:
+    if original_bytes is None or square_bytes is None:
         print(f'photocrop: {uuid} is missing a rendition; skipping')
         return None
 
-    geometry, difference = find_crop(original, square)
+    # A photo that can't be decoded must still count as attempted, or the
+    # batch it sits in would be re-selected on every pass and stall the
+    # backlog.
+    try:
+        geometry, difference = find_crop(
+            Image.open(original_bytes),
+            Image.open(square_bytes),
+        )
+    except Exception as e:
+        print(f'photocrop: {uuid} could not be matched:', e)
+        return None
 
     if difference > MAX_MATCH_DIFFERENCE:
         print(f'photocrop: {uuid} matched too poorly ({difference:.1f}); skipping')
@@ -76,14 +78,11 @@ def _geometry_of(
     return geometry
 
 async def _backfill(uuids: list[str]) -> None:
-    # `original-` is the uncropped upload; `450-` is the same square crop as
-    # `900-`, and a quarter of the pixels to fetch.
-    originals, squares = await asyncio.gather(
-        download_images(uuids, 'original-'),
-        download_images(uuids, '450-'),
-    )
-
-    def compute() -> list[dict[str, object]]:
+    def compute(
+        chunk: list[str],
+        originals: list[io.BytesIO | None],
+        squares: list[io.BytesIO | None],
+    ) -> list[dict[str, str | int]]:
         return [
             dict(
                 uuid=uuid,
@@ -92,13 +91,25 @@ async def _backfill(uuids: list[str]) -> None:
                 crop_top=geometry.crop_top,
                 crop_left=geometry.crop_left,
             )
-            for uuid, original, square in zip(uuids, originals, squares)
+            for uuid, original, square in zip(chunk, originals, squares)
             for geometry in [_geometry_of(uuid, original, square)]
             if geometry is not None
         ]
 
-    # Decoding and matching is CPU-bound; keep it off the event loop.
-    params_seq = await asyncio.to_thread(compute)
+    params_seq: list[dict[str, str | int]] = []
+
+    for start in range(0, len(uuids), PHOTO_CROP_DOWNLOAD_CHUNK):
+        chunk = uuids[start:start + PHOTO_CROP_DOWNLOAD_CHUNK]
+
+        # `original-` is the uncropped upload; `450-` is the same square crop
+        # as `900-` at a quarter of the pixels.
+        originals, squares = await asyncio.gather(
+            download_images(chunk, 'original-'),
+            download_images(chunk, '450-'),
+        )
+
+        # Decoding and matching is CPU-bound; keep it off the event loop.
+        params_seq += await asyncio.to_thread(compute, chunk, originals, squares)
 
     if DRY_RUN:
         print(
@@ -119,23 +130,35 @@ async def _backfill(uuids: list[str]) -> None:
         f'of {len(uuids)} photos'
     )
 
-async def backfill_photo_crops_once() -> None:
+async def backfill_photo_crops_once(after: str = '') -> str:
     async with api_tx() as tx:
         cur = await tx.execute(
             Q_PHOTOS_WITHOUT_GEOMETRY,
-            dict(limit=PHOTO_CROP_BATCH_SIZE),
+            dict(after=after, limit=PHOTO_CROP_BATCH_SIZE),
         )
         rows = await cur.fetchall()
 
     uuids = [row['uuid'] for row in rows]
 
     if not uuids:
-        return
+        return after
 
     await _backfill(uuids)
 
+    return uuids[-1]
+
 async def backfill_photo_crops_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
+
+    # The cursor only ever advances: a wet run drains the queue via
+    # `crop_attempted_at` anyway, and a dry run - which writes nothing - would
+    # otherwise re-download the same batch every poll. Restart to re-walk.
+    after = ''
+
     while True:
-        await print_stacktrace(backfill_photo_crops_once)
+        async def advance() -> None:
+            nonlocal after
+            after = await backfill_photo_crops_once(after)
+
+        await print_stacktrace(advance)
         await asyncio.sleep(PHOTO_CROP_POLL_SECONDS)

--- a/backend/service/cron/photocrop/sql/__init__.py
+++ b/backend/service/cron/photocrop/sql/__init__.py
@@ -26,8 +26,7 @@ SET
     width = %(width)s,
     height = %(height)s,
     crop_top = %(crop_top)s,
-    crop_left = %(crop_left)s,
-    crop_attempted_at = now()
+    crop_left = %(crop_left)s
 WHERE
     uuid = %(uuid)s
 """

--- a/backend/service/cron/photocrop/sql/__init__.py
+++ b/backend/service/cron/photocrop/sql/__init__.py
@@ -1,8 +1,7 @@
-# `crop_attempted_at` is what drains this queue. A photo whose crop can't be
-# recovered - a missing rendition, or renditions that don't match - would
-# otherwise stay `width IS NULL` and be re-fetched on every pass, and since the
-# batch isn't offset, a batch of them would sit at the head forever and the
-# backlog would never move.
+# `crop_attempted_at` drains the queue: photos whose crop can't be recovered
+# would otherwise stay `width IS NULL` and be re-fetched on every pass. The
+# keyset cursor (`after`) does the same for dry runs, which never mark
+# anything. Served by the partial index idx__photo__crop_backlog.
 Q_PHOTOS_WITHOUT_GEOMETRY = """
 SELECT
     uuid
@@ -12,6 +11,10 @@ WHERE
     width IS NULL
 AND
     crop_attempted_at IS NULL
+AND
+    uuid > %(after)s
+ORDER BY
+    uuid
 LIMIT
     %(limit)s
 """

--- a/backend/service/cron/photocrop/sql/__init__.py
+++ b/backend/service/cron/photocrop/sql/__init__.py
@@ -1,0 +1,39 @@
+# `crop_attempted_at` is what drains this queue. A photo whose crop can't be
+# recovered - a missing rendition, or renditions that don't match - would
+# otherwise stay `width IS NULL` and be re-fetched on every pass, and since the
+# batch isn't offset, a batch of them would sit at the head forever and the
+# backlog would never move.
+Q_PHOTOS_WITHOUT_GEOMETRY = """
+SELECT
+    uuid
+FROM
+    photo
+WHERE
+    width IS NULL
+AND
+    crop_attempted_at IS NULL
+LIMIT
+    %(limit)s
+"""
+
+Q_SET_PHOTO_GEOMETRY = """
+UPDATE
+    photo
+SET
+    width = %(width)s,
+    height = %(height)s,
+    crop_top = %(crop_top)s,
+    crop_left = %(crop_left)s,
+    crop_attempted_at = now()
+WHERE
+    uuid = %(uuid)s
+"""
+
+Q_MARK_PHOTO_CROP_ATTEMPTED = """
+UPDATE
+    photo
+SET
+    crop_attempted_at = now()
+WHERE
+    uuid = ANY(%(uuids)s::TEXT[])
+"""

--- a/backend/service/cron/photocrop/test_init.py
+++ b/backend/service/cron/photocrop/test_init.py
@@ -1,51 +1,15 @@
-from PIL import Image, ImageDraw
 from collections.abc import Awaitable, Callable
 from unittest import mock
 import io
-import random
 import unittest
 
 import service.cron.photocrop as photocrop
-from duophoto import PhotoGeometry
-
-def _photo(width: int, height: int, seed: int) -> Image.Image:
-    # Busy and non-repeating, so the crop offset is unambiguous (see the same
-    # helper in duophoto/test_init.py).
-    rng = random.Random(seed)
-    image = Image.new('RGB', (width, height), (12, 12, 30))
-    draw = ImageDraw.Draw(image)
-    for _ in range(160):
-        x, y = rng.randint(0, width), rng.randint(0, height)
-        draw.ellipse(
-            [x, y, x + rng.randint(15, 90), y + rng.randint(15, 90)],
-            fill=(rng.randint(0, 255), rng.randint(0, 255), rng.randint(0, 255)),
-        )
-    return image
-
-def _jpeg(image: Image.Image) -> bytes:
-    buffer = io.BytesIO()
-    image.save(buffer, format='jpeg', quality=85, subsampling=2)
-    return buffer.getvalue()
-
-# The original and its 450 square crop, as bytes - what the object store holds.
-def _renditions(
-    original: Image.Image,
-    crop_left: int,
-    crop_top: int,
-) -> tuple[bytes, bytes]:
-    min_dim = min(original.size)
-    square = original.crop((
-        crop_left,
-        crop_top,
-        crop_left + min_dim,
-        crop_top + min_dim,
-    )).resize((450, 450))
-    return _jpeg(original), _jpeg(square)
+from duophoto.fixtures import jpeg, photo, renditions
 
 class TestGeometryOf(unittest.TestCase):
     def test_recovers_the_geometry_of_a_matching_pair(self) -> None:
-        original = _photo(1200, 800, seed=1)
-        original_bytes, square_bytes = _renditions(original, crop_left=300, crop_top=0)
+        original = photo(1200, 800, seed=1)
+        original_bytes, square_bytes = renditions(original, crop_left=300, crop_top=0)
 
         geometry = photocrop._geometry_of(
             'uuid', io.BytesIO(original_bytes), io.BytesIO(square_bytes),
@@ -59,29 +23,50 @@ class TestGeometryOf(unittest.TestCase):
     def test_skips_a_pair_that_matches_too_poorly(self) -> None:
         # A square that isn't from this photo. Recording a crop from it would
         # make the photo jump when expanded, so it must be left alone.
-        original = _jpeg(_photo(1200, 800, seed=1))
-        unrelated = _jpeg(_photo(800, 800, seed=2).resize((450, 450)))
+        original = jpeg(photo(1200, 800, seed=1))
+        unrelated = jpeg(photo(800, 800, seed=2).resize((450, 450)))
 
         self.assertIsNone(
             photocrop._geometry_of('uuid', io.BytesIO(original), io.BytesIO(unrelated))
         )
 
     def test_skips_when_a_rendition_is_missing(self) -> None:
-        original = io.BytesIO(_jpeg(_photo(1200, 800, seed=1)))
+        original = io.BytesIO(jpeg(photo(1200, 800, seed=1)))
 
         self.assertIsNone(photocrop._geometry_of('uuid', original, None))
         self.assertIsNone(photocrop._geometry_of('uuid', None, original))
 
+    def test_skips_a_photo_that_fails_to_decode(self) -> None:
+        # PIL only decodes on use, so truncation surfaces during the match
+        # rather than on open. It must be caught per photo, or the whole batch
+        # would never be marked attempted and would be re-selected forever.
+        original = jpeg(photo(1200, 800, seed=1))
+        truncated = original[:len(original) // 2]
+
+        self.assertIsNone(
+            photocrop._geometry_of(
+                'uuid', io.BytesIO(truncated), io.BytesIO(original),
+            )
+        )
+
 # Records what was run against the DB, standing in for a real transaction.
 class _FakeTx:
     def __init__(self) -> None:
-        self.executed: list[tuple[str, object]] = []
-        self.executed_many: list[tuple[str, object]] = []
+        self.executed: list[tuple[str, dict[str, list[str]] | None]] = []
+        self.executed_many: list[tuple[str, list[dict[str, str | int]]]] = []
 
-    async def execute(self, query: str, params: object = None) -> None:
+    async def execute(
+        self,
+        query: str,
+        params: dict[str, list[str]] | None = None,
+    ) -> None:
         self.executed.append((query, params))
 
-    async def executemany(self, query: str, seq: object) -> None:
+    async def executemany(
+        self,
+        query: str,
+        seq: list[dict[str, str | int]],
+    ) -> None:
         self.executed_many.append((query, seq))
 
 class _FakeApiTx:
@@ -110,19 +95,29 @@ class TestBackfill(unittest.IsolatedAsyncioTestCase):
             ]
         return download
 
-    async def test_marks_the_whole_batch_even_when_a_match_fails(self) -> None:
-        # One recoverable photo and one whose square is unrelated to its
-        # original. The bad one must still be marked attempted, or the queue -
-        # which selects `crop_attempted_at IS NULL` - would hand it back forever.
-        good_original, good_square = _renditions(
-            _photo(1200, 800, seed=1), crop_left=300, crop_top=0,
+    async def test_marks_the_whole_batch_even_when_a_photo_fails(self) -> None:
+        # One recoverable photo, one whose square is unrelated to its original,
+        # and one whose original doesn't decode. The bad ones must still be
+        # marked attempted, or the queue - which selects
+        # `crop_attempted_at IS NULL` - would hand them back forever.
+        good_original, good_square = renditions(
+            photo(1200, 800, seed=1), crop_left=300, crop_top=0,
         )
-        bad_original = _jpeg(_photo(1200, 800, seed=3))
-        bad_square = _jpeg(_photo(800, 800, seed=9).resize((450, 450)))
+        bad_original = jpeg(photo(1200, 800, seed=3))
+        bad_square = jpeg(photo(800, 800, seed=9).resize((450, 450)))
+        corrupt_original = good_original[:len(good_original) // 2]
 
-        uuids = ['good', 'bad']
-        originals = {'good': good_original, 'bad': bad_original}
-        squares = {'good': good_square, 'bad': bad_square}
+        uuids = ['good', 'bad', 'corrupt']
+        originals = {
+            'good': good_original,
+            'bad': bad_original,
+            'corrupt': corrupt_original,
+        }
+        squares = {
+            'good': good_square,
+            'bad': bad_square,
+            'corrupt': good_square,
+        }
 
         tx = _FakeTx()
         with mock.patch.object(photocrop, 'download_images', self._download(originals, squares)), \
@@ -133,18 +128,17 @@ class TestBackfill(unittest.IsolatedAsyncioTestCase):
         # The whole batch is marked attempted...
         self.assertEqual(len(tx.executed), 1)
         _, params = tx.executed[0]
-        assert isinstance(params, dict)
-        self.assertEqual(set(params['uuids']), {'good', 'bad'})
+        assert params is not None
+        self.assertEqual(set(params['uuids']), {'good', 'bad', 'corrupt'})
 
         # ...but only the recoverable photo's geometry is written.
         self.assertEqual(len(tx.executed_many), 1)
         _, written = tx.executed_many[0]
-        assert isinstance(written, list)
         self.assertEqual([row['uuid'] for row in written], ['good'])
 
     async def test_writes_geometry_for_a_recovered_photo(self) -> None:
-        original, square = _renditions(
-            _photo(1000, 640, seed=5), crop_left=200, crop_top=0,
+        original, square = renditions(
+            photo(1000, 640, seed=5), crop_left=200, crop_top=0,
         )
         tx = _FakeTx()
         with mock.patch.object(photocrop, 'download_images', self._download({'a': original}, {'a': square})), \
@@ -153,15 +147,15 @@ class TestBackfill(unittest.IsolatedAsyncioTestCase):
             await photocrop._backfill(['a'])
 
         _, written = tx.executed_many[0]
-        assert isinstance(written, list)
         row = written[0]
         self.assertEqual(row['uuid'], 'a')
         self.assertEqual((row['width'], row['height']), (1000, 640))
+        assert isinstance(row['crop_left'], int)
         self.assertLessEqual(abs(row['crop_left'] - 200), 2)
 
     async def test_dry_run_writes_nothing(self) -> None:
-        original, square = _renditions(
-            _photo(1000, 640, seed=7), crop_left=100, crop_top=0,
+        original, square = renditions(
+            photo(1000, 640, seed=7), crop_left=100, crop_top=0,
         )
         tx = _FakeTx()
         with mock.patch.object(photocrop, 'download_images', self._download({'a': original}, {'a': square})), \

--- a/backend/service/cron/photocrop/test_init.py
+++ b/backend/service/cron/photocrop/test_init.py
@@ -1,0 +1,176 @@
+from PIL import Image, ImageDraw
+from collections.abc import Awaitable, Callable
+from unittest import mock
+import io
+import random
+import unittest
+
+import service.cron.photocrop as photocrop
+from duophoto import PhotoGeometry
+
+def _photo(width: int, height: int, seed: int) -> Image.Image:
+    # Busy and non-repeating, so the crop offset is unambiguous (see the same
+    # helper in duophoto/test_init.py).
+    rng = random.Random(seed)
+    image = Image.new('RGB', (width, height), (12, 12, 30))
+    draw = ImageDraw.Draw(image)
+    for _ in range(160):
+        x, y = rng.randint(0, width), rng.randint(0, height)
+        draw.ellipse(
+            [x, y, x + rng.randint(15, 90), y + rng.randint(15, 90)],
+            fill=(rng.randint(0, 255), rng.randint(0, 255), rng.randint(0, 255)),
+        )
+    return image
+
+def _jpeg(image: Image.Image) -> bytes:
+    buffer = io.BytesIO()
+    image.save(buffer, format='jpeg', quality=85, subsampling=2)
+    return buffer.getvalue()
+
+# The original and its 450 square crop, as bytes - what the object store holds.
+def _renditions(
+    original: Image.Image,
+    crop_left: int,
+    crop_top: int,
+) -> tuple[bytes, bytes]:
+    min_dim = min(original.size)
+    square = original.crop((
+        crop_left,
+        crop_top,
+        crop_left + min_dim,
+        crop_top + min_dim,
+    )).resize((450, 450))
+    return _jpeg(original), _jpeg(square)
+
+class TestGeometryOf(unittest.TestCase):
+    def test_recovers_the_geometry_of_a_matching_pair(self) -> None:
+        original = _photo(1200, 800, seed=1)
+        original_bytes, square_bytes = _renditions(original, crop_left=300, crop_top=0)
+
+        geometry = photocrop._geometry_of(
+            'uuid', io.BytesIO(original_bytes), io.BytesIO(square_bytes),
+        )
+
+        self.assertIsNotNone(geometry)
+        assert geometry is not None
+        self.assertEqual((geometry.width, geometry.height), (1200, 800))
+        self.assertLessEqual(abs(geometry.crop_left - 300), 2)
+
+    def test_skips_a_pair_that_matches_too_poorly(self) -> None:
+        # A square that isn't from this photo. Recording a crop from it would
+        # make the photo jump when expanded, so it must be left alone.
+        original = _jpeg(_photo(1200, 800, seed=1))
+        unrelated = _jpeg(_photo(800, 800, seed=2).resize((450, 450)))
+
+        self.assertIsNone(
+            photocrop._geometry_of('uuid', io.BytesIO(original), io.BytesIO(unrelated))
+        )
+
+    def test_skips_when_a_rendition_is_missing(self) -> None:
+        original = io.BytesIO(_jpeg(_photo(1200, 800, seed=1)))
+
+        self.assertIsNone(photocrop._geometry_of('uuid', original, None))
+        self.assertIsNone(photocrop._geometry_of('uuid', None, original))
+
+# Records what was run against the DB, standing in for a real transaction.
+class _FakeTx:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, object]] = []
+        self.executed_many: list[tuple[str, object]] = []
+
+    async def execute(self, query: str, params: object = None) -> None:
+        self.executed.append((query, params))
+
+    async def executemany(self, query: str, seq: object) -> None:
+        self.executed_many.append((query, seq))
+
+class _FakeApiTx:
+    def __init__(self, tx: _FakeTx) -> None:
+        self._tx = tx
+
+    async def __aenter__(self) -> _FakeTx:
+        return self._tx
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+class TestBackfill(unittest.IsolatedAsyncioTestCase):
+    def _download(
+        self,
+        originals: dict[str, bytes],
+        squares: dict[str, bytes],
+    ) -> Callable[[list[str], str], Awaitable[list[io.BytesIO | None]]]:
+        # Mirrors cronutil.download_images: a rendition per uuid, or None if the
+        # object is missing. Fresh BytesIO each call since PIL consumes them.
+        async def download(uuids: list[str], prefix: str) -> list[io.BytesIO | None]:
+            source = originals if prefix == 'original-' else squares
+            return [
+                io.BytesIO(source[u]) if u in source else None
+                for u in uuids
+            ]
+        return download
+
+    async def test_marks_the_whole_batch_even_when_a_match_fails(self) -> None:
+        # One recoverable photo and one whose square is unrelated to its
+        # original. The bad one must still be marked attempted, or the queue -
+        # which selects `crop_attempted_at IS NULL` - would hand it back forever.
+        good_original, good_square = _renditions(
+            _photo(1200, 800, seed=1), crop_left=300, crop_top=0,
+        )
+        bad_original = _jpeg(_photo(1200, 800, seed=3))
+        bad_square = _jpeg(_photo(800, 800, seed=9).resize((450, 450)))
+
+        uuids = ['good', 'bad']
+        originals = {'good': good_original, 'bad': bad_original}
+        squares = {'good': good_square, 'bad': bad_square}
+
+        tx = _FakeTx()
+        with mock.patch.object(photocrop, 'download_images', self._download(originals, squares)), \
+             mock.patch.object(photocrop, 'api_tx', lambda: _FakeApiTx(tx)), \
+             mock.patch.object(photocrop, 'DRY_RUN', False):
+            await photocrop._backfill(uuids)
+
+        # The whole batch is marked attempted...
+        self.assertEqual(len(tx.executed), 1)
+        _, params = tx.executed[0]
+        assert isinstance(params, dict)
+        self.assertEqual(set(params['uuids']), {'good', 'bad'})
+
+        # ...but only the recoverable photo's geometry is written.
+        self.assertEqual(len(tx.executed_many), 1)
+        _, written = tx.executed_many[0]
+        assert isinstance(written, list)
+        self.assertEqual([row['uuid'] for row in written], ['good'])
+
+    async def test_writes_geometry_for_a_recovered_photo(self) -> None:
+        original, square = _renditions(
+            _photo(1000, 640, seed=5), crop_left=200, crop_top=0,
+        )
+        tx = _FakeTx()
+        with mock.patch.object(photocrop, 'download_images', self._download({'a': original}, {'a': square})), \
+             mock.patch.object(photocrop, 'api_tx', lambda: _FakeApiTx(tx)), \
+             mock.patch.object(photocrop, 'DRY_RUN', False):
+            await photocrop._backfill(['a'])
+
+        _, written = tx.executed_many[0]
+        assert isinstance(written, list)
+        row = written[0]
+        self.assertEqual(row['uuid'], 'a')
+        self.assertEqual((row['width'], row['height']), (1000, 640))
+        self.assertLessEqual(abs(row['crop_left'] - 200), 2)
+
+    async def test_dry_run_writes_nothing(self) -> None:
+        original, square = _renditions(
+            _photo(1000, 640, seed=7), crop_left=100, crop_top=0,
+        )
+        tx = _FakeTx()
+        with mock.patch.object(photocrop, 'download_images', self._download({'a': original}, {'a': square})), \
+             mock.patch.object(photocrop, 'api_tx', lambda: _FakeApiTx(tx)), \
+             mock.patch.object(photocrop, 'DRY_RUN', True):
+            await photocrop._backfill(['a'])
+
+        self.assertEqual(tx.executed, [])
+        self.assertEqual(tx.executed_many, [])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/test/functionality1/feed-v2.sh
+++ b/backend/test/functionality1/feed-v2.sh
@@ -196,6 +196,12 @@ test_json_format () {
   {
     "added_photo_blurhash": "redacted_nonnull_value",
     "added_photo_extra_exts": [],
+    "added_photo_geometry": {
+      "crop_left": 0,
+      "crop_top": 0,
+      "height": 100,
+      "width": 100
+    },
     "added_photo_uuid": "redacted_nonnull_value",
     "advertiser_friendly": false,
     "age": 26,
@@ -291,6 +297,12 @@ test_json_format () {
   {
     "added_photo_blurhash": "redacted_nonnull_value",
     "added_photo_extra_exts": [],
+    "added_photo_geometry": {
+      "crop_left": 0,
+      "crop_top": 0,
+      "height": 100,
+      "width": 100
+    },
     "added_photo_uuid": "redacted_nonnull_value",
     "advertiser_friendly": false,
     "age": 26,
@@ -315,6 +327,12 @@ test_json_format () {
   {
     "added_photo_blurhash": "redacted_nonnull_value",
     "added_photo_extra_exts": [],
+    "added_photo_geometry": {
+      "crop_left": 0,
+      "crop_top": 0,
+      "height": 100,
+      "width": 100
+    },
     "added_photo_uuid": "redacted_nonnull_value",
     "advertiser_friendly": false,
     "age": 26,
@@ -339,6 +357,12 @@ test_json_format () {
   {
     "added_photo_blurhash": "redacted_nonnull_value",
     "added_photo_extra_exts": [],
+    "added_photo_geometry": {
+      "crop_left": 0,
+      "crop_top": 0,
+      "height": 100,
+      "width": 100
+    },
     "added_photo_uuid": "redacted_nonnull_value",
     "advertiser_friendly": false,
     "age": 26,

--- a/backend/test/functionality1/feed.sh
+++ b/backend/test/functionality1/feed.sh
@@ -145,6 +145,12 @@ test_json_format () {
   {
     "added_photo_blurhash": "redacted_nonnull_value",
     "added_photo_extra_exts": [],
+    "added_photo_geometry": {
+      "crop_left": 0,
+      "crop_top": 0,
+      "height": 100,
+      "width": 100
+    },
     "added_photo_uuid": "redacted_nonnull_value",
     "advertiser_friendly": false,
     "age": 26,
@@ -166,6 +172,12 @@ test_json_format () {
   {
     "added_photo_blurhash": "redacted_nonnull_value",
     "added_photo_extra_exts": [],
+    "added_photo_geometry": {
+      "crop_left": 0,
+      "crop_top": 0,
+      "height": 100,
+      "width": 100
+    },
     "added_photo_uuid": "redacted_nonnull_value",
     "advertiser_friendly": false,
     "age": 26,
@@ -207,6 +219,12 @@ test_json_format () {
   {
     "added_photo_blurhash": "redacted_nonnull_value",
     "added_photo_extra_exts": [],
+    "added_photo_geometry": {
+      "crop_left": 0,
+      "crop_top": 0,
+      "height": 100,
+      "width": 100
+    },
     "added_photo_uuid": "redacted_nonnull_value",
     "advertiser_friendly": false,
     "age": 26,

--- a/backend/test/functionality1/prospect-profile.sh
+++ b/backend/test/functionality1/prospect-profile.sh
@@ -84,6 +84,7 @@ expected=$(jq -r . << EOF
   "person_uuid": "$user2_uuid",
   "photo_blurhashes": [],
   "photo_extra_exts": [],
+  "photo_geometries": [],
   "photo_uuids": [],
   "photo_verifications": [],
   "relationship_status": null,
@@ -178,6 +179,7 @@ expected=$(jq -r . << EOF
   "person_uuid": "$user2_uuid",
   "photo_blurhashes": [],
   "photo_extra_exts": [],
+  "photo_geometries": [],
   "photo_uuids": [],
   "photo_verifications": [],
   "relationship_status": null,
@@ -278,3 +280,19 @@ gives_reply_percentage=$(
 [[ "$gets_reply_percentage" = 'null' ]]
 
 [[ "$gives_reply_percentage" = '20.0' ]]
+
+# The expand animation can't run without the photo's geometry, and the field
+# going missing from the response is invisible to the client: it just quietly
+# stops animating. `rand_image` uploads a 100x100 square, so the crop is the
+# whole photo.
+../util/create-user.sh user7 0 1
+
+user7_uuid=$(q "select uuid from person where name = 'user7'")
+
+assume_role user1
+
+photo_geometries=$(
+  c GET /prospect-profile/$user7_uuid \
+    | jq -c '.photo_geometries | map({width, height, crop_top, crop_left})')
+
+[[ "$photo_geometries" = '[{"width":100,"height":100,"crop_top":0,"crop_left":0}]' ]]

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -27,6 +27,7 @@ import { SplashScreen } from './components/splash-screen';
 import { ConversationScreen } from './components/conversation-screen/conversation-screen';
 import { ServerStatus, UtilityScreen } from './components/utility-screen';
 import { ProspectProfileScreen } from './components/prospect-profile-screen/prospect-profile-screen';
+import { GalleryScreen } from './components/gallery-screen';
 import { InviteScreen, WelcomeScreen } from './components/welcome-screen';
 import { sessionToken, sessionPersonUuid } from './kv-storage/session-token';
 import { lastPath } from './kv-storage/last-path';
@@ -538,6 +539,16 @@ const App = () => {
                 <Stack.Screen
                   name="Prospect Profile Screen"
                   component={ProspectProfileScreen} />
+                <Stack.Screen
+                  name="Gallery Screen"
+                  component={GalleryScreen}
+                  // The gallery animates itself, expanding out of the preview
+                  // on the screen underneath - which it therefore has to let
+                  // show through, and mustn't slide over.
+                  options={{
+                    presentation: 'transparentModal',
+                    animation: 'none',
+                  }} />
                 <Stack.Screen
                   name="Invite Screen"
                   component={InviteScreen}

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -53,7 +53,7 @@ import { verificationWatcher } from './verification/verification';
 import { ClubItem } from './club/club';
 import { Toast } from './components/toast';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { createLinking, isBannerRoute, focusedProspectHandle, focusedConversationHandle, focusedRouteIsWizard, getTopRouteName } from './navigation/linking';
+import { createLinking, isBannerRoute, focusedProspectHandle, focusedConversationHandle, focusedRouteIsUnrestorable, getTopRouteName } from './navigation/linking';
 import { useScrollbarStyle } from './components/navigation/scroll-bar-hooks';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
@@ -408,15 +408,12 @@ const App = () => {
     // identity (or vice versa).
     if (!getSignedInUser()) return;
 
-    // Don't persist transient wizard URLs. OptionScreen-backed routes
-    // (`Profile Option Screen`, `Search Filter Option Screen`,
-    // `Create Account Or Sign In Screen`) depend on an in-memory payload
-    // that doesn't survive a hard refresh. If we persisted the wizard URL,
-    // the next cold-start would hydrate the wizard with no payload and
-    // immediately `popToTop` to the parent screen — a visible flicker.
-    // Walking the focused route chain lets us detect this regardless of how
-    // deeply nested the wizard is.
-    if (focusedRouteIsWizard(state)) return;
+    // Don't persist URLs that can't be restored: the OptionScreen-backed
+    // wizards would hydrate with no payload and immediately `popToTop`, and
+    // the gallery would come back as the only route, with no screen under it
+    // to close onto. See `UNRESTORABLE_ROUTE_NAMES`. Walking the focused route
+    // chain detects these regardless of how deeply nested they are.
+    if (focusedRouteIsUnrestorable(state)) return;
 
     // Persist just the canonical path - not the full navigation tree - so we
     // can restore the user's last place on next startup. We let React

--- a/frontend/components/enlargeable-image.tsx
+++ b/frontend/components/enlargeable-image.tsx
@@ -1,36 +1,43 @@
-import { useCallback } from 'react';
-import { GestureResponderEvent, Pressable, StyleProp, ViewStyle } from 'react-native';
+import { useCallback, useRef } from 'react';
+import { GestureResponderEvent, Pressable, StyleProp, View, ViewStyle } from 'react-native';
 import { PhotoOrSkeleton } from './profile-card';
 import { VerificationBadge } from './verification-badge';
 import * as _ from 'lodash';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import type { ProspectParamList } from '../navigation/linking';
+import type { RootParamList } from '../navigation/linking';
 import { Image as ExpoImage } from 'expo-image';
 import { IMAGES_URL } from '../env/env';
 import { hasGifExtraExt } from '../util/photos';
+import type { PhotoGeometry } from '../util/photos';
+import { setExpandedPhoto, useIsPhotoExpanded } from '../events/expanded-photo';
 
 const EnlargeablePhoto = ({
   photoUuid,
   photoExtraExts,
   photoBlurhash,
+  photoGeometry,
   style,
   innerStyle,
   isPrimary,
   isVerified = false,
-  onPress,
 }: {
   photoUuid: string | undefined | null
   photoExtraExts?: string[] | undefined | null
   photoBlurhash: string | undefined | null
+  photoGeometry?: PhotoGeometry | undefined | null
   style?: StyleProp<ViewStyle>
   innerStyle?: StyleProp<ViewStyle>
   isPrimary: boolean
   isVerified?: boolean
-  onPress?: () => void
 }) => {
-  const navigation = useNavigation<NativeStackNavigationProp<ProspectParamList>>();
+  const navigation = useNavigation<NativeStackNavigationProp<RootParamList>>();
   const isGif = hasGifExtraExt(photoExtraExts);
+  const ref = useRef<View>(null);
+
+  // The gallery draws this same photo over the top of this preview and expands
+  // it, so the preview gets out of the way for as long as it's up.
+  const isExpanded = useIsPhotoExpanded(photoUuid);
 
   const internalOnPress = useCallback((event: GestureResponderEvent) => {
     event.stopPropagation();
@@ -39,15 +46,33 @@ const EnlargeablePhoto = ({
       return;
     }
 
-    if (onPress) {
-      return onPress();
+    if (!photoUuid) {
+      return;
     }
 
-    if (photoUuid) {
+    // Without a geometry there's nothing to uncrop the photo into, so the
+    // gallery just fades up instead. Measuring is what tells it where to
+    // expand from, and it can't be done from the layout alone: the preview
+    // scrolls, so only its position at the moment of the press will do.
+    if (!photoGeometry || !ref.current) {
       return navigation.navigate('Gallery Screen', { photoUuid });
     }
-  }, [photoUuid]);
 
+    ref.current.measureInWindow((x, y, width, height) => {
+      // A zero-sized measurement means the preview isn't laid out where we can
+      // expand from - fall back rather than animate out of nothing.
+      if (width > 0 && height > 0) {
+        setExpandedPhoto({
+          photoUuid,
+          from: { x, y, width, height },
+          geometry: photoGeometry,
+          covered: false,
+        });
+      }
+
+      navigation.navigate('Gallery Screen', { photoUuid });
+    });
+  }, [photoUuid, photoGeometry, navigation]);
 
   const prefetchEnlargedImage = useCallback(() => {
     if (!photoUuid || isGif) return;
@@ -67,6 +92,7 @@ const EnlargeablePhoto = ({
 
   return (
     <Pressable
+      ref={ref}
       disabled={isGif || !photoUuid}
       onPress={internalOnPress}
       style={[
@@ -75,6 +101,7 @@ const EnlargeablePhoto = ({
           aspectRatio: 1,
         },
         style,
+        isExpanded ? { opacity: 0 } : null,
       ]}
     >
       <PhotoOrSkeleton

--- a/frontend/components/enlargeable-image.tsx
+++ b/frontend/components/enlargeable-image.tsx
@@ -56,19 +56,14 @@ const EnlargeablePhoto = ({
     }
 
     // Without a geometry there's nothing to uncrop the photo into, so the
-    // gallery just fades up instead. Measuring is what tells it where to
-    // expand from, and it can't be done from the layout alone: the preview
-    // scrolls, so only its position at the moment of the press will do.
+    // gallery just fades up instead.
     if (!photoGeometry || !ref.current) {
       return navigation.navigate('Gallery Screen', { photoUuid });
     }
 
-    // So the gallery can animate the preview's rounded corners out to square as
-    // it fills the screen, and back on the way in. Read each corner (the
-    // big-screen primary photo rounds only its bottom two), falling back to the
-    // `borderRadius` shorthand. Only plain pixel radii are animatable here; a
-    // percentage (rare, and not used by these styles) reads as no rounding
-    // rather than a wrong number.
+    // Per corner (the big-screen primary photo rounds only its bottom two),
+    // falling back to the shorthand. Only plain pixel radii are animatable; a
+    // percentage reads as no rounding rather than a wrong number.
     const flat = StyleSheet.flatten(style) ?? {};
     const px = (value: unknown, fallback: number): number =>
       typeof value === 'number' ? value : fallback;
@@ -80,13 +75,12 @@ const EnlargeablePhoto = ({
       bottomRight: px(flat.borderBottomRightRadius, shorthand),
     };
 
-    // The photos the gallery can page between. Fall back to just this one.
     const fullAlbum: AlbumPhoto[] =
       album && album.length ? album : [{ uuid: photoUuid, geometry: photoGeometry }];
 
+    // Measured at press time because the preview scrolls; a zero-sized
+    // measurement means there's nowhere to expand from, so fall back.
     ref.current.measureInWindow((x, y, width, height) => {
-      // A zero-sized measurement means the preview isn't laid out where we can
-      // expand from - fall back rather than animate out of nothing.
       if (width > 0 && height > 0) {
         setExpandedPhoto({
           photoUuid,

--- a/frontend/components/enlargeable-image.tsx
+++ b/frontend/components/enlargeable-image.tsx
@@ -59,11 +59,21 @@ const EnlargeablePhoto = ({
     }
 
     // So the gallery can animate the preview's rounded corners out to square as
-    // it fills the screen, and back on the way in. Only a plain pixel radius is
-    // animatable here; a percentage (rare, and not used by these styles) falls
-    // back to no rounding rather than a wrong number.
-    const flatRadius = StyleSheet.flatten(style)?.borderRadius;
-    const borderRadius = typeof flatRadius === 'number' ? flatRadius : 0;
+    // it fills the screen, and back on the way in. Read each corner (the
+    // big-screen primary photo rounds only its bottom two), falling back to the
+    // `borderRadius` shorthand. Only plain pixel radii are animatable here; a
+    // percentage (rare, and not used by these styles) reads as no rounding
+    // rather than a wrong number.
+    const flat = StyleSheet.flatten(style) ?? {};
+    const px = (value: unknown, fallback: number): number =>
+      typeof value === 'number' ? value : fallback;
+    const shorthand = px(flat.borderRadius, 0);
+    const borderRadius = {
+      topLeft: px(flat.borderTopLeftRadius, shorthand),
+      topRight: px(flat.borderTopRightRadius, shorthand),
+      bottomLeft: px(flat.borderBottomLeftRadius, shorthand),
+      bottomRight: px(flat.borderBottomRightRadius, shorthand),
+    };
 
     ref.current.measureInWindow((x, y, width, height) => {
       // A zero-sized measurement means the preview isn't laid out where we can

--- a/frontend/components/enlargeable-image.tsx
+++ b/frontend/components/enlargeable-image.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react';
-import { GestureResponderEvent, Pressable, StyleProp, View, ViewStyle } from 'react-native';
+import { GestureResponderEvent, Pressable, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { PhotoOrSkeleton } from './profile-card';
 import { VerificationBadge } from './verification-badge';
 import * as _ from 'lodash';
@@ -58,6 +58,13 @@ const EnlargeablePhoto = ({
       return navigation.navigate('Gallery Screen', { photoUuid });
     }
 
+    // So the gallery can animate the preview's rounded corners out to square as
+    // it fills the screen, and back on the way in. Only a plain pixel radius is
+    // animatable here; a percentage (rare, and not used by these styles) falls
+    // back to no rounding rather than a wrong number.
+    const flatRadius = StyleSheet.flatten(style)?.borderRadius;
+    const borderRadius = typeof flatRadius === 'number' ? flatRadius : 0;
+
     ref.current.measureInWindow((x, y, width, height) => {
       // A zero-sized measurement means the preview isn't laid out where we can
       // expand from - fall back rather than animate out of nothing.
@@ -66,13 +73,14 @@ const EnlargeablePhoto = ({
           photoUuid,
           from: { x, y, width, height },
           geometry: photoGeometry,
+          borderRadius,
           covered: false,
         });
       }
 
       navigation.navigate('Gallery Screen', { photoUuid });
     });
-  }, [photoUuid, photoGeometry, navigation]);
+  }, [photoUuid, photoGeometry, style, navigation]);
 
   const prefetchEnlargedImage = useCallback(() => {
     if (!photoUuid || isGif) return;

--- a/frontend/components/enlargeable-image.tsx
+++ b/frontend/components/enlargeable-image.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef } from 'react';
-import { GestureResponderEvent, Pressable, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+import { GestureResponderEvent, Pressable, StyleProp, View, ViewStyle } from 'react-native';
 import { PhotoOrSkeleton } from './profile-card';
 import { VerificationBadge } from './verification-badge';
 import * as _ from 'lodash';
@@ -11,7 +11,28 @@ import { IMAGES_URL } from '../env/env';
 import { hasGifExtraExt } from '../util/photos';
 import type { PhotoGeometry } from '../util/photos';
 import { setExpandedPhoto, useIsPhotoExpanded } from '../events/expanded-photo';
-import type { AlbumPhoto } from '../events/expanded-photo';
+import type { AlbumPhoto, BorderRadii } from '../events/expanded-photo';
+
+// This component owns the preview's corner rounding (rather than reading it
+// back out of `style`) because the gallery animates the same radii while the
+// photo expands. Corners a partial object omits are square.
+const toBorderRadii = (
+  borderRadius: number | Partial<BorderRadii> | undefined,
+): BorderRadii =>
+  typeof borderRadius === 'number'
+    ? {
+      topLeft: borderRadius,
+      topRight: borderRadius,
+      bottomLeft: borderRadius,
+      bottomRight: borderRadius,
+    }
+    : {
+      topLeft: 0,
+      topRight: 0,
+      bottomLeft: 0,
+      bottomRight: 0,
+      ...borderRadius,
+    };
 
 const EnlargeablePhoto = ({
   photoUuid,
@@ -19,6 +40,7 @@ const EnlargeablePhoto = ({
   photoBlurhash,
   photoGeometry,
   album,
+  borderRadius,
   style,
   innerStyle,
   isPrimary,
@@ -31,6 +53,7 @@ const EnlargeablePhoto = ({
   // Every photo of the same person, so the gallery can page between them. When
   // omitted (e.g. the feed), the tapped photo is the only one.
   album?: AlbumPhoto[] | undefined | null
+  borderRadius?: number | Partial<BorderRadii>
   style?: StyleProp<ViewStyle>
   innerStyle?: StyleProp<ViewStyle>
   isPrimary: boolean
@@ -61,20 +84,6 @@ const EnlargeablePhoto = ({
       return navigation.navigate('Gallery Screen', { photoUuid });
     }
 
-    // Per corner (the big-screen primary photo rounds only its bottom two),
-    // falling back to the shorthand. Only plain pixel radii are animatable; a
-    // percentage reads as no rounding rather than a wrong number.
-    const flat = StyleSheet.flatten(style) ?? {};
-    const px = (value: unknown, fallback: number): number =>
-      typeof value === 'number' ? value : fallback;
-    const shorthand = px(flat.borderRadius, 0);
-    const borderRadius = {
-      topLeft: px(flat.borderTopLeftRadius, shorthand),
-      topRight: px(flat.borderTopRightRadius, shorthand),
-      bottomLeft: px(flat.borderBottomLeftRadius, shorthand),
-      bottomRight: px(flat.borderBottomRightRadius, shorthand),
-    };
-
     const fullAlbum: AlbumPhoto[] =
       album && album.length ? album : [{ uuid: photoUuid, geometry: photoGeometry }];
 
@@ -87,14 +96,14 @@ const EnlargeablePhoto = ({
           album: fullAlbum,
           from: { x, y, width, height },
           geometry: photoGeometry,
-          borderRadius,
+          borderRadius: toBorderRadii(borderRadius),
           covered: false,
         });
       }
 
       navigation.navigate('Gallery Screen', { photoUuid });
     });
-  }, [photoUuid, photoGeometry, album, style, navigation]);
+  }, [photoUuid, photoGeometry, album, borderRadius, navigation]);
 
   const prefetchEnlargedImage = useCallback(() => {
     if (!photoUuid || isGif) return;
@@ -112,6 +121,8 @@ const EnlargeablePhoto = ({
     return <></>;
   }
 
+  const radii = toBorderRadii(borderRadius);
+
   return (
     <Pressable
       ref={ref}
@@ -121,6 +132,10 @@ const EnlargeablePhoto = ({
         {
           width: '100%',
           aspectRatio: 1,
+          borderTopLeftRadius: radii.topLeft,
+          borderTopRightRadius: radii.topRight,
+          borderBottomLeftRadius: radii.bottomLeft,
+          borderBottomRightRadius: radii.bottomRight,
         },
         style,
         isExpanded ? { opacity: 0 } : null,

--- a/frontend/components/enlargeable-image.tsx
+++ b/frontend/components/enlargeable-image.tsx
@@ -11,12 +11,14 @@ import { IMAGES_URL } from '../env/env';
 import { hasGifExtraExt } from '../util/photos';
 import type { PhotoGeometry } from '../util/photos';
 import { setExpandedPhoto, useIsPhotoExpanded } from '../events/expanded-photo';
+import type { AlbumPhoto } from '../events/expanded-photo';
 
 const EnlargeablePhoto = ({
   photoUuid,
   photoExtraExts,
   photoBlurhash,
   photoGeometry,
+  album,
   style,
   innerStyle,
   isPrimary,
@@ -26,6 +28,9 @@ const EnlargeablePhoto = ({
   photoExtraExts?: string[] | undefined | null
   photoBlurhash: string | undefined | null
   photoGeometry?: PhotoGeometry | undefined | null
+  // Every photo of the same person, so the gallery can page between them. When
+  // omitted (e.g. the feed), the tapped photo is the only one.
+  album?: AlbumPhoto[] | undefined | null
   style?: StyleProp<ViewStyle>
   innerStyle?: StyleProp<ViewStyle>
   isPrimary: boolean
@@ -75,12 +80,17 @@ const EnlargeablePhoto = ({
       bottomRight: px(flat.borderBottomRightRadius, shorthand),
     };
 
+    // The photos the gallery can page between. Fall back to just this one.
+    const fullAlbum: AlbumPhoto[] =
+      album && album.length ? album : [{ uuid: photoUuid, geometry: photoGeometry }];
+
     ref.current.measureInWindow((x, y, width, height) => {
       // A zero-sized measurement means the preview isn't laid out where we can
       // expand from - fall back rather than animate out of nothing.
       if (width > 0 && height > 0) {
         setExpandedPhoto({
           photoUuid,
+          album: fullAlbum,
           from: { x, y, width, height },
           geometry: photoGeometry,
           borderRadius,
@@ -90,7 +100,7 @@ const EnlargeablePhoto = ({
 
       navigation.navigate('Gallery Screen', { photoUuid });
     });
-  }, [photoUuid, photoGeometry, style, navigation]);
+  }, [photoUuid, photoGeometry, album, style, navigation]);
 
   const prefetchEnlargedImage = useCallback(() => {
     if (!photoUuid || isGif) return;

--- a/frontend/components/feed-tab.tsx
+++ b/frontend/components/feed-tab.tsx
@@ -98,10 +98,20 @@ const DataItemBaseSchema = z.object({
   location: z.string().nullable(),
 });
 
+// Absent for photos whose geometry the server hasn't recorded, which the
+// gallery reads as "“don't expand this one".
+const PhotoGeometrySchema = z.object({
+  width: z.number(),
+  height: z.number(),
+  crop_top: z.number(),
+  crop_left: z.number(),
+});
+
 const AddedPhotoFieldsSchema = DataItemBaseSchema.extend({
   added_photo_uuid: z.string(),
   added_photo_blurhash: z.string(),
   added_photo_extra_exts: z.array(z.string()),
+  added_photo_geometry: PhotoGeometrySchema.optional(),
 });
 
 const AddedVoiceBioFieldsSchema = DataItemBaseSchema.extend({
@@ -328,20 +338,6 @@ const useNavigationToProfile = (
       }
     );
   }, [handle, photoBlurhash]);
-};
-
-const useNavigationToProfileGallery = (photoUuid: string) => {
-  const navigation = useNavigation<NativeStackNavigationProp<RootParamList>>();
-
-  return useCallback(() => {
-    navigation.navigate(
-      'Prospect Profile Screen',
-      {
-        screen: 'Gallery Screen',
-        params: { photoUuid },
-      }
-    );
-  }, [photoUuid]);
 };
 
 const AgeGenderLocation = ({
@@ -1336,8 +1332,6 @@ const FeedItemAddedPhoto = ({
     fields.photo_blurhash,
   );
 
-  const onPressPhoto = useNavigationToProfileGallery(fields.added_photo_uuid);
-
   const { backgroundColor, onPressIn, onPressOut } = usePressableAnimation();
 
   const props = isMobile() ? {
@@ -1375,10 +1369,10 @@ const FeedItemAddedPhoto = ({
           />
           <ActionTime action={action} time={new Date(fields.time)} />
           <EnlargeablePhoto
-            onPress={onPressPhoto}
             photoUuid={fields.added_photo_uuid}
             photoExtraExts={fields.added_photo_extra_exts}
             photoBlurhash={fields.added_photo_blurhash}
+            photoGeometry={fields.added_photo_geometry}
             isPrimary={true}
             style={{
               ...commonStyles.secondaryEnlargeablePhoto,

--- a/frontend/components/feed-tab.tsx
+++ b/frontend/components/feed-tab.tsx
@@ -99,7 +99,7 @@ const DataItemBaseSchema = z.object({
 });
 
 // Absent for photos whose geometry the server hasn't recorded, which the
-// gallery reads as "“don't expand this one".
+// gallery reads as "don't expand this one".
 const PhotoGeometrySchema = z.object({
   width: z.number(),
   height: z.number(),

--- a/frontend/components/feed-tab.tsx
+++ b/frontend/components/feed-tab.tsx
@@ -1374,6 +1374,7 @@ const FeedItemAddedPhoto = ({
             photoBlurhash={fields.added_photo_blurhash}
             photoGeometry={fields.added_photo_geometry}
             isPrimary={true}
+            borderRadius={12}
             style={{
               ...commonStyles.secondaryEnlargeablePhoto,
               marginTop: 0,

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -34,8 +34,6 @@ const EASING = Easing.bezier(0.33, 0, 0.15, 1);
 // the way to transparent.
 const DISMISS_FADE_RANGE = 300;
 
-// The backdrop's opacity for a dismiss drag of `(x, y)`: 1 untouched, fading
-// to 0 as the photo is dragged away.
 const dragBackdropOpacity = (x: number, y: number) => {
   'worklet';
   return 1 - Math.min(1, dragDistance(x, y) / DISMISS_FADE_RANGE);
@@ -101,23 +99,23 @@ const ExpandingPhoto = ({
     const dragRadius = dragDismissRadius(dismiss.x.value, dismiss.y.value);
 
     return {
-    left: lerp(closed.clip.x, opened.clip.x, progress.value),
-    top: lerp(closed.clip.y, opened.clip.y, progress.value),
-    width: lerp(closed.clip.width, opened.clip.width, progress.value),
-    height: lerp(closed.clip.height, opened.clip.height, progress.value),
-    borderTopLeftRadius: lerp(borderRadius.topLeft, 0, progress.value) + dragRadius,
-    borderTopRightRadius: lerp(borderRadius.topRight, 0, progress.value) + dragRadius,
-    borderBottomLeftRadius: lerp(borderRadius.bottomLeft, 0, progress.value) + dragRadius,
-    borderBottomRightRadius: lerp(borderRadius.bottomRight, 0, progress.value) + dragRadius,
-    transform: [
-      // The pager offset and dismiss drag are screen-space, so they go
-      // outermost, ahead of the zoom scale.
-      { translateX: (openedX - scrollX.value) + dismiss.x.value },
-      { translateY: dismiss.y.value },
-      { scale: lerp(1, zoom.scale.value, progress.value) },
-      { translateX: lerp(0, zoom.translateX.value, progress.value) },
-      { translateY: lerp(0, zoom.translateY.value, progress.value) },
-    ],
+      left: lerp(closed.clip.x, opened.clip.x, progress.value),
+      top: lerp(closed.clip.y, opened.clip.y, progress.value),
+      width: lerp(closed.clip.width, opened.clip.width, progress.value),
+      height: lerp(closed.clip.height, opened.clip.height, progress.value),
+      borderTopLeftRadius: lerp(borderRadius.topLeft, 0, progress.value) + dragRadius,
+      borderTopRightRadius: lerp(borderRadius.topRight, 0, progress.value) + dragRadius,
+      borderBottomLeftRadius: lerp(borderRadius.bottomLeft, 0, progress.value) + dragRadius,
+      borderBottomRightRadius: lerp(borderRadius.bottomRight, 0, progress.value) + dragRadius,
+      transform: [
+        // The pager offset and dismiss drag are screen-space, so they go
+        // outermost, ahead of the zoom scale.
+        { translateX: (openedX - scrollX.value) + dismiss.x.value },
+        { translateY: dismiss.y.value },
+        { scale: lerp(1, zoom.scale.value, progress.value) },
+        { translateX: lerp(0, zoom.translateX.value, progress.value) },
+        { translateY: lerp(0, zoom.translateY.value, progress.value) },
+      ],
     };
   });
 
@@ -167,10 +165,6 @@ const ExpandingPhoto = ({
   );
 };
 
-// Desktop's paging affordance, standing in for the swipe gesture: a chevron at
-// the screen's edge, matching the counter pill's look. Rendered only when
-// there's a neighbour in that direction, so the buttons also read as "you're
-// at the end".
 const PagerChevron = ({
   direction,
   onNavigate,
@@ -214,7 +208,6 @@ const GalleryScreen = ({
     return e?.photoUuid === photoUuid ? e : null;
   });
 
-  // A deep link with no album is a one-photo gallery.
   const album: AlbumPhoto[] = useMemo(
     () => expandedPhoto?.album ?? [{ uuid: photoUuid, geometry: null }],
     [expandedPhoto, photoUuid],
@@ -257,7 +250,7 @@ const GalleryScreen = ({
   }), [zoomScale, zoomTranslateX, zoomTranslateY]);
 
   // A fixed identity transform for the off-screen pages, which aren't
-  // zoomable. Only the current page gets the live `zoom`.
+  // zoomable.
   const identityScale = useSharedValue(1);
   const identityZero = useSharedValue(0);
   const identityZoom: PinchyZoom = useMemo(() => ({
@@ -352,10 +345,8 @@ const GalleryScreen = ({
     setIndex(target);
   }, []);
 
-  // Move to another photo, sliding the pager and resetting the zoom/dismiss
-  // of the photo we're leaving. Leaving a zoomed photo unzooms it in step
-  // with the slide, deferring the index - and with it, which page owns the
-  // live zoom - until both land.
+  // Leaving a zoomed photo unzooms it in step with the slide, deferring the
+  // index - and with it, which page owns the live zoom - until both land.
   const goTo = useCallback((next: number) => {
     const target = Math.max(0, Math.min(album.length - 1, next));
     if (target === index) {
@@ -449,7 +440,6 @@ const GalleryScreen = ({
     // `finish` runs even if the timing is interrupted: better to cut the
     // animation short than to leave the navigation permanently prevented.
     if (morphOnClose) {
-      // Reverse the expand back into the preview.
       setPhase('closing');
       progress.value = withTiming(
         0,
@@ -528,79 +518,79 @@ const GalleryScreen = ({
       onLayout={onContainerLayout}
       style={StyleSheet.absoluteFill}
     >
-     <Reanimated.View style={[StyleSheet.absoluteFill, fadeStyle]}>
-      <Reanimated.View style={[styles.backdrop, backdropStyle]} />
+      <Reanimated.View style={[StyleSheet.absoluteFill, fadeStyle]}>
+        <Reanimated.View style={[styles.backdrop, backdropStyle]} />
 
-      {/*
-        Stays mounted under the pager for the opened photo, so it covers the
-        moment the pager's interactive copy mounts (opening) and unmounts
-        (closing) - otherwise that hand-off flickers.
-      */}
-      {expandedPhoto && container && onOpenedPhoto &&
-        <ExpandingPhoto
-          expandedPhoto={expandedPhoto}
-          progress={progress}
-          container={container}
-          zoom={zoom}
-          dismiss={dismiss}
-          scrollX={scrollX}
-          openedX={openedIndex * width}
-          onCovered={onCovered}
-        />
-      }
+        {/*
+          Stays mounted under the pager for the opened photo, so it covers the
+          moment the pager's interactive copy mounts (opening) and unmounts
+          (closing) - otherwise that hand-off flickers.
+        */}
+        {expandedPhoto && container && onOpenedPhoto &&
+          <ExpandingPhoto
+            expandedPhoto={expandedPhoto}
+            progress={progress}
+            container={container}
+            zoom={zoom}
+            dismiss={dismiss}
+            scrollX={scrollX}
+            openedX={openedIndex * width}
+            onCovered={onCovered}
+          />
+        }
 
-      {phase === 'open' && container &&
-        <Reanimated.View style={[StyleSheet.absoluteFill, rowStyle]}>
-          {album.map((photo, i) => Math.abs(i - index) > 1 ? null : (
-            <View
-              key={photo.uuid}
-              style={[styles.slot, { left: i * width, width, height: container.height }]}
-            >
-              <Pinchy
-                uuid={photo.uuid}
-                naturalSize={photo.geometry ?? undefined}
-                zoom={i === index ? zoom : identityZoom}
-                dismiss={i === index ? dismiss : undefined}
-                onDismiss={i === index ? onDismiss : undefined}
-                page={i === index && album.length > 1 ? page : undefined}
-                onNavigate={i === index && album.length > 1 ? onNavigate : undefined}
-                onTapEdge={
-                  isDesktopWeb && i === index && album.length > 1
-                    ? onNavigate
-                    : undefined
-                }
-                viewport={container}
-                backgroundColor={i === index ? 'transparent' : 'black'}
-              />
-            </View>
-          ))}
-        </Reanimated.View>
-      }
+        {phase === 'open' && container &&
+          <Reanimated.View style={[StyleSheet.absoluteFill, rowStyle]}>
+            {album.map((photo, i) => Math.abs(i - index) > 1 ? null : (
+              <View
+                key={photo.uuid}
+                style={[styles.slot, { left: i * width, width, height: container.height }]}
+              >
+                <Pinchy
+                  uuid={photo.uuid}
+                  naturalSize={photo.geometry ?? undefined}
+                  zoom={i === index ? zoom : identityZoom}
+                  dismiss={i === index ? dismiss : undefined}
+                  onDismiss={i === index ? onDismiss : undefined}
+                  page={i === index && album.length > 1 ? page : undefined}
+                  onNavigate={i === index && album.length > 1 ? onNavigate : undefined}
+                  onTapEdge={
+                    isDesktopWeb && i === index && album.length > 1
+                      ? onNavigate
+                      : undefined
+                  }
+                  viewport={container}
+                  backgroundColor={i === index ? 'transparent' : 'black'}
+                />
+              </View>
+            ))}
+          </Reanimated.View>
+        }
 
-      {isDesktopWeb && phase === 'open' && index > 0 &&
-        <PagerChevron direction={-1} onNavigate={onNavigate} />
-      }
-      {isDesktopWeb && phase === 'open' && index < album.length - 1 &&
-        <PagerChevron direction={1} onNavigate={onNavigate} />
-      }
+        {isDesktopWeb && phase === 'open' && index > 0 &&
+          <PagerChevron direction={-1} onNavigate={onNavigate} />
+        }
+        {isDesktopWeb && phase === 'open' && index < album.length - 1 &&
+          <PagerChevron direction={1} onNavigate={onNavigate} />
+        }
 
-      {album.length > 1 &&
-        <View
-          style={[
-            styles.counter,
-            { top: 14 + (Platform.OS === 'web' ? 0 : insets.top) },
-          ]}
-          pointerEvents="none"
-        >
-          <DefaultText style={styles.counterText}>
-            {index + 1}/{album.length}
-          </DefaultText>
-        </View>
-      }
+        {album.length > 1 &&
+          <View
+            style={[
+              styles.counter,
+              { top: 14 + (Platform.OS === 'web' ? 0 : insets.top) },
+            ]}
+            pointerEvents="none"
+          >
+            <DefaultText style={styles.counterText}>
+              {index + 1}/{album.length}
+            </DefaultText>
+          </View>
+        }
 
-      <StatusBarSpacer/>
-      {isDesktopWeb && <FloatingBackButton onPress={onPressBack}/>}
-     </Reanimated.View>
+        <StatusBarSpacer/>
+        {isDesktopWeb && <FloatingBackButton onPress={onPressBack}/>}
+      </Reanimated.View>
     </View>
   );
 };

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -15,6 +15,7 @@ import { StatusBarSpacer } from './status-bar-spacer';
 import { FloatingBackButton } from './prospect-profile-screen/prospect-profile-screen';
 import { Pinchy } from './pinchy';
 import type { PinchyDismiss, PinchyZoom } from './pinchy';
+import { dragDismissRadius } from './pinchy-math';
 import { IMAGES_URL } from '../env/env';
 import { photoExpandFrame } from '../util/photos';
 import type { PhotoExpandFrame, Rect } from '../util/photos';
@@ -80,16 +81,22 @@ const ExpandingPhoto = ({
   // so closing carries it out from wherever the user left it rather than
   // snapping back to fitted first. The zoom unwinds as the photo returns to the
   // preview, where it has to be identity. Same order as Pinchy's own transform.
-  const clipStyle = useAnimatedStyle(() => ({
+  const clipStyle = useAnimatedStyle(() => {
+    // A dismiss drag rounds all four corners uniformly; it's added on top of
+    // the open/close rounding so the corners match the dragged photo at the
+    // hand-off, then unwinds to the preview's radii as the close plays out.
+    const dragRadius = dragDismissRadius(dismiss.x.value, dismiss.y.value);
+
+    return {
     left: lerp(closed.clip.x, opened.clip.x, progress.value),
     top: lerp(closed.clip.y, opened.clip.y, progress.value),
     width: lerp(closed.clip.width, opened.clip.width, progress.value),
     height: lerp(closed.clip.height, opened.clip.height, progress.value),
     // Rounded like the preview at the start, square once it fills the screen.
-    borderTopLeftRadius: lerp(borderRadius.topLeft, 0, progress.value),
-    borderTopRightRadius: lerp(borderRadius.topRight, 0, progress.value),
-    borderBottomLeftRadius: lerp(borderRadius.bottomLeft, 0, progress.value),
-    borderBottomRightRadius: lerp(borderRadius.bottomRight, 0, progress.value),
+    borderTopLeftRadius: lerp(borderRadius.topLeft, 0, progress.value) + dragRadius,
+    borderTopRightRadius: lerp(borderRadius.topRight, 0, progress.value) + dragRadius,
+    borderBottomLeftRadius: lerp(borderRadius.bottomLeft, 0, progress.value) + dragRadius,
+    borderBottomRightRadius: lerp(borderRadius.bottomRight, 0, progress.value) + dragRadius,
     transform: [
       // A dismiss drag carried in from the open photo, unwound as it closes -
       // outermost and in screen space, so the zoom scale doesn't multiply it.
@@ -99,7 +106,8 @@ const ExpandingPhoto = ({
       { translateX: lerp(0, zoom.translateX.value, progress.value) },
       { translateY: lerp(0, zoom.translateY.value, progress.value) },
     ],
-  }));
+    };
+  });
 
   const imageStyle = useAnimatedStyle(() => ({
     left: lerp(closed.image.x, opened.image.x, progress.value),

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -80,7 +80,10 @@ const ExpandingPhoto = ({
     width: lerp(closed.clip.width, opened.clip.width, progress.value),
     height: lerp(closed.clip.height, opened.clip.height, progress.value),
     // Rounded like the preview at the start, square once it fills the screen.
-    borderRadius: lerp(borderRadius, 0, progress.value),
+    borderTopLeftRadius: lerp(borderRadius.topLeft, 0, progress.value),
+    borderTopRightRadius: lerp(borderRadius.topRight, 0, progress.value),
+    borderBottomLeftRadius: lerp(borderRadius.bottomLeft, 0, progress.value),
+    borderBottomRightRadius: lerp(borderRadius.bottomRight, 0, progress.value),
     transform: [
       { scale: lerp(1, zoom.scale.value, progress.value) },
       { translateX: lerp(0, zoom.translateX.value, progress.value) },

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -17,9 +17,9 @@ import { DefaultText } from './default-text';
 import { FloatingBackButton } from './prospect-profile-screen/prospect-profile-screen';
 import { Pinchy } from './pinchy';
 import type { PinchyDismiss, PinchyPage, PinchyZoom } from './pinchy';
-import { dragDismissRadius } from './pinchy-math';
+import { dragDismissRadius, dragDistance } from './pinchy-math';
 import { IMAGES_URL } from '../env/env';
-import { photoExpandFrame } from '../util/photos';
+import { lerp, photoExpandFrame } from '../util/photos';
 import type { PhotoExpandFrame, Rect } from '../util/photos';
 import { getExpandedPhoto, setExpandedPhoto } from '../events/expanded-photo';
 import type { AlbumPhoto, ExpandedPhoto } from '../events/expanded-photo';
@@ -41,11 +41,6 @@ const isDesktopWeb = Platform.OS === 'web' && !isMobile();
 // 'open' hands over to Pinchy, which is the same photo at the same size but
 // can be zoomed. A gallery with nothing to expand from starts 'open'.
 type Phase = 'opening' | 'open' | 'closing';
-
-const lerp = (a: number, b: number, t: number) => {
-  'worklet';
-  return a + (b - a) * t;
-};
 
 // The photo, expanding. Stands in for the preview - which hides itself - so
 // that only one instance of the photo is ever apparent. The frame is linear in
@@ -272,6 +267,21 @@ const GalleryScreen = ({
     });
   }, []);
 
+  // `from` was measured when the preview was pressed, so a resize or rotation
+  // since then leaves it pointing at where the preview used to be. Closing
+  // falls back to the fade rather than morphing to the wrong place.
+  const openContainer = useRef<Rect | null>(null);
+  const [containerMoved, setContainerMoved] = useState(false);
+
+  useEffect(() => {
+    if (!container) return;
+    if (openContainer.current === null) {
+      openContainer.current = container;
+      return;
+    }
+    if (container !== openContainer.current) setContainerMoved(true);
+  }, [container]);
+
   const width = container?.width ?? 0;
 
   // The pager's horizontal scroll, in px. Slots sit at absolute `i * width`,
@@ -350,7 +360,7 @@ const GalleryScreen = ({
 
   const backdropStyle = useAnimatedStyle(() => {
     const opened = Math.min(1, progress.value * 2);
-    const dragged = Math.sqrt(dismissX.value ** 2 + dismissY.value ** 2);
+    const dragged = dragDistance(dismissX.value, dismissY.value);
     const notDragged = 1 - Math.min(1, dragged / DISMISS_FADE_RANGE);
     return { opacity: opened * notDragged };
   });
@@ -359,13 +369,15 @@ const GalleryScreen = ({
   // away, there's nothing on the profile to morph back to.
   const onOpenedPhoto = index === openedIndex;
 
+  const morphOnClose = expandedPhoto !== null && onOpenedPhoto && !containerMoved;
+
   const close = useCallback((finish: () => void) => {
     if (isFinishing.current) return;
     isFinishing.current = true;
 
     // `finish` runs even if the timing is interrupted: better to cut the
     // animation short than to leave the navigation permanently prevented.
-    if (expandedPhoto && onOpenedPhoto) {
+    if (morphOnClose) {
       // Reverse the expand back into the preview.
       setPhase('closing');
       progress.value = withTiming(
@@ -386,7 +398,7 @@ const GalleryScreen = ({
       { duration: DURATION_MS, easing: EASING },
       () => { runOnJS(finish)(); },
     );
-  }, [expandedPhoto, onOpenedPhoto]);
+  }, [morphOnClose]);
 
   const finishAndPop = useCallback((pop: () => void) => {
     setExpandedPhoto(null);
@@ -424,12 +436,12 @@ const GalleryScreen = ({
     // The reverse-morph carries the drag back into the preview, so unwind it
     // over the same time. Without a morph the gallery just fades from where
     // the photo was flicked - leave the offset be.
-    if (expandedPhoto && onOpenedPhoto) {
+    if (morphOnClose) {
       dismissX.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
       dismissY.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
     }
     onPressBack();
-  }, [onPressBack, expandedPhoto, onOpenedPhoto, dismissX, dismissY]);
+  }, [onPressBack, morphOnClose, dismissX, dismissY]);
 
   const onNavigate = useCallback((dir: number) => {
     goTo(index + dir);

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, Pressable, StyleSheet, View } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import Reanimated, {
   Easing,
@@ -12,15 +12,17 @@ import type { SharedValue } from 'react-native-reanimated';
 import { Image as ExpoImage } from 'expo-image';
 import type { RootParamList } from '../navigation/linking';
 import { StatusBarSpacer } from './status-bar-spacer';
+import { DefaultText } from './default-text';
 import { FloatingBackButton } from './prospect-profile-screen/prospect-profile-screen';
 import { Pinchy } from './pinchy';
-import type { PinchyDismiss, PinchyZoom } from './pinchy';
+import type { PinchyDismiss, PinchyPage, PinchyZoom } from './pinchy';
 import { dragDismissRadius } from './pinchy-math';
 import { IMAGES_URL } from '../env/env';
 import { photoExpandFrame } from '../util/photos';
 import type { PhotoExpandFrame, Rect } from '../util/photos';
 import { getExpandedPhoto, setExpandedPhoto } from '../events/expanded-photo';
-import type { ExpandedPhoto } from '../events/expanded-photo';
+import type { AlbumPhoto, ExpandedPhoto } from '../events/expanded-photo';
+import { isMobile } from '../util/util';
 
 const DURATION_MS = 280;
 
@@ -29,6 +31,10 @@ const EASING = Easing.bezier(0.33, 0, 0.15, 1);
 // How far (screen px) the photo has to be dragged for the backdrop to fade all
 // the way to transparent, revealing the profile it dismisses back to.
 const DISMISS_FADE_RANGE = 300;
+
+// The back button and click-to-navigate zones are desktop-web only; on mobile
+// (native or mobile web) navigation and dismissal are gestures.
+const isDesktopWeb = Platform.OS === 'web' && !isMobile();
 
 // 'opening' and 'closing' show the photo mid-expansion and own the screen;
 // 'open' hands over to Pinchy, which is the same photo at the same size but
@@ -50,6 +56,8 @@ const ExpandingPhoto = ({
   container,
   zoom,
   dismiss,
+  scrollX,
+  openedX,
   onCovered,
 }: {
   expandedPhoto: ExpandedPhoto,
@@ -57,6 +65,10 @@ const ExpandingPhoto = ({
   container: Rect,
   zoom: PinchyZoom,
   dismiss: PinchyDismiss,
+  // The pager's scroll, and this photo's resting scroll, so the morph tracks
+  // the pager and stays hidden under the current photo during a swipe.
+  scrollX: SharedValue<number>,
+  openedX: number,
   onCovered: () => void,
 }) => {
   const { photoUuid, from, geometry, borderRadius } = expandedPhoto;
@@ -98,9 +110,11 @@ const ExpandingPhoto = ({
     borderBottomLeftRadius: lerp(borderRadius.bottomLeft, 0, progress.value) + dragRadius,
     borderBottomRightRadius: lerp(borderRadius.bottomRight, 0, progress.value) + dragRadius,
     transform: [
-      // A dismiss drag carried in from the open photo, unwound as it closes -
-      // outermost and in screen space, so the zoom scale doesn't multiply it.
-      { translateX: dismiss.x.value },
+      // Track the pager so the morph slides with the current photo (and out of
+      // sight) as it's swiped, plus a dismiss drag carried in from the open
+      // photo. Both screen-space, outermost, so the zoom scale doesn't
+      // multiply them.
+      { translateX: (openedX - scrollX.value) + dismiss.x.value },
       { translateY: dismiss.y.value },
       { scale: lerp(1, zoom.scale.value, progress.value) },
       { translateX: lerp(0, zoom.translateX.value, progress.value) },
@@ -169,6 +183,33 @@ const GalleryScreen = ({
     return e?.photoUuid === photoUuid ? e : null;
   });
 
+  // The photos to page between, and where we started. A deep link with no
+  // album is a one-photo gallery.
+  const album: AlbumPhoto[] = useMemo(
+    () => expandedPhoto?.album ?? [{ uuid: photoUuid, geometry: null }],
+    [expandedPhoto, photoUuid],
+  );
+  const openedIndex = useMemo(
+    () => Math.max(0, album.findIndex((p) => p.uuid === photoUuid)),
+    [album, photoUuid],
+  );
+
+  const [index, setIndex] = useState(openedIndex);
+  const current = album[index] ?? album[0];
+
+  // Warm the cache for every photo's full-size original the moment the gallery
+  // opens. The profile only loaded the cropped preview renditions, so without
+  // this the first swipe to a neighbour flashes blank while its original loads.
+  useEffect(() => {
+    album.forEach((photo) => {
+      try {
+        ExpoImage.prefetch(`${IMAGES_URL}/original-${photo.uuid}.jpg`);
+      } catch (e) {
+        console.warn(e);
+      }
+    });
+  }, [album]);
+
   const [phase, setPhase] = useState<Phase>(
     expandedPhoto ? 'opening' : 'open',
   );
@@ -187,6 +228,16 @@ const GalleryScreen = ({
     translateY: zoomTranslateY,
   }), [zoomScale, zoomTranslateX, zoomTranslateY]);
 
+  // A fixed identity transform for the off-screen pages, which aren't zoomable.
+  // Only the current page gets the live `zoom`.
+  const identityScale = useSharedValue(1);
+  const identityZero = useSharedValue(0);
+  const identityZoom: PinchyZoom = useMemo(() => ({
+    scale: identityScale,
+    translateX: identityZero,
+    translateY: identityZero,
+  }), [identityScale, identityZero]);
+
   // Where a drag-to-dismiss has moved the photo. Owned here so the closing
   // animation can unwind it and the backdrop can fade by how far it's dragged.
   const dismissX = useSharedValue(0);
@@ -196,6 +247,10 @@ const GalleryScreen = ({
     x: dismissX,
     y: dismissY,
   }), [dismissX, dismissY]);
+
+  // Fades the whole gallery out when there's no preview to morph back into.
+  const fadeOut = useSharedValue(1);
+  const fadeStyle = useAnimatedStyle(() => ({ opacity: fadeOut.value }));
 
   const isFinishing = useRef(false);
 
@@ -224,6 +279,44 @@ const GalleryScreen = ({
     });
   }, []);
 
+  const width = container?.width ?? 0;
+
+  // The pager's horizontal scroll, in px. Slots sit at absolute `i * width`, so
+  // this settles at `index * width`; changing `index` alone never shifts a slot
+  // and so never flickers.
+  const scrollX = useSharedValue(0);
+  useEffect(() => {
+    scrollX.value = index * width;
+  }, [width]); // re-home only on a resize; navigation animates scrollX itself
+
+  const page: PinchyPage = useMemo(() => ({
+    scrollX,
+    homeX: index * width,
+    width,
+    count: album.length,
+  }), [scrollX, index, width, album.length]);
+
+  const rowStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: -scrollX.value }],
+  }));
+
+  // Move to another photo, sliding the pager and resetting the zoom/dismiss of
+  // the photo we're leaving.
+  const goTo = useCallback((next: number) => {
+    const target = Math.max(0, Math.min(album.length - 1, next));
+    if (target === index) {
+      scrollX.value = withTiming(index * width, { duration: DURATION_MS, easing: EASING });
+      return;
+    }
+    zoomScale.value = 1;
+    zoomTranslateX.value = 0;
+    zoomTranslateY.value = 0;
+    dismissX.value = 0;
+    dismissY.value = 0;
+    setIndex(target);
+    scrollX.value = withTiming(target * width, { duration: DURATION_MS, easing: EASING });
+  }, [album.length, index, width]);
+
   // Until this screen has drawn the photo over the preview, the preview is
   // still the one on show and nothing may move: the first frame has to be
   // indistinguishable from the screen underneath.
@@ -246,12 +339,8 @@ const GalleryScreen = ({
     // Nothing is drawn over the preview until the container has been measured,
     // so hiding it before then would leave the photo missing.
     if (!container) return;
-    // The photo can finish loading after a quick back-press has already
-    // started closing. Opening from there would fight the closing animation,
-    // and would re-hide a preview that nothing is left to reveal again.
     if (isFinishing.current) return;
 
-    // Only now is it safe for the preview to get out of the way.
     setExpandedPhoto({ ...expandedPhoto, covered: true });
 
     progress.value = withTiming(
@@ -264,55 +353,52 @@ const GalleryScreen = ({
   }, [expandedPhoto, isCovering, container]);
 
   const backdropStyle = useAnimatedStyle(() => {
-    // Runs ahead of the photo so the preview underneath is covered by the time
-    // the photo has moved off it, without blinking the profile out at the very
-    // start of the press.
     const opened = Math.min(1, progress.value * 2);
-
-    // Fade as the photo is dragged away, so the profile it dismisses back to
-    // shows through.
     const dragged = Math.sqrt(dismissX.value ** 2 + dismissY.value ** 2);
     const notDragged = 1 - Math.min(1, dragged / DISMISS_FADE_RANGE);
-
     return { opacity: opened * notDragged };
   });
+
+  // The open/close morph only makes sense for the photo we opened; once paged
+  // away, there's nothing on the profile to morph back to.
+  const onOpenedPhoto = index === openedIndex;
 
   const close = useCallback((finish: () => void) => {
     if (isFinishing.current) return;
     isFinishing.current = true;
 
-    if (!expandedPhoto) {
-      setExpandedPhoto(null);
-      finish();
+    if (expandedPhoto && onOpenedPhoto) {
+      // Reverse the expand back into the preview.
+      setPhase('closing');
+      progress.value = withTiming(
+        0,
+        { duration: DURATION_MS, easing: EASING },
+        (finished) => { if (finished) runOnJS(finish)(); },
+      );
       return;
     }
 
-    setPhase('closing');
-
-    progress.value = withTiming(
+    // No preview to return to (a deep link, or we paged away from the opened
+    // photo): fade the whole gallery out to reveal the screen underneath. Let
+    // the hidden preview show again now, at the start of the fade, so the
+    // profile is already there as the viewer dissolves rather than popping in
+    // once it's gone.
+    setExpandedPhoto(null);
+    fadeOut.value = withTiming(
       0,
       { duration: DURATION_MS, easing: EASING },
-      (finished) => {
-        if (finished) runOnJS(finish)();
-      },
+      (finished) => { if (finished) runOnJS(finish)(); },
     );
-  }, [expandedPhoto]);
+  }, [expandedPhoto, onOpenedPhoto]);
 
-  // Reveal the preview before popping. The photo has landed back on top of it
-  // and the two coincide exactly, so the handover is invisible; popping first
-  // would flash the empty slot for a frame.
   const finishAndPop = useCallback((pop: () => void) => {
     setExpandedPhoto(null);
     pop();
   }, []);
 
-  // Also covers the Android hardware back button and the browser's back
-  // button, either of which would otherwise pop the screen out from under the
-  // animation.
   useEffect(() => {
     return navigation.addListener('beforeRemove', (e) => {
       if (isFinishing.current) return;
-
       e.preventDefault();
       close(() => finishAndPop(() => navigation.dispatch(e.data.action)));
     });
@@ -323,21 +409,24 @@ const GalleryScreen = ({
       navigation.goBack();
       return;
     }
-
-    // Opened straight from a `/gallery/:photoUuid` link, so there's no screen
-    // underneath to close onto. Going home beats leaving the user in a
-    // fullscreen photo with a back button that does nothing.
     close(() => finishAndPop(() => navigation.reset({ routes: [{ name: 'Home' }] })));
   }, [navigation, close, finishAndPop]);
 
-  // A completed drag-to-dismiss. Unwind the drag over the same time as the
-  // reverse-morph close, so the photo travels from where it was let go back
-  // into the preview rather than snapping to centre first.
   const onDismiss = useCallback(() => {
-    dismissX.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
-    dismissY.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
+    // On the opened photo the reverse-morph carries the drag back into the
+    // preview, so unwind it over the same time. Paged away, the gallery just
+    // fades from where the photo was flicked - leave the offset be.
+    if (onOpenedPhoto) {
+      dismissX.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
+      dismissY.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
+    }
     onPressBack();
-  }, [onPressBack, dismissX, dismissY]);
+  }, [onPressBack, onOpenedPhoto, dismissX, dismissY]);
+
+  // A horizontal swipe past the threshold pages; onEnd hands us the direction.
+  const onNavigate = useCallback((dir: number) => {
+    goTo(index + dir);
+  }, [goTo, index]);
 
   return (
     <View
@@ -345,40 +434,81 @@ const GalleryScreen = ({
       onLayout={onContainerLayout}
       style={StyleSheet.absoluteFill}
     >
+     <Reanimated.View style={[StyleSheet.absoluteFill, fadeStyle]}>
       <Reanimated.View
         style={[styles.backdrop, expandedPhoto ? backdropStyle : undefined]}
       />
-      {expandedPhoto && container &&
+
+      {/*
+        Stays mounted under the pager for the opened photo, so it covers the
+        moment the pager's interactive copy mounts (opening) and unmounts
+        (closing) - otherwise that hand-off flickers. It tracks the pager
+        scroll, so during a swipe it slides away with the photo rather than
+        peeking out from under it.
+      */}
+      {expandedPhoto && container && onOpenedPhoto &&
         <ExpandingPhoto
           expandedPhoto={expandedPhoto}
           progress={progress}
           container={container}
           zoom={zoom}
           dismiss={dismiss}
+          scrollX={scrollX}
+          openedX={openedIndex * width}
           onCovered={onCovered}
         />
       }
-      {phase === 'open' &&
-        <Pinchy
-          uuid={photoUuid}
-          naturalSize={expandedPhoto?.geometry}
-          zoom={zoom}
-          // Only offer drag-to-dismiss when there's a preview to return to;
-          // a deep-linked gallery has nothing underneath to reveal.
-          dismiss={expandedPhoto ? dismiss : undefined}
-          onDismiss={expandedPhoto ? onDismiss : undefined}
-          // Both copies of the photo have to be sized and centred against the
-          // same box, or they land in different places and you see the two of
-          // them at the end of the expansion.
-          viewport={container ?? undefined}
-          // The expanded photo is drawn underneath and is pixel-identical at
-          // this point, so it - rather than a black box - is what shows while
-          // Pinchy's own copy of the image paints.
-          backgroundColor={expandedPhoto ? 'transparent' : 'black'}
-        />
+
+      {phase === 'open' && container &&
+        <Reanimated.View style={[StyleSheet.absoluteFill, rowStyle]}>
+          {album.map((photo, i) => Math.abs(i - index) > 1 ? null : (
+            <View
+              key={photo.uuid}
+              style={[styles.slot, { left: i * width, width, height: container.height }]}
+            >
+              <Pinchy
+                uuid={photo.uuid}
+                naturalSize={photo.geometry ?? undefined}
+                zoom={i === index ? zoom : identityZoom}
+                dismiss={i === index && expandedPhoto ? dismiss : undefined}
+                onDismiss={i === index && expandedPhoto ? onDismiss : undefined}
+                page={i === index && album.length > 1 ? page : undefined}
+                onNavigate={i === index && album.length > 1 ? onNavigate : undefined}
+                viewport={container}
+                backgroundColor={i === index && onOpenedPhoto && expandedPhoto ? 'transparent' : 'black'}
+              />
+            </View>
+          ))}
+        </Reanimated.View>
       }
+
+      {/* Desktop: click the left/right edge to page. */}
+      {isDesktopWeb && album.length > 1 && phase === 'open' &&
+        <>
+          <Pressable
+            style={[styles.edgeZone, { left: 0 }]}
+            onPress={() => onNavigate(-1)}
+            disabled={index === 0}
+          />
+          <Pressable
+            style={[styles.edgeZone, { right: 0 }]}
+            onPress={() => onNavigate(1)}
+            disabled={index === album.length - 1}
+          />
+        </>
+      }
+
+      {album.length > 1 &&
+        <View style={styles.counter} pointerEvents="none">
+          <DefaultText style={styles.counterText}>
+            {index + 1}/{album.length}
+          </DefaultText>
+        </View>
+      }
+
       <StatusBarSpacer/>
-      <FloatingBackButton onPress={onPressBack}/>
+      {isDesktopWeb && <FloatingBackButton onPress={onPressBack}/>}
+     </Reanimated.View>
     </View>
   );
 };
@@ -394,6 +524,32 @@ const styles = StyleSheet.create({
   },
   image: {
     position: 'absolute',
+  },
+  slot: {
+    position: 'absolute',
+    top: 0,
+  },
+  edgeZone: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    width: '30%',
+    zIndex: 998,
+  },
+  counter: {
+    position: 'absolute',
+    top: 14,
+    right: 14,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: 999,
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+    zIndex: 1000,
+  },
+  counterText: {
+    color: 'white',
+    fontFamily: 'MontserratSemiBold',
+    fontSize: 14,
   },
 });
 

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -10,6 +10,7 @@ import Reanimated, {
 } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
 import { Image as ExpoImage } from 'expo-image';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { RootParamList } from '../navigation/linking';
 import { StatusBarSpacer } from './status-bar-spacer';
 import { DefaultText } from './default-text';
@@ -29,7 +30,7 @@ const DURATION_MS = 280;
 const EASING = Easing.bezier(0.33, 0, 0.15, 1);
 
 // How far (screen px) the photo has to be dragged for the backdrop to fade all
-// the way to transparent, revealing the profile it dismisses back to.
+// the way to transparent.
 const DISMISS_FADE_RANGE = 300;
 
 // The back button and click-to-navigate zones are desktop-web only; on mobile
@@ -48,8 +49,7 @@ const lerp = (a: number, b: number, t: number) => {
 
 // The photo, expanding. Stands in for the preview - which hides itself - so
 // that only one instance of the photo is ever apparent. The frame is linear in
-// `progress`, so its endpoints are computed once here and lerped on the UI
-// thread. See `photoExpandFrame`.
+// `progress`, so its endpoints are computed once and lerped on the UI thread.
 const ExpandingPhoto = ({
   expandedPhoto,
   progress,
@@ -66,7 +66,7 @@ const ExpandingPhoto = ({
   zoom: PinchyZoom,
   dismiss: PinchyDismiss,
   // The pager's scroll, and this photo's resting scroll, so the morph tracks
-  // the pager and stays hidden under the current photo during a swipe.
+  // the pager during a swipe.
   scrollX: SharedValue<number>,
   openedX: number,
   onCovered: () => void,
@@ -75,8 +75,8 @@ const ExpandingPhoto = ({
 
   const [closed, opened] = useMemo((): [PhotoExpandFrame, PhotoExpandFrame] => {
     // `from` was measured in window coordinates, but this draws inside the
-    // gallery's container, which isn't necessarily the window: on Android the
-    // window excludes the system bars while the modal spans the whole screen.
+    // gallery's container: on Android the window excludes the system bars
+    // while the modal spans the whole screen.
     const start: Rect = {
       ...from,
       x: from.x - container.x,
@@ -90,13 +90,11 @@ const ExpandingPhoto = ({
   }, [geometry, from, container]);
 
   // At `progress` 1 this is the photo exactly as Pinchy has it, zoom and all,
-  // so closing carries it out from wherever the user left it rather than
-  // snapping back to fitted first. The zoom unwinds as the photo returns to the
-  // preview, where it has to be identity. Same order as Pinchy's own transform.
+  // so closing carries it out from wherever the user left it. Same transform
+  // order as Pinchy's.
   const clipStyle = useAnimatedStyle(() => {
-    // A dismiss drag rounds all four corners uniformly; it's added on top of
-    // the open/close rounding so the corners match the dragged photo at the
-    // hand-off, then unwinds to the preview's radii as the close plays out.
+    // A dismiss drag rounds all four corners on top of the open/close
+    // rounding, so the corners match the dragged photo at the hand-off.
     const dragRadius = dragDismissRadius(dismiss.x.value, dismiss.y.value);
 
     return {
@@ -104,16 +102,13 @@ const ExpandingPhoto = ({
     top: lerp(closed.clip.y, opened.clip.y, progress.value),
     width: lerp(closed.clip.width, opened.clip.width, progress.value),
     height: lerp(closed.clip.height, opened.clip.height, progress.value),
-    // Rounded like the preview at the start, square once it fills the screen.
     borderTopLeftRadius: lerp(borderRadius.topLeft, 0, progress.value) + dragRadius,
     borderTopRightRadius: lerp(borderRadius.topRight, 0, progress.value) + dragRadius,
     borderBottomLeftRadius: lerp(borderRadius.bottomLeft, 0, progress.value) + dragRadius,
     borderBottomRightRadius: lerp(borderRadius.bottomRight, 0, progress.value) + dragRadius,
     transform: [
-      // Track the pager so the morph slides with the current photo (and out of
-      // sight) as it's swiped, plus a dismiss drag carried in from the open
-      // photo. Both screen-space, outermost, so the zoom scale doesn't
-      // multiply them.
+      // The pager offset and dismiss drag are screen-space, so they go
+      // outermost, ahead of the zoom scale.
       { translateX: (openedX - scrollX.value) + dismiss.x.value },
       { translateY: dismiss.y.value },
       { scale: lerp(1, zoom.scale.value, progress.value) },
@@ -140,9 +135,9 @@ const ExpandingPhoto = ({
   return (
     <Reanimated.View style={[styles.clip, clipStyle]}>
       {/*
-        The square rendition the preview was already showing. It's in cache, so
-        it paints on the first frame - which it covers exactly - and holds the
-        photo's place while the original decodes.
+        The square rendition the preview was already showing: in cache, so it
+        paints on the first frame and holds the photo's place while the
+        original decodes.
       */}
       <Reanimated.View style={[styles.image, cropStyle]}>
         <ExpoImage
@@ -183,8 +178,7 @@ const GalleryScreen = ({
     return e?.photoUuid === photoUuid ? e : null;
   });
 
-  // The photos to page between, and where we started. A deep link with no
-  // album is a one-photo gallery.
+  // A deep link with no album is a one-photo gallery.
   const album: AlbumPhoto[] = useMemo(
     () => expandedPhoto?.album ?? [{ uuid: photoUuid, geometry: null }],
     [expandedPhoto, photoUuid],
@@ -195,11 +189,9 @@ const GalleryScreen = ({
   );
 
   const [index, setIndex] = useState(openedIndex);
-  const current = album[index] ?? album[0];
 
-  // Warm the cache for every photo's full-size original the moment the gallery
-  // opens. The profile only loaded the cropped preview renditions, so without
-  // this the first swipe to a neighbour flashes blank while its original loads.
+  // Warm the cache for every photo's full-size original, so the first swipe
+  // to a neighbour doesn't flash blank while its original loads.
   useEffect(() => {
     album.forEach((photo) => {
       try {
@@ -228,8 +220,8 @@ const GalleryScreen = ({
     translateY: zoomTranslateY,
   }), [zoomScale, zoomTranslateX, zoomTranslateY]);
 
-  // A fixed identity transform for the off-screen pages, which aren't zoomable.
-  // Only the current page gets the live `zoom`.
+  // A fixed identity transform for the off-screen pages, which aren't
+  // zoomable. Only the current page gets the live `zoom`.
   const identityScale = useSharedValue(1);
   const identityZero = useSharedValue(0);
   const identityZoom: PinchyZoom = useMemo(() => ({
@@ -254,10 +246,11 @@ const GalleryScreen = ({
 
   const isFinishing = useRef(false);
 
-  // Everything here is positioned within this container rather than within the
-  // window, and it's measured rather than assumed to be the window: on Android
-  // the two differ by the system bars, and anything working in window
-  // coordinates ends up offset from anything working in the container's.
+  const insets = useSafeAreaInsets();
+
+  // Everything here is positioned within this container, which is measured
+  // rather than assumed to be the window: on Android the two differ by the
+  // system bars.
   const containerRef = useRef<View>(null);
   const [container, setContainer] = useState<Rect | null>(null);
 
@@ -281,9 +274,9 @@ const GalleryScreen = ({
 
   const width = container?.width ?? 0;
 
-  // The pager's horizontal scroll, in px. Slots sit at absolute `i * width`, so
-  // this settles at `index * width`; changing `index` alone never shifts a slot
-  // and so never flickers.
+  // The pager's horizontal scroll, in px. Slots sit at absolute `i * width`,
+  // so this settles at `index * width`; changing `index` alone never shifts a
+  // slot and so never flickers.
   const scrollX = useSharedValue(0);
   useEffect(() => {
     scrollX.value = index * width;
@@ -300,8 +293,8 @@ const GalleryScreen = ({
     transform: [{ translateX: -scrollX.value }],
   }));
 
-  // Move to another photo, sliding the pager and resetting the zoom/dismiss of
-  // the photo we're leaving.
+  // Move to another photo, sliding the pager and resetting the zoom/dismiss
+  // of the photo we're leaving.
   const goTo = useCallback((next: number) => {
     const target = Math.max(0, Math.min(album.length - 1, next));
     if (target === index) {
@@ -318,15 +311,13 @@ const GalleryScreen = ({
   }, [album.length, index, width]);
 
   // Until this screen has drawn the photo over the preview, the preview is
-  // still the one on show and nothing may move: the first frame has to be
-  // indistinguishable from the screen underneath.
+  // still the one on show and nothing may move.
   const [isCovering, setIsCovering] = useState(!expandedPhoto);
 
   const onCovered = useCallback(() => setIsCovering(true), []);
 
-  // The square rendition is the one the preview is already displaying, so it
-  // comes from cache and this is a formality - but don't hang the animation on
-  // a load event that never arrives.
+  // The square rendition comes from cache, so its load event is a formality -
+  // but don't hang the animation on one that never arrives.
   useEffect(() => {
     if (!expandedPhoto) return;
     const timeout = setTimeout(onCovered, 250);
@@ -336,8 +327,8 @@ const GalleryScreen = ({
   useEffect(() => {
     if (!expandedPhoto) return;
     if (!isCovering) return;
-    // Nothing is drawn over the preview until the container has been measured,
-    // so hiding it before then would leave the photo missing.
+    // Nothing is drawn over the preview until the container has been
+    // measured, so hiding it before then would leave the photo missing.
     if (!container) return;
     if (isFinishing.current) return;
 
@@ -351,6 +342,11 @@ const GalleryScreen = ({
       },
     );
   }, [expandedPhoto, isCovering, container]);
+
+  // However this screen goes away, the preview it hid must come back.
+  useEffect(() => {
+    return () => setExpandedPhoto(null);
+  }, []);
 
   const backdropStyle = useAnimatedStyle(() => {
     const opened = Math.min(1, progress.value * 2);
@@ -367,27 +363,28 @@ const GalleryScreen = ({
     if (isFinishing.current) return;
     isFinishing.current = true;
 
+    // `finish` runs even if the timing is interrupted: better to cut the
+    // animation short than to leave the navigation permanently prevented.
     if (expandedPhoto && onOpenedPhoto) {
       // Reverse the expand back into the preview.
       setPhase('closing');
       progress.value = withTiming(
         0,
         { duration: DURATION_MS, easing: EASING },
-        (finished) => { if (finished) runOnJS(finish)(); },
+        () => { runOnJS(finish)(); },
       );
       return;
     }
 
     // No preview to return to (a deep link, or we paged away from the opened
-    // photo): fade the whole gallery out to reveal the screen underneath. Let
-    // the hidden preview show again now, at the start of the fade, so the
-    // profile is already there as the viewer dissolves rather than popping in
-    // once it's gone.
+    // photo): fade the whole gallery out. Let the hidden preview show again
+    // now, at the start of the fade, so the profile is already there as the
+    // viewer dissolves.
     setExpandedPhoto(null);
     fadeOut.value = withTiming(
       0,
       { duration: DURATION_MS, easing: EASING },
-      (finished) => { if (finished) runOnJS(finish)(); },
+      () => { runOnJS(finish)(); },
     );
   }, [expandedPhoto, onOpenedPhoto]);
 
@@ -412,18 +409,28 @@ const GalleryScreen = ({
     close(() => finishAndPop(() => navigation.reset({ routes: [{ name: 'Home' }] })));
   }, [navigation, close, finishAndPop]);
 
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onPressBack();
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onPressBack]);
+
   const onDismiss = useCallback(() => {
-    // On the opened photo the reverse-morph carries the drag back into the
-    // preview, so unwind it over the same time. Paged away, the gallery just
-    // fades from where the photo was flicked - leave the offset be.
-    if (onOpenedPhoto) {
+    // The reverse-morph carries the drag back into the preview, so unwind it
+    // over the same time. Without a morph the gallery just fades from where
+    // the photo was flicked - leave the offset be.
+    if (expandedPhoto && onOpenedPhoto) {
       dismissX.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
       dismissY.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
     }
     onPressBack();
-  }, [onPressBack, onOpenedPhoto, dismissX, dismissY]);
+  }, [onPressBack, expandedPhoto, onOpenedPhoto, dismissX, dismissY]);
 
-  // A horizontal swipe past the threshold pages; onEnd hands us the direction.
   const onNavigate = useCallback((dir: number) => {
     goTo(index + dir);
   }, [goTo, index]);
@@ -435,16 +442,12 @@ const GalleryScreen = ({
       style={StyleSheet.absoluteFill}
     >
      <Reanimated.View style={[StyleSheet.absoluteFill, fadeStyle]}>
-      <Reanimated.View
-        style={[styles.backdrop, expandedPhoto ? backdropStyle : undefined]}
-      />
+      <Reanimated.View style={[styles.backdrop, backdropStyle]} />
 
       {/*
         Stays mounted under the pager for the opened photo, so it covers the
         moment the pager's interactive copy mounts (opening) and unmounts
-        (closing) - otherwise that hand-off flickers. It tracks the pager
-        scroll, so during a swipe it slides away with the photo rather than
-        peeking out from under it.
+        (closing) - otherwise that hand-off flickers.
       */}
       {expandedPhoto && container && onOpenedPhoto &&
         <ExpandingPhoto
@@ -470,12 +473,12 @@ const GalleryScreen = ({
                 uuid={photo.uuid}
                 naturalSize={photo.geometry ?? undefined}
                 zoom={i === index ? zoom : identityZoom}
-                dismiss={i === index && expandedPhoto ? dismiss : undefined}
-                onDismiss={i === index && expandedPhoto ? onDismiss : undefined}
+                dismiss={i === index ? dismiss : undefined}
+                onDismiss={i === index ? onDismiss : undefined}
                 page={i === index && album.length > 1 ? page : undefined}
                 onNavigate={i === index && album.length > 1 ? onNavigate : undefined}
                 viewport={container}
-                backgroundColor={i === index && onOpenedPhoto && expandedPhoto ? 'transparent' : 'black'}
+                backgroundColor={i === index ? 'transparent' : 'black'}
               />
             </View>
           ))}
@@ -499,7 +502,13 @@ const GalleryScreen = ({
       }
 
       {album.length > 1 &&
-        <View style={styles.counter} pointerEvents="none">
+        <View
+          style={[
+            styles.counter,
+            { top: 14 + (Platform.OS === 'web' ? 0 : insets.top) },
+          ]}
+          pointerEvents="none"
+        >
           <DefaultText style={styles.counterText}>
             {index + 1}/{album.length}
           </DefaultText>
@@ -538,7 +547,6 @@ const styles = StyleSheet.create({
   },
   counter: {
     position: 'absolute',
-    top: 14,
     right: 14,
     paddingVertical: 4,
     paddingHorizontal: 10,

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -52,7 +52,7 @@ const ExpandingPhoto = ({
   zoom: PinchyZoom,
   onCovered: () => void,
 }) => {
-  const { photoUuid, from, geometry } = expandedPhoto;
+  const { photoUuid, from, geometry, borderRadius } = expandedPhoto;
 
   const [closed, opened] = useMemo((): [PhotoExpandFrame, PhotoExpandFrame] => {
     // `from` was measured in window coordinates, but this draws inside the
@@ -79,6 +79,8 @@ const ExpandingPhoto = ({
     top: lerp(closed.clip.y, opened.clip.y, progress.value),
     width: lerp(closed.clip.width, opened.clip.width, progress.value),
     height: lerp(closed.clip.height, opened.clip.height, progress.value),
+    // Rounded like the preview at the start, square once it fills the screen.
+    borderRadius: lerp(borderRadius, 0, progress.value),
     transform: [
       { scale: lerp(1, zoom.scale.value, progress.value) },
       { translateX: lerp(0, zoom.translateX.value, progress.value) },

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -255,8 +255,16 @@ const GalleryScreen = ({
   }, [navigation, close, finishAndPop]);
 
   const onPressBack = useCallback(() => {
-    navigation.goBack();
-  }, [navigation]);
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+
+    // Opened straight from a `/gallery/:photoUuid` link, so there's no screen
+    // underneath to close onto. Going home beats leaving the user in a
+    // fullscreen photo with a back button that does nothing.
+    close(() => finishAndPop(() => navigation.reset({ routes: [{ name: 'Home' }] })));
+  }, [navigation, close, finishAndPop]);
 
   return (
     <View

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -14,7 +14,7 @@ import type { RootParamList } from '../navigation/linking';
 import { StatusBarSpacer } from './status-bar-spacer';
 import { FloatingBackButton } from './prospect-profile-screen/prospect-profile-screen';
 import { Pinchy } from './pinchy';
-import type { PinchyZoom } from './pinchy';
+import type { PinchyDismiss, PinchyZoom } from './pinchy';
 import { IMAGES_URL } from '../env/env';
 import { photoExpandFrame } from '../util/photos';
 import type { PhotoExpandFrame, Rect } from '../util/photos';
@@ -24,6 +24,10 @@ import type { ExpandedPhoto } from '../events/expanded-photo';
 const DURATION_MS = 280;
 
 const EASING = Easing.bezier(0.33, 0, 0.15, 1);
+
+// How far (screen px) the photo has to be dragged for the backdrop to fade all
+// the way to transparent, revealing the profile it dismisses back to.
+const DISMISS_FADE_RANGE = 300;
 
 // 'opening' and 'closing' show the photo mid-expansion and own the screen;
 // 'open' hands over to Pinchy, which is the same photo at the same size but
@@ -44,12 +48,14 @@ const ExpandingPhoto = ({
   progress,
   container,
   zoom,
+  dismiss,
   onCovered,
 }: {
   expandedPhoto: ExpandedPhoto,
   progress: SharedValue<number>,
   container: Rect,
   zoom: PinchyZoom,
+  dismiss: PinchyDismiss,
   onCovered: () => void,
 }) => {
   const { photoUuid, from, geometry, borderRadius } = expandedPhoto;
@@ -85,6 +91,10 @@ const ExpandingPhoto = ({
     borderBottomLeftRadius: lerp(borderRadius.bottomLeft, 0, progress.value),
     borderBottomRightRadius: lerp(borderRadius.bottomRight, 0, progress.value),
     transform: [
+      // A dismiss drag carried in from the open photo, unwound as it closes -
+      // outermost and in screen space, so the zoom scale doesn't multiply it.
+      { translateX: dismiss.x.value },
+      { translateY: dismiss.y.value },
       { scale: lerp(1, zoom.scale.value, progress.value) },
       { translateX: lerp(0, zoom.translateX.value, progress.value) },
       { translateY: lerp(0, zoom.translateY.value, progress.value) },
@@ -169,6 +179,16 @@ const GalleryScreen = ({
     translateY: zoomTranslateY,
   }), [zoomScale, zoomTranslateX, zoomTranslateY]);
 
+  // Where a drag-to-dismiss has moved the photo. Owned here so the closing
+  // animation can unwind it and the backdrop can fade by how far it's dragged.
+  const dismissX = useSharedValue(0);
+  const dismissY = useSharedValue(0);
+
+  const dismiss: PinchyDismiss = useMemo(() => ({
+    x: dismissX,
+    y: dismissY,
+  }), [dismissX, dismissY]);
+
   const isFinishing = useRef(false);
 
   // Everything here is positioned within this container rather than within the
@@ -235,12 +255,19 @@ const GalleryScreen = ({
     );
   }, [expandedPhoto, isCovering, container]);
 
-  const backdropStyle = useAnimatedStyle(() => ({
+  const backdropStyle = useAnimatedStyle(() => {
     // Runs ahead of the photo so the preview underneath is covered by the time
     // the photo has moved off it, without blinking the profile out at the very
     // start of the press.
-    opacity: Math.min(1, progress.value * 2),
-  }));
+    const opened = Math.min(1, progress.value * 2);
+
+    // Fade as the photo is dragged away, so the profile it dismisses back to
+    // shows through.
+    const dragged = Math.sqrt(dismissX.value ** 2 + dismissY.value ** 2);
+    const notDragged = 1 - Math.min(1, dragged / DISMISS_FADE_RANGE);
+
+    return { opacity: opened * notDragged };
+  });
 
   const close = useCallback((finish: () => void) => {
     if (isFinishing.current) return;
@@ -295,6 +322,15 @@ const GalleryScreen = ({
     close(() => finishAndPop(() => navigation.reset({ routes: [{ name: 'Home' }] })));
   }, [navigation, close, finishAndPop]);
 
+  // A completed drag-to-dismiss. Unwind the drag over the same time as the
+  // reverse-morph close, so the photo travels from where it was let go back
+  // into the preview rather than snapping to centre first.
+  const onDismiss = useCallback(() => {
+    dismissX.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
+    dismissY.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
+    onPressBack();
+  }, [onPressBack, dismissX, dismissY]);
+
   return (
     <View
       ref={containerRef}
@@ -310,6 +346,7 @@ const GalleryScreen = ({
           progress={progress}
           container={container}
           zoom={zoom}
+          dismiss={dismiss}
           onCovered={onCovered}
         />
       }
@@ -318,6 +355,10 @@ const GalleryScreen = ({
           uuid={photoUuid}
           naturalSize={expandedPhoto?.geometry}
           zoom={zoom}
+          // Only offer drag-to-dismiss when there's a preview to return to;
+          // a deep-linked gallery has nothing underneath to reveal.
+          dismiss={expandedPhoto ? dismiss : undefined}
+          onDismiss={expandedPhoto ? onDismiss : undefined}
           // Both copies of the photo have to be sized and centred against the
           // same box, or they land in different places and you see the two of
           // them at the end of the expansion.

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -10,6 +10,7 @@ import Reanimated, {
 } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
 import { Image as ExpoImage } from 'expo-image';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { RootParamList } from '../navigation/linking';
 import { StatusBarSpacer } from './status-bar-spacer';
@@ -166,6 +167,39 @@ const ExpandingPhoto = ({
   );
 };
 
+// Desktop's paging affordance, standing in for the swipe gesture: a chevron at
+// the screen's edge, matching the counter pill's look. Rendered only when
+// there's a neighbour in that direction, so the buttons also read as "you're
+// at the end".
+const PagerChevron = ({
+  direction,
+  onNavigate,
+}: {
+  direction: -1 | 1,
+  onNavigate: (dir: number) => void,
+}) => {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <Pressable
+      style={[
+        styles.chevron,
+        direction === -1 ? { left: 14 } : { right: 14 },
+        hovered ? styles.chevronHovered : null,
+      ]}
+      onPress={() => onNavigate(direction)}
+      onHoverIn={() => setHovered(true)}
+      onHoverOut={() => setHovered(false)}
+    >
+      <Ionicons
+        name={direction === -1 ? 'chevron-back' : 'chevron-forward'}
+        size={26}
+        color="white"
+      />
+    </Pressable>
+  );
+};
+
 const GalleryScreen = ({
   navigation,
   route,
@@ -310,22 +344,45 @@ const GalleryScreen = ({
     transform: [{ translateX: -scrollX.value }],
   }));
 
+  // The live zoom belongs to the page at `index`, so the index can only
+  // change while the zoom is at identity - and not mid-close, where it would
+  // unmount the morphing photo.
+  const commitIndex = useCallback((target: number) => {
+    if (isFinishing.current) return;
+    setIndex(target);
+  }, []);
+
   // Move to another photo, sliding the pager and resetting the zoom/dismiss
-  // of the photo we're leaving.
+  // of the photo we're leaving. Leaving a zoomed photo unzooms it in step
+  // with the slide, deferring the index - and with it, which page owns the
+  // live zoom - until both land.
   const goTo = useCallback((next: number) => {
     const target = Math.max(0, Math.min(album.length - 1, next));
     if (target === index) {
       scrollX.value = withTiming(index * width, { duration: DURATION_MS, easing: EASING });
       return;
     }
+    dismissX.value = 0;
+    dismissY.value = 0;
+    if (zoomScale.value > 1 + 1e-5) {
+      zoomScale.value = withTiming(1, { duration: DURATION_MS, easing: EASING });
+      zoomTranslateX.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
+      zoomTranslateY.value = withTiming(0, { duration: DURATION_MS, easing: EASING });
+      scrollX.value = withTiming(
+        target * width,
+        { duration: DURATION_MS, easing: EASING },
+        (finished) => {
+          if (finished) runOnJS(commitIndex)(target);
+        },
+      );
+      return;
+    }
     zoomScale.value = 1;
     zoomTranslateX.value = 0;
     zoomTranslateY.value = 0;
-    dismissX.value = 0;
-    dismissY.value = 0;
     setIndex(target);
     scrollX.value = withTiming(target * width, { duration: DURATION_MS, easing: EASING });
-  }, [album.length, index, width]);
+  }, [album.length, index, width, commitIndex]);
 
   // Until this screen has drawn the photo over the preview, the preview is
   // still the one on show and nothing may move.
@@ -435,17 +492,6 @@ const GalleryScreen = ({
     close(() => finishAndPop(() => navigation.reset({ routes: [{ name: 'Home' }] })));
   }, [navigation, close, finishAndPop]);
 
-  useEffect(() => {
-    if (Platform.OS !== 'web') return;
-
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onPressBack();
-    };
-
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [onPressBack]);
-
   const onDismiss = useCallback(() => {
     // The reverse-morph carries the drag back into the preview, so unwind it
     // over the same time. Without a morph the gallery just fades from where
@@ -460,6 +506,21 @@ const GalleryScreen = ({
   const onNavigate = useCallback((dir: number) => {
     goTo(index + dir);
   }, [goTo, index]);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onPressBack();
+      // Not while the open/close morph owns the screen: paging then would pull
+      // the expanding photo out from under it.
+      if (e.key === 'ArrowLeft' && phase === 'open') onNavigate(-1);
+      if (e.key === 'ArrowRight' && phase === 'open') onNavigate(1);
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onPressBack, onNavigate, phase]);
 
   return (
     <View
@@ -503,6 +564,11 @@ const GalleryScreen = ({
                 onDismiss={i === index ? onDismiss : undefined}
                 page={i === index && album.length > 1 ? page : undefined}
                 onNavigate={i === index && album.length > 1 ? onNavigate : undefined}
+                onTapEdge={
+                  isDesktopWeb && i === index && album.length > 1
+                    ? onNavigate
+                    : undefined
+                }
                 viewport={container}
                 backgroundColor={i === index ? 'transparent' : 'black'}
               />
@@ -511,20 +577,11 @@ const GalleryScreen = ({
         </Reanimated.View>
       }
 
-      {/* Desktop: click the left/right edge to page. */}
-      {isDesktopWeb && album.length > 1 && phase === 'open' &&
-        <>
-          <Pressable
-            style={[styles.edgeZone, { left: 0 }]}
-            onPress={() => onNavigate(-1)}
-            disabled={index === 0}
-          />
-          <Pressable
-            style={[styles.edgeZone, { right: 0 }]}
-            onPress={() => onNavigate(1)}
-            disabled={index === album.length - 1}
-          />
-        </>
+      {isDesktopWeb && phase === 'open' && index > 0 &&
+        <PagerChevron direction={-1} onNavigate={onNavigate} />
+      }
+      {isDesktopWeb && phase === 'open' && index < album.length - 1 &&
+        <PagerChevron direction={1} onNavigate={onNavigate} />
       }
 
       {album.length > 1 &&
@@ -564,12 +621,22 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 0,
   },
-  edgeZone: {
+  chevron: {
     position: 'absolute',
-    top: 0,
-    bottom: 0,
-    width: '30%',
-    zIndex: 998,
+    top: '50%',
+    marginTop: -22,
+    width: 44,
+    height: 44,
+    borderRadius: 999,
+    backgroundColor: 'rgba(0, 0, 0, 0.55)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    // Above Pinchy's 999, like the counter - at 998 it would be unreachable
+    // beneath the photo's own stacking context.
+    zIndex: 1000,
+  },
+  chevronHovered: {
+    backgroundColor: 'rgba(0, 0, 0, 0.8)',
   },
   counter: {
     position: 'absolute',

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { StyleSheet, useWindowDimensions } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import Reanimated, {
   Easing,
@@ -16,7 +16,7 @@ import { FloatingBackButton } from './prospect-profile-screen/prospect-profile-s
 import { Pinchy } from './pinchy';
 import { IMAGES_URL } from '../env/env';
 import { photoExpandFrame } from '../util/photos';
-import type { PhotoExpandFrame } from '../util/photos';
+import type { PhotoExpandFrame, Rect } from '../util/photos';
 import { getExpandedPhoto, setExpandedPhoto } from '../events/expanded-photo';
 import type { ExpandedPhoto } from '../events/expanded-photo';
 
@@ -41,19 +41,31 @@ const lerp = (a: number, b: number, t: number) => {
 const ExpandingPhoto = ({
   expandedPhoto,
   progress,
+  container,
   onCovered,
 }: {
   expandedPhoto: ExpandedPhoto,
   progress: SharedValue<number>,
+  container: Rect,
   onCovered: () => void,
 }) => {
   const { photoUuid, from, geometry } = expandedPhoto;
-  const viewport = useWindowDimensions();
 
-  const [closed, opened] = useMemo((): [PhotoExpandFrame, PhotoExpandFrame] => [
-    photoExpandFrame(geometry, from, viewport, 0),
-    photoExpandFrame(geometry, from, viewport, 1),
-  ], [geometry, from, viewport.width, viewport.height]);
+  const [closed, opened] = useMemo((): [PhotoExpandFrame, PhotoExpandFrame] => {
+    // `from` was measured in window coordinates, but this draws inside the
+    // gallery's container, which isn't necessarily the window: on Android the
+    // window excludes the system bars while the modal spans the whole screen.
+    const start: Rect = {
+      ...from,
+      x: from.x - container.x,
+      y: from.y - container.y,
+    };
+
+    return [
+      photoExpandFrame(geometry, start, container, 0),
+      photoExpandFrame(geometry, start, container, 1),
+    ];
+  }, [geometry, from, container]);
 
   const clipStyle = useAnimatedStyle(() => ({
     left: lerp(closed.clip.x, opened.clip.x, progress.value),
@@ -130,6 +142,31 @@ const GalleryScreen = ({
 
   const isFinishing = useRef(false);
 
+  // Everything here is positioned within this container rather than within the
+  // window, and it's measured rather than assumed to be the window: on Android
+  // the two differ by the system bars, and anything working in window
+  // coordinates ends up offset from anything working in the container's.
+  const containerRef = useRef<View>(null);
+  const [container, setContainer] = useState<Rect | null>(null);
+
+  const onContainerLayout = useCallback(() => {
+    containerRef.current?.measureInWindow((x, y, width, height) => {
+      if (width <= 0 || height <= 0) return;
+
+      // Keep the identity stable when nothing moved, so a repeat layout pass
+      // doesn't restart the animation.
+      setContainer((previous) =>
+        previous
+          && previous.x === x
+          && previous.y === y
+          && previous.width === width
+          && previous.height === height
+          ? previous
+          : { x, y, width, height }
+      );
+    });
+  }, []);
+
   // Until this screen has drawn the photo over the preview, the preview is
   // still the one on show and nothing may move: the first frame has to be
   // indistinguishable from the screen underneath.
@@ -149,6 +186,9 @@ const GalleryScreen = ({
   useEffect(() => {
     if (!expandedPhoto) return;
     if (!isCovering) return;
+    // Nothing is drawn over the preview until the container has been measured,
+    // so hiding it before then would leave the photo missing.
+    if (!container) return;
     // The photo can finish loading after a quick back-press has already
     // started closing. Opening from there would fight the closing animation,
     // and would re-hide a preview that nothing is left to reveal again.
@@ -164,7 +204,7 @@ const GalleryScreen = ({
         if (finished) runOnJS(setPhase)('open');
       },
     );
-  }, [expandedPhoto, isCovering]);
+  }, [expandedPhoto, isCovering, container]);
 
   const backdropStyle = useAnimatedStyle(() => ({
     // Runs ahead of the photo so the preview underneath is covered by the time
@@ -219,14 +259,19 @@ const GalleryScreen = ({
   }, [navigation]);
 
   return (
-    <>
+    <View
+      ref={containerRef}
+      onLayout={onContainerLayout}
+      style={StyleSheet.absoluteFill}
+    >
       <Reanimated.View
         style={[styles.backdrop, expandedPhoto ? backdropStyle : undefined]}
       />
-      {expandedPhoto &&
+      {expandedPhoto && container &&
         <ExpandingPhoto
           expandedPhoto={expandedPhoto}
           progress={progress}
+          container={container}
           onCovered={onCovered}
         />
       }
@@ -234,6 +279,10 @@ const GalleryScreen = ({
         <Pinchy
           uuid={photoUuid}
           naturalSize={expandedPhoto?.geometry}
+          // Both copies of the photo have to be sized and centred against the
+          // same box, or they land in different places and you see the two of
+          // them at the end of the expansion.
+          viewport={container ?? undefined}
           // The expanded photo is drawn underneath and is pixel-identical at
           // this point, so it - rather than a black box - is what shows while
           // Pinchy's own copy of the image paints.
@@ -242,7 +291,7 @@ const GalleryScreen = ({
       }
       <StatusBarSpacer/>
       <FloatingBackButton onPress={onPressBack}/>
-    </>
+    </View>
   );
 };
 

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -33,6 +33,13 @@ const EASING = Easing.bezier(0.33, 0, 0.15, 1);
 // the way to transparent.
 const DISMISS_FADE_RANGE = 300;
 
+// The backdrop's opacity for a dismiss drag of `(x, y)`: 1 untouched, fading
+// to 0 as the photo is dragged away.
+const dragBackdropOpacity = (x: number, y: number) => {
+  'worklet';
+  return 1 - Math.min(1, dragDistance(x, y) / DISMISS_FADE_RANGE);
+};
+
 // The back button and click-to-navigate zones are desktop-web only; on mobile
 // (native or mobile web) navigation and dismissal are gestures.
 const isDesktopWeb = Platform.OS === 'web' && !isMobile();
@@ -358,11 +365,15 @@ const GalleryScreen = ({
     return () => setExpandedPhoto(null);
   }, []);
 
+  // The backdrop opacity when the close began. Dismissing unwinds the drag
+  // offset while the photo morphs home, and without this cap the drag fade
+  // would recover with it, flashing the backdrop back to black mid-close.
+  const backdropAtClose = useSharedValue(1);
+
   const backdropStyle = useAnimatedStyle(() => {
     const opened = Math.min(1, progress.value * 2);
-    const dragged = dragDistance(dismissX.value, dismissY.value);
-    const notDragged = 1 - Math.min(1, dragged / DISMISS_FADE_RANGE);
-    return { opacity: opened * notDragged };
+    const notDragged = dragBackdropOpacity(dismissX.value, dismissY.value);
+    return { opacity: opened * Math.min(notDragged, backdropAtClose.value) };
   });
 
   // The open/close morph only makes sense for the photo we opened; once paged
@@ -374,6 +385,9 @@ const GalleryScreen = ({
   const close = useCallback((finish: () => void) => {
     if (isFinishing.current) return;
     isFinishing.current = true;
+
+    backdropAtClose.value =
+      dragBackdropOpacity(dismissX.value, dismissY.value);
 
     // `finish` runs even if the timing is interrupted: better to cut the
     // animation short than to leave the navigation permanently prevented.

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { StyleSheet, useWindowDimensions } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import Reanimated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import type { SharedValue } from 'react-native-reanimated';
+import { Image as ExpoImage } from 'expo-image';
+import type { RootParamList } from '../navigation/linking';
+import { StatusBarSpacer } from './status-bar-spacer';
+import { FloatingBackButton } from './prospect-profile-screen/prospect-profile-screen';
+import { Pinchy } from './pinchy';
+import { IMAGES_URL } from '../env/env';
+import { photoExpandFrame } from '../util/photos';
+import type { PhotoExpandFrame } from '../util/photos';
+import { getExpandedPhoto, setExpandedPhoto } from '../events/expanded-photo';
+import type { ExpandedPhoto } from '../events/expanded-photo';
+
+const DURATION_MS = 280;
+
+const EASING = Easing.bezier(0.33, 0, 0.15, 1);
+
+// 'opening' and 'closing' show the photo mid-expansion and own the screen;
+// 'open' hands over to Pinchy, which is the same photo at the same size but
+// can be zoomed. A gallery with nothing to expand from starts 'open'.
+type Phase = 'opening' | 'open' | 'closing';
+
+const lerp = (a: number, b: number, t: number) => {
+  'worklet';
+  return a + (b - a) * t;
+};
+
+// The photo, expanding. Stands in for the preview - which hides itself - so
+// that only one instance of the photo is ever apparent. The frame is linear in
+// `progress`, so its endpoints are computed once here and lerped on the UI
+// thread. See `photoExpandFrame`.
+const ExpandingPhoto = ({
+  expandedPhoto,
+  progress,
+  onCovered,
+}: {
+  expandedPhoto: ExpandedPhoto,
+  progress: SharedValue<number>,
+  onCovered: () => void,
+}) => {
+  const { photoUuid, from, geometry } = expandedPhoto;
+  const viewport = useWindowDimensions();
+
+  const [closed, opened] = useMemo((): [PhotoExpandFrame, PhotoExpandFrame] => [
+    photoExpandFrame(geometry, from, viewport, 0),
+    photoExpandFrame(geometry, from, viewport, 1),
+  ], [geometry, from, viewport.width, viewport.height]);
+
+  const clipStyle = useAnimatedStyle(() => ({
+    left: lerp(closed.clip.x, opened.clip.x, progress.value),
+    top: lerp(closed.clip.y, opened.clip.y, progress.value),
+    width: lerp(closed.clip.width, opened.clip.width, progress.value),
+    height: lerp(closed.clip.height, opened.clip.height, progress.value),
+  }));
+
+  const imageStyle = useAnimatedStyle(() => ({
+    left: lerp(closed.image.x, opened.image.x, progress.value),
+    top: lerp(closed.image.y, opened.image.y, progress.value),
+    width: lerp(closed.image.width, opened.image.width, progress.value),
+    height: lerp(closed.image.height, opened.image.height, progress.value),
+  }));
+
+  const cropStyle = useAnimatedStyle(() => ({
+    left: lerp(closed.crop.x, opened.crop.x, progress.value),
+    top: lerp(closed.crop.y, opened.crop.y, progress.value),
+    width: lerp(closed.crop.width, opened.crop.width, progress.value),
+    height: lerp(closed.crop.height, opened.crop.height, progress.value),
+  }));
+
+  return (
+    <Reanimated.View style={[styles.clip, clipStyle]}>
+      {/*
+        The square rendition the preview was already showing. It's in cache, so
+        it paints on the first frame - which it covers exactly - and holds the
+        photo's place while the original decodes.
+      */}
+      <Reanimated.View style={[styles.image, cropStyle]}>
+        <ExpoImage
+          source={{ uri: `${IMAGES_URL}/900-${photoUuid}.jpg` }}
+          style={StyleSheet.absoluteFill}
+          contentFit="fill"
+          transition={0}
+          cachePolicy="memory-disk"
+          onLoad={onCovered}
+        />
+      </Reanimated.View>
+      <Reanimated.View style={[styles.image, imageStyle]}>
+        <ExpoImage
+          source={{ uri: `${IMAGES_URL}/original-${photoUuid}.jpg` }}
+          style={StyleSheet.absoluteFill}
+          // The frame already has the photo's aspect ratio, so `fill` matches
+          // `contain` without risking a sub-pixel letterbox down one edge.
+          contentFit="fill"
+          transition={0}
+          cachePolicy="memory-disk"
+        />
+      </Reanimated.View>
+    </Reanimated.View>
+  );
+};
+
+const GalleryScreen = ({
+  navigation,
+  route,
+}: NativeStackScreenProps<RootParamList, 'Gallery Screen'>) => {
+  const { photoUuid } = route.params;
+
+  // Captured once: the press stashes this immediately before navigating. Deep
+  // links arrive without it, and photos whose geometry the server hasn't
+  // recorded can't be expanded, so both fall back to fading the gallery in.
+  const [expandedPhoto] = useState<ExpandedPhoto | null>(() => {
+    const e = getExpandedPhoto();
+    return e?.photoUuid === photoUuid ? e : null;
+  });
+
+  const [phase, setPhase] = useState<Phase>(
+    expandedPhoto ? 'opening' : 'open',
+  );
+
+  const progress = useSharedValue(expandedPhoto ? 0 : 1);
+
+  const isFinishing = useRef(false);
+
+  // Until this screen has drawn the photo over the preview, the preview is
+  // still the one on show and nothing may move: the first frame has to be
+  // indistinguishable from the screen underneath.
+  const [isCovering, setIsCovering] = useState(!expandedPhoto);
+
+  const onCovered = useCallback(() => setIsCovering(true), []);
+
+  // The square rendition is the one the preview is already displaying, so it
+  // comes from cache and this is a formality - but don't hang the animation on
+  // a load event that never arrives.
+  useEffect(() => {
+    if (!expandedPhoto) return;
+    const timeout = setTimeout(onCovered, 250);
+    return () => clearTimeout(timeout);
+  }, [expandedPhoto, onCovered]);
+
+  useEffect(() => {
+    if (!expandedPhoto) return;
+    if (!isCovering) return;
+    // The photo can finish loading after a quick back-press has already
+    // started closing. Opening from there would fight the closing animation,
+    // and would re-hide a preview that nothing is left to reveal again.
+    if (isFinishing.current) return;
+
+    // Only now is it safe for the preview to get out of the way.
+    setExpandedPhoto({ ...expandedPhoto, covered: true });
+
+    progress.value = withTiming(
+      1,
+      { duration: DURATION_MS, easing: EASING },
+      (finished) => {
+        if (finished) runOnJS(setPhase)('open');
+      },
+    );
+  }, [expandedPhoto, isCovering]);
+
+  const backdropStyle = useAnimatedStyle(() => ({
+    // Runs ahead of the photo so the preview underneath is covered by the time
+    // the photo has moved off it, without blinking the profile out at the very
+    // start of the press.
+    opacity: Math.min(1, progress.value * 2),
+  }));
+
+  const close = useCallback((finish: () => void) => {
+    if (isFinishing.current) return;
+    isFinishing.current = true;
+
+    if (!expandedPhoto) {
+      setExpandedPhoto(null);
+      finish();
+      return;
+    }
+
+    setPhase('closing');
+
+    progress.value = withTiming(
+      0,
+      { duration: DURATION_MS, easing: EASING },
+      (finished) => {
+        if (finished) runOnJS(finish)();
+      },
+    );
+  }, [expandedPhoto]);
+
+  // Reveal the preview before popping. The photo has landed back on top of it
+  // and the two coincide exactly, so the handover is invisible; popping first
+  // would flash the empty slot for a frame.
+  const finishAndPop = useCallback((pop: () => void) => {
+    setExpandedPhoto(null);
+    pop();
+  }, []);
+
+  // Also covers the Android hardware back button and the browser's back
+  // button, either of which would otherwise pop the screen out from under the
+  // animation.
+  useEffect(() => {
+    return navigation.addListener('beforeRemove', (e) => {
+      if (isFinishing.current) return;
+
+      e.preventDefault();
+      close(() => finishAndPop(() => navigation.dispatch(e.data.action)));
+    });
+  }, [navigation, close, finishAndPop]);
+
+  const onPressBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  return (
+    <>
+      <Reanimated.View
+        style={[styles.backdrop, expandedPhoto ? backdropStyle : undefined]}
+      />
+      {expandedPhoto &&
+        <ExpandingPhoto
+          expandedPhoto={expandedPhoto}
+          progress={progress}
+          onCovered={onCovered}
+        />
+      }
+      {phase === 'open' &&
+        <Pinchy
+          uuid={photoUuid}
+          naturalSize={expandedPhoto?.geometry}
+          // The expanded photo is drawn underneath and is pixel-identical at
+          // this point, so it - rather than a black box - is what shows while
+          // Pinchy's own copy of the image paints.
+          backgroundColor={expandedPhoto ? 'transparent' : 'black'}
+        />
+      }
+      <StatusBarSpacer/>
+      <FloatingBackButton onPress={onPressBack}/>
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'black',
+  },
+  clip: {
+    position: 'absolute',
+    overflow: 'hidden',
+  },
+  image: {
+    position: 'absolute',
+  },
+});
+
+export {
+  GalleryScreen,
+};

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -14,6 +14,7 @@ import type { RootParamList } from '../navigation/linking';
 import { StatusBarSpacer } from './status-bar-spacer';
 import { FloatingBackButton } from './prospect-profile-screen/prospect-profile-screen';
 import { Pinchy } from './pinchy';
+import type { PinchyZoom } from './pinchy';
 import { IMAGES_URL } from '../env/env';
 import { photoExpandFrame } from '../util/photos';
 import type { PhotoExpandFrame, Rect } from '../util/photos';
@@ -42,11 +43,13 @@ const ExpandingPhoto = ({
   expandedPhoto,
   progress,
   container,
+  zoom,
   onCovered,
 }: {
   expandedPhoto: ExpandedPhoto,
   progress: SharedValue<number>,
   container: Rect,
+  zoom: PinchyZoom,
   onCovered: () => void,
 }) => {
   const { photoUuid, from, geometry } = expandedPhoto;
@@ -67,11 +70,20 @@ const ExpandingPhoto = ({
     ];
   }, [geometry, from, container]);
 
+  // At `progress` 1 this is the photo exactly as Pinchy has it, zoom and all,
+  // so closing carries it out from wherever the user left it rather than
+  // snapping back to fitted first. The zoom unwinds as the photo returns to the
+  // preview, where it has to be identity. Same order as Pinchy's own transform.
   const clipStyle = useAnimatedStyle(() => ({
     left: lerp(closed.clip.x, opened.clip.x, progress.value),
     top: lerp(closed.clip.y, opened.clip.y, progress.value),
     width: lerp(closed.clip.width, opened.clip.width, progress.value),
     height: lerp(closed.clip.height, opened.clip.height, progress.value),
+    transform: [
+      { scale: lerp(1, zoom.scale.value, progress.value) },
+      { translateX: lerp(0, zoom.translateX.value, progress.value) },
+      { translateY: lerp(0, zoom.translateY.value, progress.value) },
+    ],
   }));
 
   const imageStyle = useAnimatedStyle(() => ({
@@ -139,6 +151,18 @@ const GalleryScreen = ({
   );
 
   const progress = useSharedValue(expandedPhoto ? 0 : 1);
+
+  // Lives here rather than inside Pinchy so the photo can be animated out from
+  // wherever the user pinched it to, after Pinchy itself has gone.
+  const zoomScale = useSharedValue(1);
+  const zoomTranslateX = useSharedValue(0);
+  const zoomTranslateY = useSharedValue(0);
+
+  const zoom: PinchyZoom = useMemo(() => ({
+    scale: zoomScale,
+    translateX: zoomTranslateX,
+    translateY: zoomTranslateY,
+  }), [zoomScale, zoomTranslateX, zoomTranslateY]);
 
   const isFinishing = useRef(false);
 
@@ -280,6 +304,7 @@ const GalleryScreen = ({
           expandedPhoto={expandedPhoto}
           progress={progress}
           container={container}
+          zoom={zoom}
           onCovered={onCovered}
         />
       }
@@ -287,6 +312,7 @@ const GalleryScreen = ({
         <Pinchy
           uuid={photoUuid}
           naturalSize={expandedPhoto?.geometry}
+          zoom={zoom}
           // Both copies of the photo have to be sized and centred against the
           // same box, or they land in different places and you see the two of
           // them at the end of the expansion.

--- a/frontend/components/pinchy-math.tsx
+++ b/frontend/components/pinchy-math.tsx
@@ -68,6 +68,36 @@ const constrainPosition = (
   };
 };
 
+// The mode a fresh drag locks to once it commits to an axis: sideways pages,
+// up/down dismisses, and when the committed axis's mode isn't available the
+// drag falls through to whichever one is.
+const lockedDragMode = (
+  horizontal: boolean,
+  canPage: boolean,
+  canDismiss: boolean,
+): 'none' | 'page' | 'dismiss' => {
+  'worklet';
+  if (horizontal && canPage) return 'page';
+  if (!horizontal && canDismiss) return 'dismiss';
+  if (canPage) return 'page';
+  if (canDismiss) return 'dismiss';
+  return 'none';
+};
+
+// Which neighbour a finished page drag of `translationX` lands on: 1 (next),
+// -1 (previous), or 0 to slide back, clamped at the album's ends.
+const pageNavDirection = (
+  translationX: number,
+  threshold: number,
+  atIndex: number,
+  count: number,
+): -1 | 0 | 1 => {
+  'worklet';
+  if (translationX <= -threshold && atIndex < count - 1) return 1;
+  if (translationX >= threshold && atIndex > 0) return -1;
+  return 0;
+};
+
 // How far (screen px) a dismiss drag rounds the photo's corners over, and the
 // radius it reaches. The photo rounds as it's dragged away so the user never
 // sees square corners lifting off the screen.
@@ -93,4 +123,6 @@ export {
   dragDismissRadius,
   dragDistance,
   focalZoomPosition,
+  lockedDragMode,
+  pageNavDirection,
 };

--- a/frontend/components/pinchy-math.tsx
+++ b/frontend/components/pinchy-math.tsx
@@ -68,7 +68,22 @@ const constrainPosition = (
   };
 };
 
+// How far (screen px) a dismiss drag rounds the photo's corners over, and the
+// radius it reaches. The photo rounds as it's dragged away so the user never
+// sees square corners lifting off the screen.
+const DRAG_DISMISS_RADIUS_RANGE = 60;
+const DRAG_DISMISS_MAX_RADIUS = 24;
+
+// The corner radius for a dismiss drag of `(x, y)` screen px. Shared by the
+// dragged photo and the closing one so the two agree at the hand-off.
+const dragDismissRadius = (x: number, y: number): number => {
+  'worklet';
+  const dragged = Math.sqrt(x * x + y * y);
+  return Math.min(dragged / DRAG_DISMISS_RADIUS_RANGE, 1) * DRAG_DISMISS_MAX_RADIUS;
+};
+
 export {
   constrainPosition,
+  dragDismissRadius,
   focalZoomPosition,
 };

--- a/frontend/components/pinchy-math.tsx
+++ b/frontend/components/pinchy-math.tsx
@@ -74,16 +74,23 @@ const constrainPosition = (
 const DRAG_DISMISS_RADIUS_RANGE = 60;
 const DRAG_DISMISS_MAX_RADIUS = 24;
 
+// How far (screen px) a dismiss drag of `(x, y)` has carried the photo.
+const dragDistance = (x: number, y: number): number => {
+  'worklet';
+  return Math.sqrt(x * x + y * y);
+};
+
 // The corner radius for a dismiss drag of `(x, y)` screen px. Shared by the
 // dragged photo and the closing one so the two agree at the hand-off.
 const dragDismissRadius = (x: number, y: number): number => {
   'worklet';
-  const dragged = Math.sqrt(x * x + y * y);
-  return Math.min(dragged / DRAG_DISMISS_RADIUS_RANGE, 1) * DRAG_DISMISS_MAX_RADIUS;
+  return Math.min(dragDistance(x, y) / DRAG_DISMISS_RADIUS_RANGE, 1)
+    * DRAG_DISMISS_MAX_RADIUS;
 };
 
 export {
   constrainPosition,
   dragDismissRadius,
+  dragDistance,
   focalZoomPosition,
 };

--- a/frontend/components/pinchy-math.tsx
+++ b/frontend/components/pinchy-math.tsx
@@ -1,0 +1,74 @@
+// Pure gesture math for the zoomable image viewer (`pinchy.tsx`). Kept free of
+// react-native-reanimated so it can be unit-tested off the UI thread; the
+// `'worklet'` directives let the reanimated babel plugin inline these into the
+// gesture worklets that call them.
+
+// The (pre-scale, image-unit) position that keeps the point under the fingers
+// at the start of a pinch under them at `newScale`. Screen coordinates relate
+// to position as `screen = centre + scale * (imagePoint + position)`, so the
+// image point under the base focal is `(focalBase - centre)/baseScale -
+// basePosition`, and we solve for the position that puts it under the current
+// focal at the new scale. When the fingers move without spreading this reduces
+// to a pan.
+const focalZoomPosition = (
+  baseScale: number,
+  newScale: number,
+  basePosition: { x: number, y: number },
+  baseFocal: { x: number, y: number },
+  focal: { x: number, y: number },
+  viewportWidth: number,
+  viewportHeight: number,
+) => {
+  'worklet';
+  const cx = viewportWidth / 2;
+  const cy = viewportHeight / 2;
+
+  const anchorX = (baseFocal.x - cx) / baseScale - basePosition.x;
+  const anchorY = (baseFocal.y - cy) / baseScale - basePosition.y;
+
+  return {
+    x: (focal.x - cx) / newScale - anchorX,
+    y: (focal.y - cy) / newScale - anchorY,
+  };
+};
+
+// Clamp a position so the image can't be dragged past its own edges: when the
+// image is larger than the viewport on an axis it may pan within its overhang,
+// and when it's smaller it stays centred.
+const constrainPosition = (
+  currentScale: number,
+  imageWidth: number,
+  imageHeight: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  x: number,
+  y: number,
+  dx: number = 0,
+  dy: number = 0,
+) => {
+  'worklet';
+  const adjustedWidth = imageWidth * currentScale;
+  const adjustedHeight = imageHeight * currentScale;
+
+  const maxTranslateX = (adjustedWidth > viewportWidth) ?
+    (adjustedWidth - viewportWidth) / 2 / currentScale :
+    (viewportWidth - adjustedWidth) / 2 / currentScale;
+
+  const maxTranslateY = (adjustedHeight > viewportHeight) ?
+    (adjustedHeight - viewportHeight) / 2 / currentScale :
+    (viewportHeight - adjustedHeight) / 2 / currentScale;
+
+  return {
+    x: (adjustedWidth > viewportWidth) ?
+       Math.min(maxTranslateX, Math.max(-maxTranslateX, x + dx / currentScale)) :
+       0,
+    y: (adjustedHeight > viewportHeight) ?
+       Math.min(maxTranslateY, Math.max(-maxTranslateY, y + dy / currentScale)) :
+       0,
+  };
+};
+
+export {
+  constrainPosition,
+  focalZoomPosition,
+};

--- a/frontend/components/pinchy.spec.tsx
+++ b/frontend/components/pinchy.spec.tsx
@@ -1,4 +1,4 @@
-import { focalZoomPosition } from './pinchy-math';
+import { dragDismissRadius, focalZoomPosition } from './pinchy-math';
 
 // The screen position of an image point, under the model the transform
 // implements: `screen = centre + scale * (imagePoint + position)`, where
@@ -93,5 +93,30 @@ describe('focalZoomPosition', () => {
     // A drag of (40, 30) screen px at scale 2 is (20, 15) image units.
     expect(position.x).toBeCloseTo(basePosition.x + 40 / baseScale);
     expect(position.y).toBeCloseTo(basePosition.y + 30 / baseScale);
+  });
+});
+
+describe('dragDismissRadius', () => {
+  it('is zero before the photo is dragged', () => {
+    expect(dragDismissRadius(0, 0)).toBe(0);
+  });
+
+  it('grows with the drag distance, not the axis', () => {
+    // Uses Euclidean distance, so a diagonal drag rounds as much as a straight
+    // one of the same length.
+    const straight = dragDismissRadius(0, 30);
+    const diagonal = dragDismissRadius(18, 24); // 3-4-5 -> distance 30
+
+    expect(straight).toBeGreaterThan(0);
+    expect(diagonal).toBeCloseTo(straight);
+  });
+
+  it('caps once dragged past the range rather than growing without bound', () => {
+    const atRange = dragDismissRadius(0, 60);
+    const wellPast = dragDismissRadius(0, 600);
+
+    // Both maxed out - a far drag doesn't over-round.
+    expect(atRange).toBeCloseTo(wellPast);
+    expect(wellPast).toBeLessThanOrEqual(24);
   });
 });

--- a/frontend/components/pinchy.spec.tsx
+++ b/frontend/components/pinchy.spec.tsx
@@ -1,0 +1,97 @@
+import { focalZoomPosition } from './pinchy-math';
+
+// The screen position of an image point, under the model the transform
+// implements: `screen = centre + scale * (imagePoint + position)`, where
+// position is in pre-scale image units and both are measured from the viewport
+// centre. This is what `focalZoomPosition` has to keep invariant at the focal.
+const screenOf = (
+  imagePoint: { x: number, y: number },
+  scale: number,
+  position: { x: number, y: number },
+  viewport: { width: number, height: number },
+) => ({
+  x: viewport.width / 2 + scale * (imagePoint.x + position.x),
+  y: viewport.height / 2 + scale * (imagePoint.y + position.y),
+});
+
+// Recover which image point currently sits under a screen point.
+const imagePointUnder = (
+  screen: { x: number, y: number },
+  scale: number,
+  position: { x: number, y: number },
+  viewport: { width: number, height: number },
+) => ({
+  x: (screen.x - viewport.width / 2) / scale - position.x,
+  y: (screen.y - viewport.height / 2) / scale - position.y,
+});
+
+const viewport = { width: 400, height: 800 };
+
+describe('focalZoomPosition', () => {
+  it('keeps the pinched point under the fingers as the scale grows', () => {
+    const baseScale = 1;
+    const basePosition = { x: 0, y: 0 };
+    // Fingers centred on a point up and to the left of the middle.
+    const focal = { x: 120, y: 250 };
+
+    // The image point the fingers are on before zooming.
+    const anchored = imagePointUnder(focal, baseScale, basePosition, viewport);
+
+    const newScale = 2.5;
+    const position = focalZoomPosition(
+      baseScale, newScale, basePosition, focal, focal, viewport.width, viewport.height,
+    );
+
+    // That same image point must still project to the focal after zooming.
+    const after = screenOf(anchored, newScale, position, viewport);
+    expect(after.x).toBeCloseTo(focal.x);
+    expect(after.y).toBeCloseTo(focal.y);
+  });
+
+  it('tracks the fingers when they also move (pinch + pan together)', () => {
+    const baseScale = 1.5;
+    const basePosition = { x: 10, y: -20 };
+    const baseFocal = { x: 150, y: 300 };
+
+    const anchored = imagePointUnder(baseFocal, baseScale, basePosition, viewport);
+
+    // Fingers spread AND slide to a new focal.
+    const newScale = 3;
+    const focal = { x: 260, y: 520 };
+    const position = focalZoomPosition(
+      baseScale, newScale, basePosition, baseFocal, focal, viewport.width, viewport.height,
+    );
+
+    // The originally-anchored point follows the fingers to the new focal.
+    const after = screenOf(anchored, newScale, position, viewport);
+    expect(after.x).toBeCloseTo(focal.x);
+    expect(after.y).toBeCloseTo(focal.y);
+  });
+
+  it('leaves the centre fixed when pinching about the centre', () => {
+    const centre = { x: viewport.width / 2, y: viewport.height / 2 };
+
+    const position = focalZoomPosition(
+      1, 4, { x: 0, y: 0 }, centre, centre, viewport.width, viewport.height,
+    );
+
+    // Pinching dead centre needs no translation - the old centre behaviour.
+    expect(position.x).toBeCloseTo(0);
+    expect(position.y).toBeCloseTo(0);
+  });
+
+  it('is a pure pan when the scale does not change', () => {
+    const baseScale = 2;
+    const basePosition = { x: 5, y: 5 };
+    const baseFocal = { x: 100, y: 100 };
+    const focal = { x: 140, y: 130 }; // fingers slid by (40, 30)
+
+    const position = focalZoomPosition(
+      baseScale, baseScale, basePosition, baseFocal, focal, viewport.width, viewport.height,
+    );
+
+    // A drag of (40, 30) screen px at scale 2 is (20, 15) image units.
+    expect(position.x).toBeCloseTo(basePosition.x + 40 / baseScale);
+    expect(position.y).toBeCloseTo(basePosition.y + 30 / baseScale);
+  });
+});

--- a/frontend/components/pinchy.spec.tsx
+++ b/frontend/components/pinchy.spec.tsx
@@ -31,10 +31,8 @@ describe('focalZoomPosition', () => {
   it('keeps the pinched point under the fingers as the scale grows', () => {
     const baseScale = 1;
     const basePosition = { x: 0, y: 0 };
-    // Fingers centred on a point up and to the left of the middle.
     const focal = { x: 120, y: 250 };
 
-    // The image point the fingers are on before zooming.
     const anchored = imagePointUnder(focal, baseScale, basePosition, viewport);
 
     const newScale = 2.5;
@@ -42,7 +40,6 @@ describe('focalZoomPosition', () => {
       baseScale, newScale, basePosition, focal, focal, viewport.width, viewport.height,
     );
 
-    // That same image point must still project to the focal after zooming.
     const after = screenOf(anchored, newScale, position, viewport);
     expect(after.x).toBeCloseTo(focal.x);
     expect(after.y).toBeCloseTo(focal.y);
@@ -55,14 +52,12 @@ describe('focalZoomPosition', () => {
 
     const anchored = imagePointUnder(baseFocal, baseScale, basePosition, viewport);
 
-    // Fingers spread AND slide to a new focal.
     const newScale = 3;
     const focal = { x: 260, y: 520 };
     const position = focalZoomPosition(
       baseScale, newScale, basePosition, baseFocal, focal, viewport.width, viewport.height,
     );
 
-    // The originally-anchored point follows the fingers to the new focal.
     const after = screenOf(anchored, newScale, position, viewport);
     expect(after.x).toBeCloseTo(focal.x);
     expect(after.y).toBeCloseTo(focal.y);
@@ -75,7 +70,6 @@ describe('focalZoomPosition', () => {
       1, 4, { x: 0, y: 0 }, centre, centre, viewport.width, viewport.height,
     );
 
-    // Pinching dead centre needs no translation - the old centre behaviour.
     expect(position.x).toBeCloseTo(0);
     expect(position.y).toBeCloseTo(0);
   });
@@ -102,8 +96,6 @@ describe('dragDismissRadius', () => {
   });
 
   it('grows with the drag distance, not the axis', () => {
-    // Uses Euclidean distance, so a diagonal drag rounds as much as a straight
-    // one of the same length.
     const straight = dragDismissRadius(0, 30);
     const diagonal = dragDismissRadius(18, 24); // 3-4-5 -> distance 30
 
@@ -115,7 +107,6 @@ describe('dragDismissRadius', () => {
     const atRange = dragDismissRadius(0, 60);
     const wellPast = dragDismissRadius(0, 600);
 
-    // Both maxed out - a far drag doesn't over-round.
     expect(atRange).toBeCloseTo(wellPast);
     expect(wellPast).toBeLessThanOrEqual(24);
   });

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -167,7 +167,7 @@ type PinchyPage = {
   count: number
 };
 
-const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, onNavigate, backgroundColor = 'black'}: {
+const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, onNavigate, onTapEdge, backgroundColor = 'black'}: {
   uuid: string,
   naturalSize?: { width: number, height: number },
   // The box to fit the photo within and centre it in.
@@ -180,6 +180,10 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, on
   // When provided, a sideways drag pages between photos instead of dismissing.
   page?: PinchyPage,
   onNavigate?: (dir: number) => void,
+  // When provided, a tap on the left or right third of the viewport pages to
+  // the neighbour. A gesture rather than overlay views, which would swallow
+  // the pan and double-tap wherever they sat.
+  onTapEdge?: (dir: number) => void,
   backgroundColor?: string,
 }) => {
   const {
@@ -419,9 +423,25 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, on
     [scale, positionX, positionY],
   );
 
+  const edgeTap = useMemo(
+    () => Gesture.Tap()
+      .maxDuration(300)
+      .maxDistance(10)
+      .onEnd((e, success) => {
+        'worklet';
+        if (!success || !onTapEdge) return;
+        const width = viewportWidthSv.value;
+        if (e.x < width / 3) runOnJS(onTapEdge)(-1);
+        else if (e.x > width * 2 / 3) runOnJS(onTapEdge)(1);
+      }),
+    [onTapEdge],
+  );
+
   const composed = useMemo(
-    () => Gesture.Simultaneous(pinch, pan, doubleTap),
-    [pinch, pan, doubleTap],
+    // Exclusive so a double-tap zooms without also paging: the edge tap only
+    // activates once the double-tap window has passed.
+    () => Gesture.Simultaneous(pinch, pan, Gesture.Exclusive(doubleTap, edgeTap)),
+    [pinch, pan, doubleTap, edgeTap],
   );
 
   const animatedStyle = useAnimatedStyle<ImageStyle>(() => {

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -27,7 +27,14 @@ import Animated, {
 } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
 import { IMAGES_URL } from '../env/env';
-import { constrainPosition, dragDismissRadius, dragDistance, focalZoomPosition } from './pinchy-math';
+import {
+  constrainPosition,
+  dragDismissRadius,
+  dragDistance,
+  focalZoomPosition,
+  lockedDragMode,
+  pageNavDirection,
+} from './pinchy-math';
 
 // Double-tap zoom eases in rather than snapping. A pinch or pan writing the
 // shared values directly cancels it mid-flight, which is what you want.
@@ -91,9 +98,6 @@ const FitWithinScreenImage = ({
   const [imageHeight, setImageHeight] = useState<number | null>(initialFit?.height ?? null);
 
   useEffect(() => {
-    // Callers that already know the photo's dimensions (the API reports them)
-    // save the round trip, and with it the spinner that would otherwise appear
-    // for a frame in place of an image the caller has already drawn.
     if (naturalSize) {
       setImageSize(naturalSize);
       return;
@@ -262,7 +266,6 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, on
         'worklet';
         const newScale = Math.max(1, e.scale * pinchBaseScale.value);
 
-        // Zoom towards the fingers rather than the middle of the photo.
         const target = focalZoomPosition(
           pinchBaseScale.value,
           newScale,
@@ -342,17 +345,15 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, on
           return;
         }
 
-        // Lock to whichever axis the drag commits to first: sideways pages,
-        // up/down dismisses. Only the modes the caller enabled are available.
-        if (dragMode.value === 'none') {
-          const moved = Math.max(Math.abs(e.translationX), Math.abs(e.translationY));
-          if (moved > 8) {
-            const horizontal = Math.abs(e.translationX) >= Math.abs(e.translationY);
-            if (horizontal && page) dragMode.value = 'page';
-            else if (!horizontal && dismiss) dragMode.value = 'dismiss';
-            else if (page) dragMode.value = 'page';
-            else if (dismiss) dragMode.value = 'dismiss';
-          }
+        const moved = Math.max(Math.abs(e.translationX), Math.abs(e.translationY));
+
+        // Lock to whichever axis the drag commits to first.
+        if (dragMode.value === 'none' && moved > 8) {
+          dragMode.value = lockedDragMode(
+            Math.abs(e.translationX) >= Math.abs(e.translationY),
+            page !== undefined,
+            dismiss !== undefined,
+          );
         }
 
         if (dragMode.value === 'page' && page) {
@@ -365,27 +366,38 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, on
       })
       .onEnd((e) => {
         'worklet';
-        if (dragMode.value === 'page' && page) {
+        const endPageDrag = () => {
+          if (!page) return;
+
           const atIndex = Math.round(page.homeX / page.width);
-          let dir = 0;
-          if (e.translationX <= -NAV_THRESHOLD && atIndex < page.count - 1) dir = 1;
-          else if (e.translationX >= NAV_THRESHOLD && atIndex > 0) dir = -1;
+          const dir = pageNavDirection(
+            e.translationX, NAV_THRESHOLD, atIndex, page.count,
+          );
 
           if (dir !== 0 && onNavigate) {
             runOnJS(onNavigate)(dir);
-          } else {
-            // Not far enough (or at an end): slide back in one motion.
-            page.scrollX.value = withTiming(page.homeX, DISMISS_RETURN);
+            return;
           }
-        } else if (dragMode.value === 'dismiss' && dismiss) {
+
+          page.scrollX.value = withTiming(page.homeX, DISMISS_RETURN);
+        };
+
+        const endDismissDrag = () => {
+          if (!dismiss) return;
+
           const dragged = dragDistance(dismiss.x.value, dismiss.y.value);
+
           if (dragged > DISMISS_THRESHOLD && onDismiss) {
             runOnJS(onDismiss)();
-          } else {
-            dismiss.x.value = withTiming(0, DISMISS_RETURN);
-            dismiss.y.value = withTiming(0, DISMISS_RETURN);
+            return;
           }
-        }
+
+          dismiss.x.value = withTiming(0, DISMISS_RETURN);
+          dismiss.y.value = withTiming(0, DISMISS_RETURN);
+        };
+
+        if (dragMode.value === 'page') endPageDrag();
+        if (dragMode.value === 'dismiss') endDismissDrag();
       }),
     [dismiss, onDismiss, page, onNavigate, scale, positionX, positionY],
   );
@@ -449,8 +461,6 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, on
     const dismissY = dismiss ? dismiss.y.value : 0;
 
     return {
-      // Round the corners as the photo is dragged away, so it never lifts off
-      // the screen looking square.
       borderRadius: dragDismissRadius(dismissX, dismissY),
       // The dismiss drag translates the whole photo in screen space, so it goes
       // outermost (ahead of the zoom scale, which it must not be multiplied by).

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -19,13 +19,19 @@ import {
 } from 'react-native-gesture-handler';
 import Animated, {
   AnimatedStyle,
+  Easing,
   runOnUI,
   useAnimatedStyle,
   useSharedValue,
+  withTiming,
 } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
 import { IMAGES_URL } from '../env/env';
 import { constrainPosition, focalZoomPosition } from './pinchy-math';
+
+// Double-tap zoom eases in rather than snapping. A pinch or pan writing the
+// shared values directly cancels it mid-flight, which is what you want.
+const ZOOM_TIMING = { duration: 220, easing: Easing.out(Easing.cubic) };
 
 const FitWithinScreenImage = ({
   source,
@@ -274,9 +280,9 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, backgroundColor = 'black'}: 
         if (!success) return;
         const isZoomed = scale.value > 1 + 1e-5;
         if (isZoomed) {
-          scale.value = 1;
-          positionX.value = 0;
-          positionY.value = 0;
+          scale.value = withTiming(1, ZOOM_TIMING);
+          positionX.value = withTiming(0, ZOOM_TIMING);
+          positionY.value = withTiming(0, ZOOM_TIMING);
         } else {
           const offsetX = imageWidth.value / 2 - e.x;
           const offsetY = imageHeight.value / 2 - e.y;
@@ -289,9 +295,9 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, backgroundColor = 'black'}: 
             offsetX,
             offsetY,
           );
-          scale.value = 2;
-          positionX.value = newPos.x;
-          positionY.value = newPos.y;
+          scale.value = withTiming(2, ZOOM_TIMING);
+          positionX.value = withTiming(newPos.x, ZOOM_TIMING);
+          positionY.value = withTiming(newPos.y, ZOOM_TIMING);
         }
       }),
     [],

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -62,18 +62,30 @@ const FitWithinScreenImage = ({
   source,
   animatedStyle,
   onUpdateImageSize,
+  naturalSize,
 }: {
   source: { uri: string };
   animatedStyle: AnimatedStyle<ImageStyle>;
   onUpdateImageSize: (size: { imageWidth: number, imageHeight: number }) => void;
+  naturalSize?: { width: number, height: number };
 }) => {
   const isFetchingSize = useRef(false);
-  const [imageSize, setImageSize] = useState({width: 0, height: 0});
+  const [imageSize, setImageSize] = useState(
+    naturalSize ?? {width: 0, height: 0},
+  );
   const [imageWidth, setImageWidth] = useState<number | null>(null);
   const [imageHeight, setImageHeight] = useState<number | null>(null);
   const { width: viewportWidth, height: viewportHeight } = useWindowDimensions();
 
   useEffect(() => {
+    // Callers that already know the photo's dimensions (the API reports them)
+    // save the round trip, and with it the spinner that would otherwise appear
+    // for a frame in place of an image the caller has already drawn.
+    if (naturalSize) {
+      setImageSize(naturalSize);
+      return;
+    }
+
     if (isFetchingSize.current) {
       return;
     }
@@ -83,7 +95,7 @@ const FitWithinScreenImage = ({
       setImageSize({width, height});
       isFetchingSize.current = false;
     });
-  }, [source.uri]);
+  }, [source.uri, naturalSize?.width, naturalSize?.height]);
 
   useEffect(() => {
     let newWidth = imageSize.width;
@@ -123,7 +135,11 @@ const FitWithinScreenImage = ({
   return <LogoActivityIndicator size="large" color="white"/>;
 };
 
-const Pinchy = ({uuid}: {uuid: string}) => {
+const Pinchy = ({uuid, naturalSize, backgroundColor = 'black'}: {
+  uuid: string,
+  naturalSize?: { width: number, height: number },
+  backgroundColor?: string,
+}) => {
   const { width: viewportWidth, height: viewportHeight } = useWindowDimensions();
 
   const scale = useSharedValue(1);
@@ -274,11 +290,12 @@ const Pinchy = ({uuid}: {uuid: string}) => {
 
   return (
     <GestureDetector gesture={composed}>
-      <View style={styles.container}>
+      <View style={[styles.container, { backgroundColor }]}>
         <FitWithinScreenImage
           source={{ uri: `${IMAGES_URL}/original-${uuid}.jpg` }}
           animatedStyle={animatedStyle}
           onUpdateImageSize={onUpdateImageSize}
+          naturalSize={naturalSize}
         />
       </View>
     </GestureDetector>
@@ -291,7 +308,6 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: 'black',
     overflow: 'hidden',
     zIndex: 999,
     // @ts-ignore

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -23,6 +23,7 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';
+import type { SharedValue } from 'react-native-reanimated';
 import { IMAGES_URL } from '../env/env';
 
 const constrainPosition = (
@@ -137,12 +138,22 @@ const FitWithinScreenImage = ({
   return <LogoActivityIndicator size="large" color="white"/>;
 };
 
-const Pinchy = ({uuid, naturalSize, viewport, backgroundColor = 'black'}: {
+// Where the user has pinched and panned the photo to. Owned by the caller
+// rather than in here, because closing the gallery has to animate the photo out
+// from wherever the zoom left it - starting from anywhere else is the jump.
+type PinchyZoom = {
+  scale: SharedValue<number>
+  translateX: SharedValue<number>
+  translateY: SharedValue<number>
+};
+
+const Pinchy = ({uuid, naturalSize, viewport, zoom, backgroundColor = 'black'}: {
   uuid: string,
   naturalSize?: { width: number, height: number },
   // The box to fit the photo within and centre it in. Defaults to the window,
   // which is only the same thing when this fills the screen.
   viewport?: { width: number, height: number },
+  zoom: PinchyZoom,
   backgroundColor?: string,
 }) => {
   const window = useWindowDimensions();
@@ -152,9 +163,11 @@ const Pinchy = ({uuid, naturalSize, viewport, backgroundColor = 'black'}: {
     height: viewportHeight,
   } = viewport ?? window;
 
-  const scale = useSharedValue(1);
-  const positionX = useSharedValue(0);
-  const positionY = useSharedValue(0);
+  const {
+    scale,
+    translateX: positionX,
+    translateY: positionY,
+  } = zoom;
 
   const pinchBaseScale = useSharedValue(1);
   const panBaseX = useSharedValue(0);
@@ -328,4 +341,8 @@ const styles = StyleSheet.create({
 
 export {
   Pinchy
+};
+
+export type {
+  PinchyZoom,
 };

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -294,13 +294,11 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, on
       .manualActivation(true)
       .onTouchesMove((e, stateManager) => {
         'worklet';
-        // Activate the moment a second finger is down - i.e. a pinch - even
-        // before it has grown the scale past 1, so pan tracks the touch from
-        // the start of the gesture. React Native Gesture Handler then smooths
-        // out the discontinuity when a finger lifts; a pan that only activates
-        // partway through (once the pinch crosses scale 1) starts tracking the
-        // centroid mid-gesture, and the lift jumps the image instead. A single
-        // finger pans once zoomed, or drags to dismiss/page when zoomed out.
+        // Activate the moment a second finger is down - even before the pinch
+        // grows the scale past 1 - so pan tracks the touch from the start of
+        // the gesture; activating mid-gesture makes the finger lift jump the
+        // image. A single finger pans once zoomed, or drags to dismiss/page
+        // when zoomed out.
         if (
           e.numberOfTouches > 1 ||
           scale.value > 1 + 1e-5 ||

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -38,8 +38,30 @@ const ZOOM_TIMING = { duration: 220, easing: Easing.out(Easing.cubic) };
 // dismisses the gallery; a shorter drag returns the photo to centre.
 const DISMISS_THRESHOLD = 55;
 
+// Sideways drag this far (screen px) before lifting pages to the neighbour.
+const NAV_THRESHOLD = 55;
+
 // A drag that doesn't dismiss returns in one motion, no spring wobble.
 const DISMISS_RETURN = { duration: 200, easing: Easing.out(Easing.cubic) };
+
+// Shrink an image to fit the viewport, never enlarging it past native size.
+const fitWithin = (
+  size: { width: number, height: number },
+  viewportWidth: number,
+  viewportHeight: number,
+): { width: number, height: number } => {
+  let width = size.width;
+  let height = size.height;
+  if (width > viewportWidth) {
+    width = viewportWidth;
+    height = (viewportWidth / size.width) * size.height;
+  }
+  if (height > viewportHeight) {
+    height = viewportHeight;
+    width = (viewportHeight / size.height) * size.width;
+  }
+  return { width, height };
+};
 
 const FitWithinScreenImage = ({
   source,
@@ -58,9 +80,16 @@ const FitWithinScreenImage = ({
   const [imageSize, setImageSize] = useState(
     naturalSize ?? {width: 0, height: 0},
   );
-  const [imageWidth, setImageWidth] = useState<number | null>(null);
-  const [imageHeight, setImageHeight] = useState<number | null>(null);
   const { width: viewportWidth, height: viewportHeight } = viewport;
+
+  // Fit synchronously from the known size, so a photo the caller reports the
+  // dimensions of paints on its first frame - no spinner flash when a new page
+  // mounts.
+  const initialFit = naturalSize && naturalSize.width && naturalSize.height
+    ? fitWithin(naturalSize, viewportWidth, viewportHeight)
+    : null;
+  const [imageWidth, setImageWidth] = useState<number | null>(initialFit?.width ?? null);
+  const [imageHeight, setImageHeight] = useState<number | null>(initialFit?.height ?? null);
 
   useEffect(() => {
     // Callers that already know the photo's dimensions (the API reports them)
@@ -83,18 +112,10 @@ const FitWithinScreenImage = ({
   }, [source.uri, naturalSize?.width, naturalSize?.height]);
 
   useEffect(() => {
-    let newWidth = imageSize.width;
-    let newHeight = imageSize.height;
+    if (!imageSize.width || !imageSize.height) return;
 
-    if (imageSize.width > viewportWidth) {
-      newWidth = viewportWidth;
-      newHeight = (viewportWidth / imageSize.width) * imageSize.height;
-    }
-
-    if (newHeight > viewportHeight) {
-      newHeight = viewportHeight;
-      newWidth = (viewportHeight / imageSize.height) * imageSize.width;
-    }
+    const { width: newWidth, height: newHeight } =
+      fitWithin(imageSize, viewportWidth, viewportHeight);
 
     setImageWidth(newWidth);
     setImageHeight(newHeight);
@@ -137,7 +158,17 @@ type PinchyDismiss = {
   y: SharedValue<number>
 };
 
-const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, backgroundColor = 'black'}: {
+// The horizontal pager this photo sits in. A sideways drag on the zoomed-out
+// photo drives `scrollX` (settled at `homeX`); crossing the threshold fires
+// `onNavigate`, which the caller uses to slide to the neighbour.
+type PinchyPage = {
+  scrollX: SharedValue<number>
+  homeX: number
+  width: number
+  count: number
+};
+
+const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, onNavigate, backgroundColor = 'black'}: {
   uuid: string,
   naturalSize?: { width: number, height: number },
   // The box to fit the photo within and centre it in. Defaults to the window,
@@ -148,6 +179,9 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, backgrou
   // this offset, and `onDismiss` fires if it's dragged past the threshold.
   dismiss?: PinchyDismiss,
   onDismiss?: () => void,
+  // When provided, a sideways drag pages between photos instead of dismissing.
+  page?: PinchyPage,
+  onNavigate?: (dir: number) => void,
   backgroundColor?: string,
 }) => {
   const window = useWindowDimensions();
@@ -167,11 +201,13 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, backgrou
   const panBaseX = useSharedValue(0);
   const panBaseY = useSharedValue(0);
 
-  // A single-finger drag on the zoomed-out photo is a drag-to-dismiss rather
-  // than a pan; this records that, and where the drag started from.
-  const isDismissing = useSharedValue(false);
+  // A single-finger drag on the zoomed-out photo either dismisses (vertical) or
+  // pages (horizontal). `dragMode` is locked once the drag picks a direction:
+  // 'pan' zoomed in, else 'none' until it commits to 'dismiss' or 'page'.
+  const dragMode = useSharedValue<'none' | 'pan' | 'dismiss' | 'page'>('none');
   const dismissBaseX = useSharedValue(0);
   const dismissBaseY = useSharedValue(0);
+  const pageBaseX = useSharedValue(0);
 
   // The scale, position and finger focal point captured when a pinch begins, so
   // each update can keep the point that was under the fingers under them still.
@@ -202,7 +238,7 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, backgrou
       positionX.value = newPos.x;
       positionY.value = newPos.y;
     })(viewportWidth, viewportHeight);
-  }, [viewportWidth, viewportHeight]);
+  }, [viewportWidth, viewportHeight, scale, positionX, positionY]);
 
   const onUpdateImageSize = useCallback(
     ({ imageWidth: w, imageHeight: h }: { imageWidth: number, imageHeight: number }) => {
@@ -250,7 +286,7 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, backgrou
         positionX.value = newPos.x;
         positionY.value = newPos.y;
       }),
-    [],
+    [scale, positionX, positionY],
   );
 
   const pan = useMemo(
@@ -264,11 +300,12 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, backgrou
         // out the discontinuity when a finger lifts; a pan that only activates
         // partway through (once the pinch crosses scale 1) starts tracking the
         // centroid mid-gesture, and the lift jumps the image instead. A single
-        // finger pans once zoomed, or drags to dismiss when zoomed out.
+        // finger pans once zoomed, or drags to dismiss/page when zoomed out.
         if (
           e.numberOfTouches > 1 ||
           scale.value > 1 + 1e-5 ||
-          dismiss !== undefined
+          dismiss !== undefined ||
+          page !== undefined
         ) {
           stateManager.activate();
         } else {
@@ -277,62 +314,82 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, backgrou
       })
       .onStart((e) => {
         'worklet';
-        // A single finger on the zoomed-out photo drags to dismiss; anything
-        // else (a pinch, or a drag while zoomed in) pans.
-        isDismissing.value =
-          dismiss !== undefined &&
-          e.numberOfPointers <= 1 &&
-          scale.value <= 1 + 1e-5;
+        // Zoomed in, or a pinch: pan the image. Zoomed out with a single
+        // finger: wait for the drag to reveal its direction (dismiss/page).
+        const panning = scale.value > 1 + 1e-5 || e.numberOfPointers > 1;
+        dragMode.value = panning ? 'pan' : 'none';
 
-        if (isDismissing.value && dismiss) {
-          dismissBaseX.value = dismiss.x.value;
-          dismissBaseY.value = dismiss.y.value;
-        } else {
-          panBaseX.value = positionX.value;
-          panBaseY.value = positionY.value;
-        }
+        panBaseX.value = positionX.value;
+        panBaseY.value = positionY.value;
+        dismissBaseX.value = dismiss?.x.value ?? 0;
+        dismissBaseY.value = dismiss?.y.value ?? 0;
+        pageBaseX.value = page?.scrollX.value ?? 0;
       })
       .onUpdate((e) => {
         'worklet';
-        if (isDismissing.value && dismiss) {
+        if (dragMode.value === 'pan') {
+          const newPos = constrainPosition(
+            scale.value,
+            imageWidth.value,
+            imageHeight.value,
+            viewportWidthSv.value,
+            viewportHeightSv.value,
+            panBaseX.value,
+            panBaseY.value,
+            e.translationX,
+            e.translationY,
+          );
+          positionX.value = newPos.x;
+          positionY.value = newPos.y;
+          return;
+        }
+
+        // Lock to whichever axis the drag commits to first: sideways pages,
+        // up/down dismisses. Only the modes the caller enabled are available.
+        if (dragMode.value === 'none') {
+          const moved = Math.max(Math.abs(e.translationX), Math.abs(e.translationY));
+          if (moved > 8) {
+            const horizontal = Math.abs(e.translationX) >= Math.abs(e.translationY);
+            if (horizontal && page) dragMode.value = 'page';
+            else if (!horizontal && dismiss) dragMode.value = 'dismiss';
+            else if (page) dragMode.value = 'page';
+            else if (dismiss) dragMode.value = 'dismiss';
+          }
+        }
+
+        if (dragMode.value === 'page' && page) {
+          const max = (page.count - 1) * page.width;
+          page.scrollX.value = Math.min(max, Math.max(0, pageBaseX.value - e.translationX));
+        } else if (dragMode.value === 'dismiss' && dismiss) {
           dismiss.x.value = dismissBaseX.value + e.translationX;
           dismiss.y.value = dismissBaseY.value + e.translationY;
-          return;
         }
-
-        const newPos = constrainPosition(
-          scale.value,
-          imageWidth.value,
-          imageHeight.value,
-          viewportWidthSv.value,
-          viewportHeightSv.value,
-          panBaseX.value,
-          panBaseY.value,
-          e.translationX,
-          e.translationY,
-        );
-        positionX.value = newPos.x;
-        positionY.value = newPos.y;
       })
-      .onEnd(() => {
+      .onEnd((e) => {
         'worklet';
-        if (!isDismissing.value || !dismiss) {
-          return;
-        }
+        if (dragMode.value === 'page' && page) {
+          const atIndex = Math.round(page.homeX / page.width);
+          let dir = 0;
+          if (e.translationX <= -NAV_THRESHOLD && atIndex < page.count - 1) dir = 1;
+          else if (e.translationX >= NAV_THRESHOLD && atIndex > 0) dir = -1;
 
-        const dragged = Math.sqrt(
-          dismiss.x.value ** 2 + dismiss.y.value ** 2,
-        );
-
-        if (dragged > DISMISS_THRESHOLD && onDismiss) {
-          runOnJS(onDismiss)();
-        } else {
-          // Didn't drag far enough - ease back to centre in one motion.
-          dismiss.x.value = withTiming(0, DISMISS_RETURN);
-          dismiss.y.value = withTiming(0, DISMISS_RETURN);
+          if (dir !== 0 && onNavigate) {
+            runOnJS(onNavigate)(dir);
+          } else {
+            // Not far enough (or at an end): slide back in one motion.
+            page.scrollX.value = withTiming(page.homeX, DISMISS_RETURN);
+          }
+        } else if (dragMode.value === 'dismiss' && dismiss) {
+          const dragged = Math.sqrt(dismiss.x.value ** 2 + dismiss.y.value ** 2);
+          if (dragged > DISMISS_THRESHOLD && onDismiss) {
+            runOnJS(onDismiss)();
+          } else {
+            dismiss.x.value = withTiming(0, DISMISS_RETURN);
+            dismiss.y.value = withTiming(0, DISMISS_RETURN);
+          }
         }
       }),
-    [dismiss, onDismiss],
+    [dismiss, onDismiss, page, onNavigate, scale, positionX, positionY],
   );
 
   const doubleTap = useMemo(
@@ -365,7 +422,7 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, backgrou
           positionY.value = withTiming(newPos.y, ZOOM_TIMING);
         }
       }),
-    [],
+    [scale, positionX, positionY],
   );
 
   const composed = useMemo(
@@ -427,5 +484,6 @@ export {
 
 export type {
   PinchyDismiss,
+  PinchyPage,
   PinchyZoom,
 };

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -25,39 +25,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
 import { IMAGES_URL } from '../env/env';
-
-const constrainPosition = (
-  currentScale: number,
-  imageWidth: number,
-  imageHeight: number,
-  viewportWidth: number,
-  viewportHeight: number,
-  x: number,
-  y: number,
-  dx: number = 0,
-  dy: number = 0,
-) => {
-  'worklet';
-  const adjustedWidth = imageWidth * currentScale;
-  const adjustedHeight = imageHeight * currentScale;
-
-  const maxTranslateX = (adjustedWidth > viewportWidth) ?
-    (adjustedWidth - viewportWidth) / 2 / currentScale :
-    (viewportWidth - adjustedWidth) / 2 / currentScale;
-
-  const maxTranslateY = (adjustedHeight > viewportHeight) ?
-    (adjustedHeight - viewportHeight) / 2 / currentScale :
-    (viewportHeight - adjustedHeight) / 2 / currentScale;
-
-  return {
-    x: (adjustedWidth > viewportWidth) ?
-       Math.min(maxTranslateX, Math.max(-maxTranslateX, x + dx / currentScale)) :
-       0,
-    y: (adjustedHeight > viewportHeight) ?
-       Math.min(maxTranslateY, Math.max(-maxTranslateY, y + dy / currentScale)) :
-       0,
-  };
-};
+import { constrainPosition, focalZoomPosition } from './pinchy-math';
 
 const FitWithinScreenImage = ({
   source,
@@ -173,6 +141,13 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, backgroundColor = 'black'}: 
   const panBaseX = useSharedValue(0);
   const panBaseY = useSharedValue(0);
 
+  // The scale, position and finger focal point captured when a pinch begins, so
+  // each update can keep the point that was under the fingers under them still.
+  const pinchBaseX = useSharedValue(0);
+  const pinchBaseY = useSharedValue(0);
+  const focalBaseX = useSharedValue(0);
+  const focalBaseY = useSharedValue(0);
+
   const imageWidth = useSharedValue(0);
   const imageHeight = useSharedValue(0);
   const viewportWidthSv = useSharedValue(viewportWidth);
@@ -207,21 +182,37 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, backgroundColor = 'black'}: 
 
   const pinch = useMemo(
     () => Gesture.Pinch()
-      .onStart(() => {
+      .onStart((e) => {
         'worklet';
         pinchBaseScale.value = scale.value;
+        pinchBaseX.value = positionX.value;
+        pinchBaseY.value = positionY.value;
+        focalBaseX.value = e.focalX;
+        focalBaseY.value = e.focalY;
       })
       .onUpdate((e) => {
         'worklet';
         const newScale = Math.max(1, e.scale * pinchBaseScale.value);
+
+        // Zoom towards the fingers rather than the middle of the photo.
+        const target = focalZoomPosition(
+          pinchBaseScale.value,
+          newScale,
+          { x: pinchBaseX.value, y: pinchBaseY.value },
+          { x: focalBaseX.value, y: focalBaseY.value },
+          { x: e.focalX, y: e.focalY },
+          viewportWidthSv.value,
+          viewportHeightSv.value,
+        );
+
         const newPos = constrainPosition(
           newScale,
           imageWidth.value,
           imageHeight.value,
           viewportWidthSv.value,
           viewportHeightSv.value,
-          positionX.value,
-          positionY.value,
+          target.x,
+          target.y,
         );
         scale.value = newScale;
         positionX.value = newPos.x;
@@ -340,7 +331,7 @@ const styles = StyleSheet.create({
 });
 
 export {
-  Pinchy
+  Pinchy,
 };
 
 export type {

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -63,11 +63,13 @@ const FitWithinScreenImage = ({
   animatedStyle,
   onUpdateImageSize,
   naturalSize,
+  viewport,
 }: {
   source: { uri: string };
   animatedStyle: AnimatedStyle<ImageStyle>;
   onUpdateImageSize: (size: { imageWidth: number, imageHeight: number }) => void;
   naturalSize?: { width: number, height: number };
+  viewport: { width: number, height: number };
 }) => {
   const isFetchingSize = useRef(false);
   const [imageSize, setImageSize] = useState(
@@ -75,7 +77,7 @@ const FitWithinScreenImage = ({
   );
   const [imageWidth, setImageWidth] = useState<number | null>(null);
   const [imageHeight, setImageHeight] = useState<number | null>(null);
-  const { width: viewportWidth, height: viewportHeight } = useWindowDimensions();
+  const { width: viewportWidth, height: viewportHeight } = viewport;
 
   useEffect(() => {
     // Callers that already know the photo's dimensions (the API reports them)
@@ -135,12 +137,20 @@ const FitWithinScreenImage = ({
   return <LogoActivityIndicator size="large" color="white"/>;
 };
 
-const Pinchy = ({uuid, naturalSize, backgroundColor = 'black'}: {
+const Pinchy = ({uuid, naturalSize, viewport, backgroundColor = 'black'}: {
   uuid: string,
   naturalSize?: { width: number, height: number },
+  // The box to fit the photo within and centre it in. Defaults to the window,
+  // which is only the same thing when this fills the screen.
+  viewport?: { width: number, height: number },
   backgroundColor?: string,
 }) => {
-  const { width: viewportWidth, height: viewportHeight } = useWindowDimensions();
+  const window = useWindowDimensions();
+
+  const {
+    width: viewportWidth,
+    height: viewportHeight,
+  } = viewport ?? window;
 
   const scale = useSharedValue(1);
   const positionX = useSharedValue(0);
@@ -296,6 +306,7 @@ const Pinchy = ({uuid, naturalSize, backgroundColor = 'black'}: {
           animatedStyle={animatedStyle}
           onUpdateImageSize={onUpdateImageSize}
           naturalSize={naturalSize}
+          viewport={{ width: viewportWidth, height: viewportHeight }}
         />
       </View>
     </GestureDetector>

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -224,11 +224,19 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, backgroundColor = 'black'}: 
   const pan = useMemo(
     () => Gesture.Pan()
       .manualActivation(true)
-      .onTouchesMove((_e, stateManager) => {
+      .onTouchesMove((e, stateManager) => {
         'worklet';
-        if (scale.value > 1 + 1e-5) {
+        // Activate the moment a second finger is down - i.e. a pinch - even
+        // before it has grown the scale past 1, so pan tracks the touch from
+        // the start of the gesture. React Native Gesture Handler then smooths
+        // out the discontinuity when a finger lifts; a pan that only activates
+        // partway through (once the pinch crosses scale 1) starts tracking the
+        // centroid mid-gesture, and the lift jumps the image instead. Also
+        // activate for a single finger once zoomed, so you can pan around.
+        if (e.numberOfTouches > 1 || scale.value > 1 + 1e-5) {
           stateManager.activate();
         } else {
+          // A single finger on an unzoomed image isn't a pan; let it through.
           stateManager.fail();
         }
       })

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -10,7 +10,6 @@ import {
   ImageStyle,
   StyleSheet,
   View,
-  useWindowDimensions,
 } from 'react-native';
 import { LogoActivityIndicator } from './logo/logo-activity-indicator';
 import {
@@ -28,7 +27,7 @@ import Animated, {
 } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
 import { IMAGES_URL } from '../env/env';
-import { constrainPosition, dragDismissRadius, focalZoomPosition } from './pinchy-math';
+import { constrainPosition, dragDismissRadius, dragDistance, focalZoomPosition } from './pinchy-math';
 
 // Double-tap zoom eases in rather than snapping. A pinch or pan writing the
 // shared values directly cancels it mid-flight, which is what you want.
@@ -171,9 +170,8 @@ type PinchyPage = {
 const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, onNavigate, backgroundColor = 'black'}: {
   uuid: string,
   naturalSize?: { width: number, height: number },
-  // The box to fit the photo within and centre it in. Defaults to the window,
-  // which is only the same thing when this fills the screen.
-  viewport?: { width: number, height: number },
+  // The box to fit the photo within and centre it in.
+  viewport: { width: number, height: number },
   zoom: PinchyZoom,
   // When provided, a single-finger drag on the zoomed-out photo moves it by
   // this offset, and `onDismiss` fires if it's dragged past the threshold.
@@ -184,12 +182,10 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, on
   onNavigate?: (dir: number) => void,
   backgroundColor?: string,
 }) => {
-  const window = useWindowDimensions();
-
   const {
     width: viewportWidth,
     height: viewportHeight,
-  } = viewport ?? window;
+  } = viewport;
 
   const {
     scale,
@@ -378,7 +374,7 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, page, on
             page.scrollX.value = withTiming(page.homeX, DISMISS_RETURN);
           }
         } else if (dragMode.value === 'dismiss' && dismiss) {
-          const dragged = Math.sqrt(dismiss.x.value ** 2 + dismiss.y.value ** 2);
+          const dragged = dragDistance(dismiss.x.value, dismiss.y.value);
           if (dragged > DISMISS_THRESHOLD && onDismiss) {
             runOnJS(onDismiss)();
           } else {

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -24,22 +24,22 @@ import Animated, {
   runOnUI,
   useAnimatedStyle,
   useSharedValue,
-  withSpring,
   withTiming,
 } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
 import { IMAGES_URL } from '../env/env';
-import { constrainPosition, focalZoomPosition } from './pinchy-math';
+import { constrainPosition, dragDismissRadius, focalZoomPosition } from './pinchy-math';
 
 // Double-tap zoom eases in rather than snapping. A pinch or pan writing the
 // shared values directly cancels it mid-flight, which is what you want.
 const ZOOM_TIMING = { duration: 220, easing: Easing.out(Easing.cubic) };
 
 // Dragging the zoomed-out photo at least this far (screen px) before lifting
-// dismisses the gallery; a shorter drag springs the photo back to centre.
-const DISMISS_THRESHOLD = 110;
+// dismisses the gallery; a shorter drag returns the photo to centre.
+const DISMISS_THRESHOLD = 55;
 
-const DISMISS_SPRING = { damping: 22, stiffness: 220 };
+// A drag that doesn't dismiss returns in one motion, no spring wobble.
+const DISMISS_RETURN = { duration: 200, easing: Easing.out(Easing.cubic) };
 
 const FitWithinScreenImage = ({
   source,
@@ -327,9 +327,9 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, backgrou
         if (dragged > DISMISS_THRESHOLD && onDismiss) {
           runOnJS(onDismiss)();
         } else {
-          // Didn't drag far enough - spring back to centre.
-          dismiss.x.value = withSpring(0, DISMISS_SPRING);
-          dismiss.y.value = withSpring(0, DISMISS_SPRING);
+          // Didn't drag far enough - ease back to centre in one motion.
+          dismiss.x.value = withTiming(0, DISMISS_RETURN);
+          dismiss.y.value = withTiming(0, DISMISS_RETURN);
         }
       }),
     [dismiss, onDismiss],
@@ -373,17 +373,25 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, backgrou
     [pinch, pan, doubleTap],
   );
 
-  const animatedStyle = useAnimatedStyle<ImageStyle>(() => ({
-    // The dismiss drag translates the whole photo in screen space, so it goes
-    // outermost (ahead of the zoom scale, which it must not be multiplied by).
-    transform: [
-      { translateX: dismiss ? dismiss.x.value : 0 },
-      { translateY: dismiss ? dismiss.y.value : 0 },
-      { scale: scale.value },
-      { translateX: positionX.value },
-      { translateY: positionY.value },
-    ],
-  }));
+  const animatedStyle = useAnimatedStyle<ImageStyle>(() => {
+    const dismissX = dismiss ? dismiss.x.value : 0;
+    const dismissY = dismiss ? dismiss.y.value : 0;
+
+    return {
+      // Round the corners as the photo is dragged away, so it never lifts off
+      // the screen looking square.
+      borderRadius: dragDismissRadius(dismissX, dismissY),
+      // The dismiss drag translates the whole photo in screen space, so it goes
+      // outermost (ahead of the zoom scale, which it must not be multiplied by).
+      transform: [
+        { translateX: dismissX },
+        { translateY: dismissY },
+        { scale: scale.value },
+        { translateX: positionX.value },
+        { translateY: positionY.value },
+      ],
+    };
+  });
 
   return (
     <GestureDetector gesture={composed}>

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -20,9 +20,11 @@ import {
 import Animated, {
   AnimatedStyle,
   Easing,
+  runOnJS,
   runOnUI,
   useAnimatedStyle,
   useSharedValue,
+  withSpring,
   withTiming,
 } from 'react-native-reanimated';
 import type { SharedValue } from 'react-native-reanimated';
@@ -32,6 +34,12 @@ import { constrainPosition, focalZoomPosition } from './pinchy-math';
 // Double-tap zoom eases in rather than snapping. A pinch or pan writing the
 // shared values directly cancels it mid-flight, which is what you want.
 const ZOOM_TIMING = { duration: 220, easing: Easing.out(Easing.cubic) };
+
+// Dragging the zoomed-out photo at least this far (screen px) before lifting
+// dismisses the gallery; a shorter drag springs the photo back to centre.
+const DISMISS_THRESHOLD = 110;
+
+const DISMISS_SPRING = { damping: 22, stiffness: 220 };
 
 const FitWithinScreenImage = ({
   source,
@@ -121,13 +129,25 @@ type PinchyZoom = {
   translateY: SharedValue<number>
 };
 
-const Pinchy = ({uuid, naturalSize, viewport, zoom, backgroundColor = 'black'}: {
+// The screen-space offset of a drag-to-dismiss in progress. Owned by the caller
+// so it can carry the same offset into the closing animation - and fade its
+// backdrop by how far the photo has been dragged.
+type PinchyDismiss = {
+  x: SharedValue<number>
+  y: SharedValue<number>
+};
+
+const Pinchy = ({uuid, naturalSize, viewport, zoom, dismiss, onDismiss, backgroundColor = 'black'}: {
   uuid: string,
   naturalSize?: { width: number, height: number },
   // The box to fit the photo within and centre it in. Defaults to the window,
   // which is only the same thing when this fills the screen.
   viewport?: { width: number, height: number },
   zoom: PinchyZoom,
+  // When provided, a single-finger drag on the zoomed-out photo moves it by
+  // this offset, and `onDismiss` fires if it's dragged past the threshold.
+  dismiss?: PinchyDismiss,
+  onDismiss?: () => void,
   backgroundColor?: string,
 }) => {
   const window = useWindowDimensions();
@@ -146,6 +166,12 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, backgroundColor = 'black'}: 
   const pinchBaseScale = useSharedValue(1);
   const panBaseX = useSharedValue(0);
   const panBaseY = useSharedValue(0);
+
+  // A single-finger drag on the zoomed-out photo is a drag-to-dismiss rather
+  // than a pan; this records that, and where the drag started from.
+  const isDismissing = useSharedValue(false);
+  const dismissBaseX = useSharedValue(0);
+  const dismissBaseY = useSharedValue(0);
 
   // The scale, position and finger focal point captured when a pinch begins, so
   // each update can keep the point that was under the fingers under them still.
@@ -237,22 +263,43 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, backgroundColor = 'black'}: 
         // the start of the gesture. React Native Gesture Handler then smooths
         // out the discontinuity when a finger lifts; a pan that only activates
         // partway through (once the pinch crosses scale 1) starts tracking the
-        // centroid mid-gesture, and the lift jumps the image instead. Also
-        // activate for a single finger once zoomed, so you can pan around.
-        if (e.numberOfTouches > 1 || scale.value > 1 + 1e-5) {
+        // centroid mid-gesture, and the lift jumps the image instead. A single
+        // finger pans once zoomed, or drags to dismiss when zoomed out.
+        if (
+          e.numberOfTouches > 1 ||
+          scale.value > 1 + 1e-5 ||
+          dismiss !== undefined
+        ) {
           stateManager.activate();
         } else {
-          // A single finger on an unzoomed image isn't a pan; let it through.
           stateManager.fail();
         }
       })
-      .onStart(() => {
+      .onStart((e) => {
         'worklet';
-        panBaseX.value = positionX.value;
-        panBaseY.value = positionY.value;
+        // A single finger on the zoomed-out photo drags to dismiss; anything
+        // else (a pinch, or a drag while zoomed in) pans.
+        isDismissing.value =
+          dismiss !== undefined &&
+          e.numberOfPointers <= 1 &&
+          scale.value <= 1 + 1e-5;
+
+        if (isDismissing.value && dismiss) {
+          dismissBaseX.value = dismiss.x.value;
+          dismissBaseY.value = dismiss.y.value;
+        } else {
+          panBaseX.value = positionX.value;
+          panBaseY.value = positionY.value;
+        }
       })
       .onUpdate((e) => {
         'worklet';
+        if (isDismissing.value && dismiss) {
+          dismiss.x.value = dismissBaseX.value + e.translationX;
+          dismiss.y.value = dismissBaseY.value + e.translationY;
+          return;
+        }
+
         const newPos = constrainPosition(
           scale.value,
           imageWidth.value,
@@ -266,8 +313,26 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, backgroundColor = 'black'}: 
         );
         positionX.value = newPos.x;
         positionY.value = newPos.y;
+      })
+      .onEnd(() => {
+        'worklet';
+        if (!isDismissing.value || !dismiss) {
+          return;
+        }
+
+        const dragged = Math.sqrt(
+          dismiss.x.value ** 2 + dismiss.y.value ** 2,
+        );
+
+        if (dragged > DISMISS_THRESHOLD && onDismiss) {
+          runOnJS(onDismiss)();
+        } else {
+          // Didn't drag far enough - spring back to centre.
+          dismiss.x.value = withSpring(0, DISMISS_SPRING);
+          dismiss.y.value = withSpring(0, DISMISS_SPRING);
+        }
       }),
-    [],
+    [dismiss, onDismiss],
   );
 
   const doubleTap = useMemo(
@@ -309,7 +374,11 @@ const Pinchy = ({uuid, naturalSize, viewport, zoom, backgroundColor = 'black'}: 
   );
 
   const animatedStyle = useAnimatedStyle<ImageStyle>(() => ({
+    // The dismiss drag translates the whole photo in screen space, so it goes
+    // outermost (ahead of the zoom scale, which it must not be multiplied by).
     transform: [
+      { translateX: dismiss ? dismiss.x.value : 0 },
+      { translateY: dismiss ? dismiss.y.value : 0 },
       { scale: scale.value },
       { translateX: positionX.value },
       { translateY: positionY.value },
@@ -349,5 +418,6 @@ export {
 };
 
 export type {
+  PinchyDismiss,
   PinchyZoom,
 };

--- a/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
+++ b/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
@@ -1129,6 +1129,11 @@ const CurriedContent = ({navigationRef, navigation, route}: ProspectScreenProps 
                   album={album}
                   isPrimary={true}
                   isVerified={imageVerification0}
+                  borderRadius={
+                    width > 600 ?
+                    { bottomLeft: 12, bottomRight: 12 } :
+                    undefined
+                  }
                   style={
                     width > 600 ?
                     commonStyles.primaryEnlargeablePhotoBigScreen :
@@ -1384,37 +1389,24 @@ const Body = ({
   const [signedInUser] = useSignedInUser();
   const isOnline = useOnline(personUuid);
 
-  const photoUuid1 = data?.photo_uuids && data?.photo_uuids[1];
-  const photoUuid2 = data?.photo_uuids && data?.photo_uuids[2];
-  const photoUuid3 = data?.photo_uuids && data?.photo_uuids[3];
-  const photoUuid4 = data?.photo_uuids && data?.photo_uuids[4];
-  const photoUuid5 = data?.photo_uuids && data?.photo_uuids[5];
-  const photoUuid6 = data?.photo_uuids && data?.photo_uuids[6];
-
-  const photoExtraExts1 = data?.photo_extra_exts && data?.photo_extra_exts[1];
-  const photoExtraExts2 = data?.photo_extra_exts && data?.photo_extra_exts[2];
-  const photoExtraExts3 = data?.photo_extra_exts && data?.photo_extra_exts[3];
-  const photoExtraExts4 = data?.photo_extra_exts && data?.photo_extra_exts[4];
-  const photoExtraExts5 = data?.photo_extra_exts && data?.photo_extra_exts[5];
-  const photoExtraExts6 = data?.photo_extra_exts && data?.photo_extra_exts[6];
-
-  const photoBlurhash1 = data?.photo_blurhashes && data?.photo_blurhashes[1];
-  const photoBlurhash2 = data?.photo_blurhashes && data?.photo_blurhashes[2];
-  const photoBlurhash3 = data?.photo_blurhashes && data?.photo_blurhashes[3];
-  const photoBlurhash4 = data?.photo_blurhashes && data?.photo_blurhashes[4];
-  const photoBlurhash5 = data?.photo_blurhashes && data?.photo_blurhashes[5];
-  const photoBlurhash6 = data?.photo_blurhashes && data?.photo_blurhashes[6];
-
-  const imageVerification1 = data?.photo_verifications && data?.photo_verifications[1] || false;
-  const imageVerification2 = data?.photo_verifications && data?.photo_verifications[2] || false;
-  const imageVerification3 = data?.photo_verifications && data?.photo_verifications[3] || false;
-  const imageVerification4 = data?.photo_verifications && data?.photo_verifications[4] || false;
-  const imageVerification5 = data?.photo_verifications && data?.photo_verifications[5] || false;
-  const imageVerification6 = data?.photo_verifications && data?.photo_verifications[6] || false;
-
   const album = useMemo(
     () => buildAlbum(data?.photo_uuids, data?.photo_geometries),
     [data?.photo_uuids, data?.photo_geometries],
+  );
+
+  const profilePhoto = (position: number) => (
+    <EnlargeablePhoto
+      photoUuid={data?.photo_uuids?.[position]}
+      photoExtraExts={data?.photo_extra_exts?.[position]}
+      photoBlurhash={data?.photo_blurhashes?.[position]}
+      photoGeometry={album[position]?.geometry}
+      album={album}
+      borderRadius={12}
+      style={commonStyles.secondaryEnlargeablePhoto}
+      innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
+      isPrimary={false}
+      isVerified={data?.photo_verifications?.[position] ?? false}
+    />
   );
 
   // Compare on UUID rather than the numeric `personId` we lift out of `data`,
@@ -1603,17 +1595,7 @@ const Body = ({
           </DefaultText>
         </>}
 
-        <EnlargeablePhoto
-          photoUuid={photoUuid1}
-          photoExtraExts={photoExtraExts1}
-          photoBlurhash={photoBlurhash1}
-          photoGeometry={album[1]?.geometry}
-          album={album}
-          style={commonStyles.secondaryEnlargeablePhoto}
-          innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
-          isPrimary={false}
-          isVerified={imageVerification1}
-        />
+        {profilePhoto(1)}
 
         {!data?.name &&
           <Title style={{color: data?.theme?.title_color}}>About ...</Title>
@@ -1630,29 +1612,9 @@ const Body = ({
           </>
         }
 
-        <EnlargeablePhoto
-          photoUuid={photoUuid2}
-          photoExtraExts={photoExtraExts2}
-          photoBlurhash={photoBlurhash2}
-          photoGeometry={album[2]?.geometry}
-          album={album}
-          style={commonStyles.secondaryEnlargeablePhoto}
-          innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
-          isPrimary={false}
-          isVerified={imageVerification2}
-        />
+        {profilePhoto(2)}
 
-        <EnlargeablePhoto
-          photoUuid={photoUuid3}
-          photoExtraExts={photoExtraExts3}
-          photoBlurhash={photoBlurhash3}
-          photoGeometry={album[3]?.geometry}
-          album={album}
-          style={commonStyles.secondaryEnlargeablePhoto}
-          innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
-          isPrimary={false}
-          isVerified={imageVerification3}
-        />
+        {profilePhoto(3)}
 
         <AllClubs
           mutualClubs={data?.mutual_clubs ?? []}
@@ -1662,41 +1624,11 @@ const Body = ({
           titleColor={data?.theme?.title_color}
         />
 
-        <EnlargeablePhoto
-          photoUuid={photoUuid4}
-          photoExtraExts={photoExtraExts4}
-          photoBlurhash={photoBlurhash4}
-          photoGeometry={album[4]?.geometry}
-          album={album}
-          style={commonStyles.secondaryEnlargeablePhoto}
-          innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
-          isPrimary={false}
-          isVerified={imageVerification4}
-        />
+        {profilePhoto(4)}
 
-        <EnlargeablePhoto
-          photoUuid={photoUuid5}
-          photoExtraExts={photoExtraExts5}
-          photoBlurhash={photoBlurhash5}
-          photoGeometry={album[5]?.geometry}
-          album={album}
-          style={commonStyles.secondaryEnlargeablePhoto}
-          innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
-          isPrimary={false}
-          isVerified={imageVerification5}
-        />
+        {profilePhoto(5)}
 
-        <EnlargeablePhoto
-          photoUuid={photoUuid6}
-          photoExtraExts={photoExtraExts6}
-          photoBlurhash={photoBlurhash6}
-          photoGeometry={album[6]?.geometry}
-          album={album}
-          style={commonStyles.secondaryEnlargeablePhoto}
-          innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
-          isPrimary={false}
-          isVerified={imageVerification6}
-        />
+        {profilePhoto(6)}
 
         {hasAnyStats(data) && <>
           <Title style={{color: data?.theme?.title_color}}>Stats</Title>

--- a/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
+++ b/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
@@ -83,6 +83,7 @@ import { HeartBackground } from '../heart-background';
 import { AudioPlayer } from '../audio-player';
 import { EnlargeablePhoto } from '../enlargeable-image';
 import type { PhotoGeometry } from '../../util/photos';
+import type { AlbumPhoto } from '../../events/expanded-photo';
 import { commonStyles } from '../../styles';
 import { useSkipped, setSkipped } from '../../hide-and-block/hide-and-block';
 import { OnlineIndicator } from '../online-indicator';
@@ -93,6 +94,16 @@ import { faChildren } from '@fortawesome/free-solid-svg-icons/faChildren'
 import { AboutText } from './about-reply';
 import { useQuote } from '../conversation-screen/quote';
 import { copyProfileLink } from '../../util/util';
+
+// The person's photos in order, so tapping any one lets the gallery page
+// through the rest.
+const buildAlbum = (
+  uuids: string[] | undefined,
+  geometries: (PhotoGeometry | null)[] | undefined,
+): AlbumPhoto[] =>
+  (uuids ?? [])
+    .map((uuid, i) => ({ uuid, geometry: geometries?.[i] ?? null }))
+    .filter((photo) => Boolean(photo.uuid));
 
 type ProspectNavigation = NativeStackNavigationProp<ProspectParamList>;
 type ProspectNavigationRef = MutableRefObject<ProspectNavigation | undefined>;
@@ -1002,6 +1013,11 @@ const CurriedContent = ({navigationRef, navigation, route}: ProspectScreenProps 
 
   const photoGeometries = data?.photo_geometries;
 
+  const album = useMemo(
+    () => buildAlbum(data?.photo_uuids, data?.photo_geometries),
+    [data?.photo_uuids, data?.photo_geometries],
+  );
+
   const photoUuid0 = (() => {
     if (photoUuids === undefined) {
       return undefined;
@@ -1114,6 +1130,7 @@ const CurriedContent = ({navigationRef, navigation, route}: ProspectScreenProps 
                   photoExtraExts={photoExtraExts0}
                   photoBlurhash={photoBlurhash0}
                   photoGeometry={photoGeometries?.[0]}
+                  album={album}
                   isPrimary={true}
                   isVerified={imageVerification0}
                   style={
@@ -1399,6 +1416,11 @@ const Body = ({
   const imageVerification5 = data?.photo_verifications && data?.photo_verifications[5] || false;
   const imageVerification6 = data?.photo_verifications && data?.photo_verifications[6] || false;
 
+  const album = useMemo(
+    () => buildAlbum(data?.photo_uuids, data?.photo_geometries),
+    [data?.photo_uuids, data?.photo_geometries],
+  );
+
   const photoGeometry1 = data?.photo_geometries && data?.photo_geometries[1];
   const photoGeometry2 = data?.photo_geometries && data?.photo_geometries[2];
   const photoGeometry3 = data?.photo_geometries && data?.photo_geometries[3];
@@ -1597,6 +1619,7 @@ const Body = ({
           photoExtraExts={photoExtraExts1}
           photoBlurhash={photoBlurhash1}
           photoGeometry={photoGeometry1}
+          album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}
@@ -1623,6 +1646,7 @@ const Body = ({
           photoExtraExts={photoExtraExts2}
           photoBlurhash={photoBlurhash2}
           photoGeometry={photoGeometry2}
+          album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}
@@ -1634,6 +1658,7 @@ const Body = ({
           photoExtraExts={photoExtraExts3}
           photoBlurhash={photoBlurhash3}
           photoGeometry={photoGeometry3}
+          album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}
@@ -1653,6 +1678,7 @@ const Body = ({
           photoExtraExts={photoExtraExts4}
           photoBlurhash={photoBlurhash4}
           photoGeometry={photoGeometry4}
+          album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}
@@ -1664,6 +1690,7 @@ const Body = ({
           photoExtraExts={photoExtraExts5}
           photoBlurhash={photoBlurhash5}
           photoGeometry={photoGeometry5}
+          album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}
@@ -1675,6 +1702,7 @@ const Body = ({
           photoExtraExts={photoExtraExts6}
           photoBlurhash={photoBlurhash6}
           photoGeometry={photoGeometry6}
+          album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}

--- a/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
+++ b/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
@@ -44,7 +44,6 @@ import { api } from '../../api/api';
 import { cmToFeetInchesStr } from '../../units/units';
 import { useSignedInUser } from '../../events/signed-in-user';
 import { postSkipped } from '../../hide-and-block/hide-and-block';
-import { Pinchy } from '../pinchy';
 import { Basic, Basics } from '../basic';
 import { themedSurface, legibleSurface } from '../../app-theme/surface';
 import { Club, Clubs } from '../club';
@@ -83,6 +82,7 @@ import { useOnline } from '../../chat/application-layer/hooks/online';
 import { HeartBackground } from '../heart-background';
 import { AudioPlayer } from '../audio-player';
 import { EnlargeablePhoto } from '../enlargeable-image';
+import type { PhotoGeometry } from '../../util/photos';
 import { commonStyles } from '../../styles';
 import { useSkipped, setSkipped } from '../../hide-and-block/hide-and-block';
 import { OnlineIndicator } from '../online-indicator';
@@ -129,20 +129,7 @@ const ProspectProfileScreen = () => {
     >
       <Stack.Screen name="Prospect Profile" component={ProspectProfileScreen_} />
       <Stack.Screen name="In-Depth" component={InDepthScreen_} />
-      <Stack.Screen name="Gallery Screen" component={GalleryScreen} />
     </Stack.Navigator>
-  );
-};
-
-const GalleryScreen = ({navigation, route}: NativeStackScreenProps<ProspectParamList, 'Gallery Screen'>) => {
-  const { photoUuid } = route.params;
-
-  return (
-    <>
-      <Pinchy uuid={photoUuid}/>
-      <StatusBarSpacer/>
-      <FloatingBackButton onPress={() => navigation.goBack()}/>
-    </>
   );
 };
 
@@ -757,6 +744,7 @@ type UserData = {
   photo_extra_exts: string[][],
   photo_blurhashes: string[],
   photo_verifications: boolean[],
+  photo_geometries: (PhotoGeometry | null)[],
   audio_bio_uuid: string | null,
   age: number | null,
   location: string | null
@@ -1012,6 +1000,8 @@ const CurriedContent = ({navigationRef, navigation, route}: ProspectScreenProps 
 
   const imageVerifications = data?.photo_verifications;
 
+  const photoGeometries = data?.photo_geometries;
+
   const photoUuid0 = (() => {
     if (photoUuids === undefined) {
       return undefined;
@@ -1123,6 +1113,7 @@ const CurriedContent = ({navigationRef, navigation, route}: ProspectScreenProps 
                   photoUuid={photoUuid0}
                   photoExtraExts={photoExtraExts0}
                   photoBlurhash={photoBlurhash0}
+                  photoGeometry={photoGeometries?.[0]}
                   isPrimary={true}
                   isVerified={imageVerification0}
                   style={
@@ -1408,6 +1399,13 @@ const Body = ({
   const imageVerification5 = data?.photo_verifications && data?.photo_verifications[5] || false;
   const imageVerification6 = data?.photo_verifications && data?.photo_verifications[6] || false;
 
+  const photoGeometry1 = data?.photo_geometries && data?.photo_geometries[1];
+  const photoGeometry2 = data?.photo_geometries && data?.photo_geometries[2];
+  const photoGeometry3 = data?.photo_geometries && data?.photo_geometries[3];
+  const photoGeometry4 = data?.photo_geometries && data?.photo_geometries[4];
+  const photoGeometry5 = data?.photo_geometries && data?.photo_geometries[5];
+  const photoGeometry6 = data?.photo_geometries && data?.photo_geometries[6];
+
   // Compare on UUID rather than the numeric `personId` we lift out of `data`,
   // so the "Block" button doesn't briefly render before the API response lands.
   const isViewingSelf =
@@ -1598,6 +1596,7 @@ const Body = ({
           photoUuid={photoUuid1}
           photoExtraExts={photoExtraExts1}
           photoBlurhash={photoBlurhash1}
+          photoGeometry={photoGeometry1}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}
@@ -1623,6 +1622,7 @@ const Body = ({
           photoUuid={photoUuid2}
           photoExtraExts={photoExtraExts2}
           photoBlurhash={photoBlurhash2}
+          photoGeometry={photoGeometry2}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}
@@ -1633,6 +1633,7 @@ const Body = ({
           photoUuid={photoUuid3}
           photoExtraExts={photoExtraExts3}
           photoBlurhash={photoBlurhash3}
+          photoGeometry={photoGeometry3}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}
@@ -1651,6 +1652,7 @@ const Body = ({
           photoUuid={photoUuid4}
           photoExtraExts={photoExtraExts4}
           photoBlurhash={photoBlurhash4}
+          photoGeometry={photoGeometry4}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}
@@ -1661,6 +1663,7 @@ const Body = ({
           photoUuid={photoUuid5}
           photoExtraExts={photoExtraExts5}
           photoBlurhash={photoBlurhash5}
+          photoGeometry={photoGeometry5}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}
@@ -1671,6 +1674,7 @@ const Body = ({
           photoUuid={photoUuid6}
           photoExtraExts={photoExtraExts6}
           photoBlurhash={photoBlurhash6}
+          photoGeometry={photoGeometry6}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
           isPrimary={false}
@@ -1770,7 +1774,6 @@ const styles = StyleSheet.create({
 
 export {
   FloatingBackButton,
-  GalleryScreen,
   InDepthScreen,
   ProspectProfileScreen,
 };

--- a/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
+++ b/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
@@ -101,9 +101,7 @@ const buildAlbum = (
   uuids: string[] | undefined,
   geometries: (PhotoGeometry | null)[] | undefined,
 ): AlbumPhoto[] =>
-  (uuids ?? [])
-    .map((uuid, i) => ({ uuid, geometry: geometries?.[i] ?? null }))
-    .filter((photo) => Boolean(photo.uuid));
+  (uuids ?? []).map((uuid, i) => ({ uuid, geometry: geometries?.[i] ?? null }));
 
 type ProspectNavigation = NativeStackNavigationProp<ProspectParamList>;
 type ProspectNavigationRef = MutableRefObject<ProspectNavigation | undefined>;
@@ -1011,8 +1009,6 @@ const CurriedContent = ({navigationRef, navigation, route}: ProspectScreenProps 
 
   const imageVerifications = data?.photo_verifications;
 
-  const photoGeometries = data?.photo_geometries;
-
   const album = useMemo(
     () => buildAlbum(data?.photo_uuids, data?.photo_geometries),
     [data?.photo_uuids, data?.photo_geometries],
@@ -1129,7 +1125,7 @@ const CurriedContent = ({navigationRef, navigation, route}: ProspectScreenProps 
                   photoUuid={photoUuid0}
                   photoExtraExts={photoExtraExts0}
                   photoBlurhash={photoBlurhash0}
-                  photoGeometry={photoGeometries?.[0]}
+                  photoGeometry={album[0]?.geometry}
                   album={album}
                   isPrimary={true}
                   isVerified={imageVerification0}
@@ -1421,13 +1417,6 @@ const Body = ({
     [data?.photo_uuids, data?.photo_geometries],
   );
 
-  const photoGeometry1 = data?.photo_geometries && data?.photo_geometries[1];
-  const photoGeometry2 = data?.photo_geometries && data?.photo_geometries[2];
-  const photoGeometry3 = data?.photo_geometries && data?.photo_geometries[3];
-  const photoGeometry4 = data?.photo_geometries && data?.photo_geometries[4];
-  const photoGeometry5 = data?.photo_geometries && data?.photo_geometries[5];
-  const photoGeometry6 = data?.photo_geometries && data?.photo_geometries[6];
-
   // Compare on UUID rather than the numeric `personId` we lift out of `data`,
   // so the "Block" button doesn't briefly render before the API response lands.
   const isViewingSelf =
@@ -1618,7 +1607,7 @@ const Body = ({
           photoUuid={photoUuid1}
           photoExtraExts={photoExtraExts1}
           photoBlurhash={photoBlurhash1}
-          photoGeometry={photoGeometry1}
+          photoGeometry={album[1]?.geometry}
           album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
@@ -1645,7 +1634,7 @@ const Body = ({
           photoUuid={photoUuid2}
           photoExtraExts={photoExtraExts2}
           photoBlurhash={photoBlurhash2}
-          photoGeometry={photoGeometry2}
+          photoGeometry={album[2]?.geometry}
           album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
@@ -1657,7 +1646,7 @@ const Body = ({
           photoUuid={photoUuid3}
           photoExtraExts={photoExtraExts3}
           photoBlurhash={photoBlurhash3}
-          photoGeometry={photoGeometry3}
+          photoGeometry={album[3]?.geometry}
           album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
@@ -1677,7 +1666,7 @@ const Body = ({
           photoUuid={photoUuid4}
           photoExtraExts={photoExtraExts4}
           photoBlurhash={photoBlurhash4}
-          photoGeometry={photoGeometry4}
+          photoGeometry={album[4]?.geometry}
           album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
@@ -1689,7 +1678,7 @@ const Body = ({
           photoUuid={photoUuid5}
           photoExtraExts={photoExtraExts5}
           photoBlurhash={photoBlurhash5}
-          photoGeometry={photoGeometry5}
+          photoGeometry={album[5]?.geometry}
           album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}
@@ -1701,7 +1690,7 @@ const Body = ({
           photoUuid={photoUuid6}
           photoExtraExts={photoExtraExts6}
           photoBlurhash={photoBlurhash6}
-          photoGeometry={photoGeometry6}
+          photoGeometry={album[6]?.geometry}
           album={album}
           style={commonStyles.secondaryEnlargeablePhoto}
           innerStyle={commonStyles.secondaryEnlargeablePhotoInner}

--- a/frontend/events/expanded-photo.tsx
+++ b/frontend/events/expanded-photo.tsx
@@ -1,0 +1,67 @@
+import { useLayoutEffect, useState } from 'react';
+import { listen, notify, lastEvent } from './events';
+import type { PhotoGeometry, Rect } from '../util/photos';
+
+const EVENT_KEY = 'expanded-photo';
+
+// The photo the gallery is currently expanding out of, and back into when it
+// closes. Passing this through React Navigation's `route.params` would leak
+// measured pixel coordinates into the URL, so - as with `prospect-cache` - the
+// press stashes it here and the gallery reads it on mount.
+//
+// `null` while no photo is expanded. Only ever one, since the gallery covers
+// the screen it was opened from.
+type ExpandedPhoto = {
+  photoUuid: string
+
+  // Where the preview being expanded sits on screen, from `measureInWindow`.
+  from: Rect
+
+  geometry: PhotoGeometry
+
+  // Whether the gallery has drawn its copy of the photo over the preview yet.
+  // The preview only hides once this is set, because the gallery is a screen
+  // and doesn't paint on the same frame as the press: hiding on the press
+  // itself leaves the photo missing for a frame or two.
+  covered: boolean
+};
+
+const setExpandedPhoto = (expandedPhoto: ExpandedPhoto | null) => {
+  notify<ExpandedPhoto | null>(EVENT_KEY, expandedPhoto);
+};
+
+const getExpandedPhoto = (): ExpandedPhoto | null =>
+  lastEvent<ExpandedPhoto | null>(EVENT_KEY) ?? null;
+
+// Whether the gallery has this preview's photo covered. Such a preview hides
+// itself: the gallery draws the same photo over the top of it, and the two
+// mustn't both be visible once the gallery's copy starts moving - the whole
+// point being that there's only ever one apparent instance of the photo.
+const useIsPhotoExpanded = (photoUuid: string | undefined | null): boolean => {
+  const [expandedPhoto, setExpandedPhoto_] = useState<ExpandedPhoto | null>(
+    () => getExpandedPhoto(),
+  );
+
+  useLayoutEffect(() => {
+    return listen<ExpandedPhoto | null>(
+      EVENT_KEY,
+      (e) => setExpandedPhoto_(e ?? null),
+      true,
+    );
+  }, []);
+
+  if (!photoUuid) return false;
+  if (expandedPhoto?.photoUuid !== photoUuid) return false;
+
+  return expandedPhoto.covered;
+};
+
+export {
+  getExpandedPhoto,
+  setExpandedPhoto,
+  useIsPhotoExpanded,
+};
+
+export type {
+  ExpandedPhoto,
+};

--- a/frontend/events/expanded-photo.tsx
+++ b/frontend/events/expanded-photo.tsx
@@ -4,6 +4,16 @@ import type { PhotoGeometry, Rect } from '../util/photos';
 
 const EVENT_KEY = 'expanded-photo';
 
+// Per-corner so a preview that rounds only some corners (the big-screen primary
+// photo rounds just its bottom two) animates each correctly, rather than
+// snapping the corners a single radius can't describe.
+type BorderRadii = {
+  topLeft: number
+  topRight: number
+  bottomLeft: number
+  bottomRight: number
+};
+
 // The photo the gallery is currently expanding out of, and back into when it
 // closes. Passing this through React Navigation's `route.params` would leak
 // measured pixel coordinates into the URL, so - as with `prospect-cache` - the
@@ -19,8 +29,8 @@ type ExpandedPhoto = {
 
   geometry: PhotoGeometry
 
-  // The preview's corner radius, animated out to square as it fills the screen.
-  borderRadius: number
+  // The preview's corner radii, animated out to square as it fills the screen.
+  borderRadius: BorderRadii
 
   // Whether the gallery has drawn its copy of the photo over the preview yet.
   // The preview only hides once this is set, because the gallery is a screen
@@ -63,6 +73,10 @@ export {
   getExpandedPhoto,
   setExpandedPhoto,
   useIsPhotoExpanded,
+};
+
+export type {
+  BorderRadii,
 };
 
 export type {

--- a/frontend/events/expanded-photo.tsx
+++ b/frontend/events/expanded-photo.tsx
@@ -4,9 +4,8 @@ import type { PhotoGeometry, Rect } from '../util/photos';
 
 const EVENT_KEY = 'expanded-photo';
 
-// Per-corner so a preview that rounds only some corners (the big-screen primary
-// photo rounds just its bottom two) animates each correctly, rather than
-// snapping the corners a single radius can't describe.
+// Per-corner because some previews round only some corners (the big-screen
+// primary photo rounds just its bottom two).
 type BorderRadii = {
   topLeft: number
   topRight: number
@@ -14,39 +13,33 @@ type BorderRadii = {
   bottomRight: number
 };
 
-// One photo in the album the gallery can page through.
 type AlbumPhoto = {
   uuid: string
   geometry: PhotoGeometry | null
 };
 
 // The photo the gallery is currently expanding out of, and back into when it
-// closes. Passing this through React Navigation's `route.params` would leak
-// measured pixel coordinates into the URL, so - as with `prospect-cache` - the
-// press stashes it here and the gallery reads it on mount.
-//
-// `null` while no photo is expanded. Only ever one, since the gallery covers
-// the screen it was opened from.
+// closes. Passing this through `route.params` would leak measured pixel
+// coordinates into the URL, so - as with `prospect-cache` - the press stashes
+// it here and the gallery reads it on mount. `null` while no photo is
+// expanded.
 type ExpandedPhoto = {
   photoUuid: string
 
-  // Every photo of the same person, so the gallery can page between them. The
-  // tapped one (`photoUuid`) is where it starts and what the open/close morph
-  // is anchored to.
+  // Every photo of the same person, so the gallery can page between them.
   album: AlbumPhoto[]
 
-  // Where the preview being expanded sits on screen, from `measureInWindow`.
+  // Where the preview sits on screen, from `measureInWindow`.
   from: Rect
 
   geometry: PhotoGeometry
 
-  // The preview's corner radii, animated out to square as it fills the screen.
   borderRadius: BorderRadii
 
   // Whether the gallery has drawn its copy of the photo over the preview yet.
-  // The preview only hides once this is set, because the gallery is a screen
-  // and doesn't paint on the same frame as the press: hiding on the press
-  // itself leaves the photo missing for a frame or two.
+  // The preview only hides once this is set: the gallery doesn't paint on the
+  // same frame as the press, so hiding sooner leaves the photo missing for a
+  // frame or two.
   covered: boolean
 };
 
@@ -58,9 +51,7 @@ const getExpandedPhoto = (): ExpandedPhoto | null =>
   lastEvent<ExpandedPhoto | null>(EVENT_KEY) ?? null;
 
 // Whether the gallery has this preview's photo covered. Such a preview hides
-// itself: the gallery draws the same photo over the top of it, and the two
-// mustn't both be visible once the gallery's copy starts moving - the whole
-// point being that there's only ever one apparent instance of the photo.
+// itself, so only one instance of the photo is ever apparent.
 const useIsPhotoExpanded = (photoUuid: string | undefined | null): boolean => {
   const [expandedPhoto, setExpandedPhoto_] = useState<ExpandedPhoto | null>(
     () => getExpandedPhoto(),

--- a/frontend/events/expanded-photo.tsx
+++ b/frontend/events/expanded-photo.tsx
@@ -19,6 +19,9 @@ type ExpandedPhoto = {
 
   geometry: PhotoGeometry
 
+  // The preview's corner radius, animated out to square as it fills the screen.
+  borderRadius: number
+
   // Whether the gallery has drawn its copy of the photo over the preview yet.
   // The preview only hides once this is set, because the gallery is a screen
   // and doesn't paint on the same frame as the press: hiding on the press

--- a/frontend/events/expanded-photo.tsx
+++ b/frontend/events/expanded-photo.tsx
@@ -14,6 +14,12 @@ type BorderRadii = {
   bottomRight: number
 };
 
+// One photo in the album the gallery can page through.
+type AlbumPhoto = {
+  uuid: string
+  geometry: PhotoGeometry | null
+};
+
 // The photo the gallery is currently expanding out of, and back into when it
 // closes. Passing this through React Navigation's `route.params` would leak
 // measured pixel coordinates into the URL, so - as with `prospect-cache` - the
@@ -23,6 +29,11 @@ type BorderRadii = {
 // the screen it was opened from.
 type ExpandedPhoto = {
   photoUuid: string
+
+  // Every photo of the same person, so the gallery can page between them. The
+  // tapped one (`photoUuid`) is where it starts and what the open/close morph
+  // is anchored to.
+  album: AlbumPhoto[]
 
   // Where the preview being expanded sits on screen, from `measureInWindow`.
   from: Rect
@@ -76,9 +87,7 @@ export {
 };
 
 export type {
+  AlbumPhoto,
   BorderRadii,
-};
-
-export type {
   ExpandedPhoto,
 };

--- a/frontend/navigation/gallery-linking.test.tsx
+++ b/frontend/navigation/gallery-linking.test.tsx
@@ -1,0 +1,46 @@
+import { getStateFromPath, getPathFromState } from '@react-navigation/native';
+import { createLinking } from './linking';
+
+// `/gallery/:photoUuid` is a URL users can already be holding, and the gallery
+// moved from the prospect navigator to the root one to be able to draw over the
+// feed as well. These pin that the move didn't disturb the URL.
+
+jest.mock('../events/signed-in-user', () => ({
+  getSignedInUser: () => ({ personUuid: 'someone' }),
+  isWebLoggedOut: () => false,
+}));
+
+const photoUuid = 'a'.repeat(64);
+
+describe('the gallery URL', () => {
+  test('resolves to the root Gallery Screen', () => {
+    const linking = createLinking();
+
+    const state = linking.getStateFromPath(`/gallery/${photoUuid}`, linking.config);
+
+    expect(state?.routes[state.routes.length - 1]).toMatchObject({
+      name: 'Gallery Screen',
+      params: { photoUuid },
+    });
+  });
+
+  test('round-trips back to the same path', () => {
+    const linking = createLinking();
+
+    const state = getStateFromPath(`/gallery/${photoUuid}`, linking.config);
+
+    expect(state && getPathFromState(state, linking.config))
+      .toBe(`/gallery/${photoUuid}`);
+  });
+
+  test('is not swallowed by the bare-slug profile route', () => {
+    const linking = createLinking();
+
+    // `Prospect Profile` matches any single bare slug, and is declared first.
+    // A two-segment gallery path must not be read as a profile named "gallery".
+    const state = linking.getStateFromPath(`/gallery/${photoUuid}`, linking.config);
+
+    const names = state?.routes.map((r) => r.name) ?? [];
+    expect(names).not.toContain('Prospect Profile Screen');
+  });
+});

--- a/frontend/navigation/gallery-restore.test.tsx
+++ b/frontend/navigation/gallery-restore.test.tsx
@@ -1,0 +1,55 @@
+import { jest } from '@jest/globals';
+
+// A build before the gallery was made unrestorable could have persisted
+// `/gallery/:photoUuid` as the last path. Restoring it brings the gallery back
+// as the only route, with no screen underneath to close onto: the back button
+// reports "GO_BACK was not handled by any navigator" and restarting the app
+// lands right back on it.
+
+const mockStored = { path: null as string | null };
+
+jest.mock('../kv-storage/last-path', () => ({
+  lastPath: async (path?: string | null) => {
+    if (path === undefined) return mockStored.path;
+    mockStored.path = path ?? null;
+    return undefined;
+  },
+}));
+
+jest.mock('../kv-storage/navigation-state', () => ({
+  consumeLegacyNavigationState: async () => null,
+}));
+
+jest.mock('../events/signed-in-user', () => ({
+  getSignedInUser: () => ({ personUuid: 'someone' }),
+  isWebLoggedOut: () => false,
+}));
+
+import { getPersistedState } from './startup';
+import { createLinking } from './linking';
+
+const photoUuid = 'a'.repeat(64);
+
+describe('restoring the last path', () => {
+  test('drops a persisted gallery path rather than stranding the user in it', async () => {
+    mockStored.path = `/gallery/${photoUuid}`;
+
+    expect(await getPersistedState(createLinking())).toBe(null);
+  });
+
+  test('still restores an ordinary path', async () => {
+    mockStored.path = '/qa';
+
+    const state = await getPersistedState(createLinking());
+
+    expect(state).not.toBe(null);
+  });
+
+  test('still restores a profile, which the gallery is opened from', async () => {
+    mockStored.path = '/some-user';
+
+    const state = await getPersistedState(createLinking());
+
+    expect(state).not.toBe(null);
+  });
+});

--- a/frontend/navigation/linking.tsx
+++ b/frontend/navigation/linking.tsx
@@ -66,10 +66,19 @@ const SLUG_REGEX_SOURCE = '[a-z0-9_-]+';
 
 const PROFILE_SUBROUTES = ['settings', 'clubs', 'invites'];
 
-const WIZARD_ROUTE_NAMES = new Set([
+// Routes that must never be restored on a cold start.
+//
+// The OptionScreen-backed wizards depend on an in-memory payload that doesn't
+// survive a restart, and would `popToTop` immediately.
+//
+// `Gallery Screen` is an overlay drawn over whichever screen opened it, so
+// restoring it as the only route strands the user in a fullscreen photo with
+// nothing to go back to.
+const UNRESTORABLE_ROUTE_NAMES = new Set([
   'Create Account Or Sign In Screen',
   'Profile Option Screen',
   'Search Filter Option Screen',
+  'Gallery Screen',
 ]);
 
 const GATED_LOGGED_OUT_PATHS = new Set([
@@ -114,13 +123,13 @@ const isBannerRoute = (state: RouteState | undefined): boolean => {
   return false;
 };
 
-const focusedRouteIsWizard = (state: RouteState | undefined): boolean => {
+const focusedRouteIsUnrestorable = (state: RouteState | undefined): boolean => {
   let node: RouteState | undefined = state;
   while (node && Array.isArray(node.routes)) {
     const idx = typeof node.index === 'number' ? node.index : 0;
     const route = node.routes[idx];
     if (!route) return false;
-    if (WIZARD_ROUTE_NAMES.has(route.name)) return true;
+    if (UNRESTORABLE_ROUTE_NAMES.has(route.name)) return true;
     node = route.state;
   }
   return false;
@@ -260,7 +269,7 @@ const createLinking = () => {
 
 type Linking = ReturnType<typeof createLinking>;
 
-export { createLinking, isBannerRoute, focusedProspectHandle, focusedConversationHandle, focusedRouteIsWizard, getTopRouteName };
+export { createLinking, isBannerRoute, focusedProspectHandle, focusedConversationHandle, focusedRouteIsUnrestorable, getTopRouteName };
 export type {
   Linking,
   RootParamList,

--- a/frontend/navigation/linking.tsx
+++ b/frontend/navigation/linking.tsx
@@ -47,15 +47,18 @@ type HomeParamList = {
 
 type ProspectParamList = {
   'Prospect Profile': { personUuid: string };
-  'Gallery Screen': { photoUuid: string };
   'In-Depth': { personUuid: string };
 };
 
+// The gallery is a root screen rather than a prospect one because it's opened
+// from the feed as well, and has to draw over whichever screen opened it for
+// the photo to appear to expand out of that screen's preview.
 type RootParamList = {
   Welcome: NavigatorScreenParams<WelcomeParamList> | undefined;
   Home: NavigatorScreenParams<HomeParamList> | undefined;
   'Conversation Screen': { personUuid: string };
   'Prospect Profile Screen': NavigatorScreenParams<ProspectParamList> | undefined;
+  'Gallery Screen': { photoUuid: string };
   'Invite Screen': { clubName: string };
 };
 
@@ -177,17 +180,20 @@ const homeConfig: PathConfig<HomeParamList> = {
 const prospectConfig: PathConfig<ProspectParamList> = {
   screens: {
     'Prospect Profile': `:personUuid(${UUID_REGEX_SOURCE}|${SLUG_REGEX_SOURCE})`,
-    'Gallery Screen': 'gallery/:photoUuid',
     'In-Depth': `in-depth/:personUuid(${UUID_REGEX_SOURCE})`,
   },
 };
 
+// `Gallery Screen` keeps the `/gallery/:photoUuid` URL it had when it was a
+// prospect screen: `Prospect Profile Screen` contributes no path segment of its
+// own, so the path was never nested under one.
 const linkingConfig: LinkingOptions<RootParamList>['config'] = {
   screens: {
     Welcome: welcomeConfig,
     Home: homeConfig,
     'Conversation Screen': `chat/:personUuid(${UUID_REGEX_SOURCE})`,
     'Prospect Profile Screen': prospectConfig,
+    'Gallery Screen': 'gallery/:photoUuid',
     'Invite Screen': 'invite/:clubName',
   },
 };

--- a/frontend/navigation/startup.tsx
+++ b/frontend/navigation/startup.tsx
@@ -4,6 +4,7 @@ import { lastPath } from '../kv-storage/last-path';
 import { consumeLegacyNavigationState } from '../kv-storage/navigation-state';
 import { ClubItem } from '../club/club';
 import type { Linking } from './linking';
+import { focusedRouteIsUnrestorable } from './linking';
 
 type NavState = PartialState<NavigationState>;
 
@@ -125,7 +126,13 @@ export async function getPersistedState(
 
   const fromPath = (p: string): NavState | null => {
     try {
-      return linking.getStateFromPath(p, linking.config) ?? null;
+      const state = linking.getStateFromPath(p, linking.config) ?? null;
+      // Also checked before persisting, but a path stored by an older build -
+      // or by one that persisted a route later made unrestorable - is still
+      // out there. Restoring the gallery from one strands the user in a
+      // fullscreen photo with nothing underneath to close onto.
+      if (focusedRouteIsUnrestorable(state ?? undefined)) return null;
+      return state;
     } catch {
       return null;
     }

--- a/frontend/styles.tsx
+++ b/frontend/styles.tsx
@@ -1,13 +1,12 @@
 import { StyleSheet } from 'react-native';
 
+// The photo styles carry no corner radii: EnlargeablePhoto rounds itself via
+// its `borderRadius` prop, which the gallery also animates.
 const commonStyles = StyleSheet.create({
   primaryEnlargeablePhotoBigScreen: {
     overflow: 'hidden',
-    borderBottomLeftRadius: 12,
-    borderBottomRightRadius: 12,
   },
   secondaryEnlargeablePhoto: {
-    borderRadius: 12,
     overflow: 'hidden',
     marginTop: 12,
     marginBottom: 12,

--- a/frontend/util/photos.spec.tsx
+++ b/frontend/util/photos.spec.tsx
@@ -1,4 +1,10 @@
-import { hasGifExtraExt, photoUri, supportedExtraExt } from './photos';
+import {
+  hasGifExtraExt,
+  photoExpandFrame,
+  photoUri,
+  supportedExtraExt,
+} from './photos';
+import type { PhotoGeometry, Rect } from './photos';
 import { IMAGES_URL } from '../env/env';
 
 describe('supportedExtraExt', () => {
@@ -60,5 +66,150 @@ describe('photoUri', () => {
   it('falls back to the jpg still for unsupported extra exts', () => {
     expect(photoUri(uuid, 450, ['mp4']))
       .toBe(`${IMAGES_URL}/450-${uuid}.jpg`);
+  });
+});
+
+describe('photoExpandFrame', () => {
+  const viewport = { width: 400, height: 800 };
+
+  // A landscape photo whose square crop the uploader dragged to the right.
+  const offCentre: PhotoGeometry = {
+    width: 1000,
+    height: 500,
+    crop_top: 0,
+    crop_left: 400,
+  };
+
+  // The preview square, as measured on screen.
+  const preview: Rect = { x: 20, y: 100, width: 200, height: 200 };
+
+  // The part of the image the preview is showing, in screen coordinates.
+  const cropOnScreen = (frame: ReturnType<typeof photoExpandFrame>, g: PhotoGeometry) => {
+    const scale = frame.image.width / g.width;
+    return {
+      x: frame.clip.x + frame.image.x + g.crop_left * scale,
+      y: frame.clip.y + frame.image.y + g.crop_top * scale,
+      size: Math.min(g.width, g.height) * scale,
+    };
+  };
+
+  it('starts as the preview, so the first frame replaces it seamlessly', () => {
+    const frame = photoExpandFrame(offCentre, preview, viewport, 0);
+
+    // The window onto the photo is exactly the preview square...
+    expect(frame.clip).toEqual(preview);
+
+    // ...and the crop lands on it exactly, rather than merely nearby.
+    const crop = cropOnScreen(frame, offCentre);
+    expect(crop.x).toBeCloseTo(preview.x);
+    expect(crop.y).toBeCloseTo(preview.y);
+    expect(crop.size).toBeCloseTo(preview.width);
+  });
+
+  it('fills the first frame with the crop, which is the cached preview image', () => {
+    // The original hasn't decoded on the first frame. If the square rendition
+    // didn't cover the window exactly here, the photo would visibly blink out
+    // at the moment of the press.
+    const frame = photoExpandFrame(offCentre, preview, viewport, 0);
+
+    expect(frame.crop.x).toBeCloseTo(0);
+    expect(frame.crop.y).toBeCloseTo(0);
+    expect(frame.crop.width).toBeCloseTo(frame.clip.width);
+    expect(frame.crop.height).toBeCloseTo(frame.clip.height);
+  });
+
+  it('tracks the crop onto the right part of the photo as it opens', () => {
+    // The crop is the right-hand 500px of a 1000x500 photo, so once open it
+    // should sit over the right-hand half of the fitted image.
+    const frame = photoExpandFrame(offCentre, preview, viewport, 1);
+
+    expect(frame.image).toEqual({ x: 0, y: 0, width: 400, height: 200 });
+    expect(frame.crop.x).toBeCloseTo(160); // 400/1000 * 400
+    expect(frame.crop.width).toBeCloseTo(200);
+    expect(frame.crop.height).toBeCloseTo(200);
+  });
+
+  it('keeps the crop glued to the same pixels throughout', () => {
+    // Wherever the animation is, the square rendition must land exactly where
+    // those same pixels are in the original, or the two would visibly disagree.
+    for (const t of [0, 0.3, 0.7, 1]) {
+      const frame = photoExpandFrame(offCentre, preview, viewport, t);
+      const scale = frame.image.width / offCentre.width;
+
+      expect(frame.crop.x).toBeCloseTo(frame.image.x + offCentre.crop_left * scale);
+      expect(frame.crop.y).toBeCloseTo(frame.image.y + offCentre.crop_top * scale);
+      expect(frame.crop.width).toBeCloseTo(500 * scale);
+    }
+  });
+
+  it('ends with the whole photo fitted and centred in the viewport', () => {
+    const frame = photoExpandFrame(offCentre, preview, viewport, 1);
+
+    // 1000x500 into 400x800 is width-bound: 400x200, centred vertically.
+    expect(frame.clip).toEqual({ x: 0, y: 300, width: 400, height: 200 });
+
+    // The whole image fills the window: nothing is cropped away any more.
+    expect(frame.image).toEqual({ x: 0, y: 0, width: 400, height: 200 });
+  });
+
+  it('never crops tighter than the preview while opening', () => {
+    // The visible fraction of the photo should only ever grow, otherwise the
+    // crop would appear to close before it opens.
+    const visible = [0, 0.25, 0.5, 0.75, 1].map((t) => {
+      const frame = photoExpandFrame(offCentre, preview, viewport, t);
+      return frame.clip.width / frame.image.width;
+    });
+
+    for (let i = 1; i < visible.length; i++) {
+      expect(visible[i]).toBeGreaterThan(visible[i - 1]);
+    }
+    expect(visible[0]).toBeCloseTo(0.5); // 500 of 1000px wide
+    expect(visible[visible.length - 1]).toBeCloseTo(1);
+  });
+
+  it('keeps a centred crop centred, for photos the uploader never dragged', () => {
+    const centred: PhotoGeometry = {
+      width: 1000,
+      height: 500,
+      crop_top: 0,
+      crop_left: 250,
+    };
+
+    const frame = photoExpandFrame(centred, preview, viewport, 0);
+    const crop = cropOnScreen(frame, centred);
+
+    expect(crop.x).toBeCloseTo(preview.x);
+    expect(crop.size).toBeCloseTo(preview.width);
+  });
+
+  it('handles portrait photos, which fit by height', () => {
+    const portrait: PhotoGeometry = {
+      width: 500,
+      height: 1000,
+      crop_top: 100,
+      crop_left: 0,
+    };
+
+    const frame = photoExpandFrame(portrait, preview, viewport, 1);
+
+    // 500x1000 into 400x800 is height-bound: 400x800 exactly fills it.
+    expect(frame.clip).toEqual({ x: 0, y: 0, width: 400, height: 800 });
+  });
+
+  it('is a no-op expansion for a square photo, which has nothing to uncrop', () => {
+    const square: PhotoGeometry = {
+      width: 600,
+      height: 600,
+      crop_top: 0,
+      crop_left: 0,
+    };
+
+    const start = photoExpandFrame(square, preview, viewport, 0);
+    const end = photoExpandFrame(square, preview, viewport, 1);
+
+    // The window always shows the whole photo; it only ever grows.
+    expect(start.clip.width / start.image.width).toBeCloseTo(1);
+    expect(end.clip.width / end.image.width).toBeCloseTo(1);
+    expect(end.clip.width).toBe(400);
   });
 });

--- a/frontend/util/photos.spec.tsx
+++ b/frontend/util/photos.spec.tsx
@@ -196,6 +196,44 @@ describe('photoExpandFrame', () => {
     expect(frame.clip).toEqual({ x: 0, y: 0, width: 400, height: 800 });
   });
 
+  it('shows a photo smaller than the viewport at native size, not enlarged', () => {
+    // Both dimensions fit within 400x800, so it must not be scaled up - it
+    // ends at its own resolution, centred, matching the zoomable viewer.
+    const small: PhotoGeometry = {
+      width: 200,
+      height: 150,
+      crop_top: 0,
+      crop_left: 25,
+    };
+
+    const frame = photoExpandFrame(small, preview, viewport, 1);
+
+    // Native size (`image` fills its clip), and the clip is centred on screen.
+    expect(frame.image).toEqual({ x: 0, y: 0, width: 200, height: 150 });
+    expect(frame.clip).toEqual({
+      x: (viewport.width - 200) / 2,
+      y: (viewport.height - 150) / 2,
+      width: 200,
+      height: 150,
+    });
+  });
+
+  it('still fits a photo that overflows on only one axis', () => {
+    // Narrower than the viewport but taller: fit by height, not native size.
+    const tall: PhotoGeometry = {
+      width: 200,
+      height: 1600,
+      crop_top: 700,
+      crop_left: 0,
+    };
+
+    const frame = photoExpandFrame(tall, preview, viewport, 1);
+
+    // 200x1600 into 400x800 is height-bound: scale 0.5 -> 100x800, centred.
+    expect(frame.image).toEqual({ x: 0, y: 0, width: 100, height: 800 });
+    expect(frame.clip).toEqual({ x: 150, y: 0, width: 100, height: 800 });
+  });
+
   it('is a no-op expansion for a square photo, which has nothing to uncrop', () => {
     const square: PhotoGeometry = {
       width: 600,

--- a/frontend/util/photos.tsx
+++ b/frontend/util/photos.tsx
@@ -54,20 +54,11 @@ type Rect = {
   height: number
 };
 
-// One frame of the expand animation: where the uncropped original sits, and
-// which part of it is visible.
-//
-// `clip` is a window onto the photo; `image` is the whole original, positioned
-// relative to `clip`'s top-left and drawn behind it. At t=0 `clip` is the
-// on-screen preview and the crop fills it exactly, so the frame is
-// indistinguishable from the preview it replaces. At t=1 `clip` has grown to
-// contain the whole image, which is now fitted to the viewport. In between the
-// window widens and the photo scales, which reads as the crop opening up.
-//
-// `crop` is where the square rendition - the very image the preview is already
-// showing, so it's in cache and paints immediately - lines up within `clip`.
-// Drawing it under `image` means the photo is never missing while the original
-// decodes. At t=0 it covers `clip` exactly.
+// One frame of the expand animation. `clip` is a window onto the photo;
+// `image` is the whole original, positioned relative to `clip`'s top-left. At
+// t=0 `clip` is the on-screen preview; at t=1 it contains the whole image,
+// fitted to the viewport. `crop` is where the square rendition - cached, so it
+// paints while the original decodes - lines up within `clip`.
 type PhotoExpandFrame = {
   clip: Rect
   image: Rect
@@ -142,23 +133,7 @@ const photoExpandFrame = (
   };
 };
 
-// The on-screen size of a photo fitted within `viewport`, never enlarged past
-// its native resolution - the same rule `photoExpandFrame` and the zoomable
-// viewer use, so a photo is the same size however it's shown.
-const fittedPhotoSize = (
-  geometry: { width: number, height: number },
-  viewport: { width: number, height: number },
-): { width: number, height: number } => {
-  const scale = Math.min(
-    1,
-    viewport.width / geometry.width,
-    viewport.height / geometry.height,
-  );
-  return { width: geometry.width * scale, height: geometry.height * scale };
-};
-
 export {
-  fittedPhotoSize,
   hasGifExtraExt,
   photoExpandFrame,
   photoUri,

--- a/frontend/util/photos.tsx
+++ b/frontend/util/photos.tsx
@@ -65,7 +65,11 @@ type PhotoExpandFrame = {
   crop: Rect
 };
 
-const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+// Workletised so the gallery can lerp the same frames on the UI thread.
+const lerp = (a: number, b: number, t: number): number => {
+  'worklet';
+  return a + (b - a) * t;
+};
 
 const lerpRect = (a: Rect, b: Rect, t: number): Rect => ({
   x: lerp(a.x, b.x, t),
@@ -135,6 +139,7 @@ const photoExpandFrame = (
 
 export {
   hasGifExtraExt,
+  lerp,
   photoExpandFrame,
   photoUri,
   supportedExtraExt,

--- a/frontend/util/photos.tsx
+++ b/frontend/util/photos.tsx
@@ -37,8 +37,118 @@ const photoUri = (
     : `${IMAGES_URL}/${resolution}-${photoUuid}.jpg`;
 };
 
+// How `900-{uuid}.jpg` was cut out of `original-{uuid}.jpg`, as reported by the
+// API. In the original's pixels, after EXIF rotation. Null for photos the
+// server hasn't recorded a geometry for.
+type PhotoGeometry = {
+  width: number
+  height: number
+  crop_top: number
+  crop_left: number
+};
+
+type Rect = {
+  x: number
+  y: number
+  width: number
+  height: number
+};
+
+// One frame of the expand animation: where the uncropped original sits, and
+// which part of it is visible.
+//
+// `clip` is a window onto the photo; `image` is the whole original, positioned
+// relative to `clip`'s top-left and drawn behind it. At t=0 `clip` is the
+// on-screen preview and the crop fills it exactly, so the frame is
+// indistinguishable from the preview it replaces. At t=1 `clip` has grown to
+// contain the whole image, which is now fitted to the viewport. In between the
+// window widens and the photo scales, which reads as the crop opening up.
+//
+// `crop` is where the square rendition - the very image the preview is already
+// showing, so it's in cache and paints immediately - lines up within `clip`.
+// Drawing it under `image` means the photo is never missing while the original
+// decodes. At t=0 it covers `clip` exactly.
+type PhotoExpandFrame = {
+  clip: Rect
+  image: Rect
+  crop: Rect
+};
+
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+const lerpRect = (a: Rect, b: Rect, t: number): Rect => ({
+  x: lerp(a.x, b.x, t),
+  y: lerp(a.y, b.y, t),
+  width: lerp(a.width, b.width, t),
+  height: lerp(a.height, b.height, t),
+});
+
+const photoExpandFrame = (
+  geometry: PhotoGeometry,
+  // The preview's square on screen. Square because the server only ever cuts
+  // square renditions.
+  from: Rect,
+  viewport: { width: number, height: number },
+  t: number,
+): PhotoExpandFrame => {
+  const { width, height, crop_top, crop_left } = geometry;
+
+  const minDim = Math.min(width, height);
+
+  // Scale that makes the crop exactly fill the preview square...
+  const fromScale = from.width / minDim;
+
+  // ...and the one that fits the whole original within the viewport.
+  const toScale = Math.min(viewport.width / width, viewport.height / height);
+
+  const fromImage: Rect = {
+    x: -crop_left * fromScale,
+    y: -crop_top * fromScale,
+    width: width * fromScale,
+    height: height * fromScale,
+  };
+
+  const toImage: Rect = {
+    x: 0,
+    y: 0,
+    width: width * toScale,
+    height: height * toScale,
+  };
+
+  const to: Rect = {
+    x: (viewport.width - toImage.width) / 2,
+    y: (viewport.height - toImage.height) / 2,
+    width: toImage.width,
+    height: toImage.height,
+  };
+
+  const cropWithin = (image: Rect, scale: number): Rect => ({
+    x: image.x + crop_left * scale,
+    y: image.y + crop_top * scale,
+    width: minDim * scale,
+    height: minDim * scale,
+  });
+
+  return {
+    clip: lerpRect(from, to, t),
+    image: lerpRect(fromImage, toImage, t),
+    crop: lerpRect(
+      cropWithin(fromImage, fromScale),
+      cropWithin(toImage, toScale),
+      t,
+    ),
+  };
+};
+
 export {
   hasGifExtraExt,
+  photoExpandFrame,
   photoUri,
   supportedExtraExt,
+};
+
+export type {
+  PhotoExpandFrame,
+  PhotoGeometry,
+  Rect,
 };

--- a/frontend/util/photos.tsx
+++ b/frontend/util/photos.tsx
@@ -142,7 +142,23 @@ const photoExpandFrame = (
   };
 };
 
+// The on-screen size of a photo fitted within `viewport`, never enlarged past
+// its native resolution - the same rule `photoExpandFrame` and the zoomable
+// viewer use, so a photo is the same size however it's shown.
+const fittedPhotoSize = (
+  geometry: { width: number, height: number },
+  viewport: { width: number, height: number },
+): { width: number, height: number } => {
+  const scale = Math.min(
+    1,
+    viewport.width / geometry.width,
+    viewport.height / geometry.height,
+  );
+  return { width: geometry.width * scale, height: geometry.height * scale };
+};
+
 export {
+  fittedPhotoSize,
   hasGifExtraExt,
   photoExpandFrame,
   photoUri,

--- a/frontend/util/photos.tsx
+++ b/frontend/util/photos.tsx
@@ -98,8 +98,10 @@ const photoExpandFrame = (
   // Scale that makes the crop exactly fill the preview square...
   const fromScale = from.width / minDim;
 
-  // ...and the one that fits the whole original within the viewport.
-  const toScale = Math.min(viewport.width / width, viewport.height / height);
+  // ...and the one that fits the whole original within the viewport, but never
+  // enlarging it past its native resolution - a photo smaller than the screen
+  // shows at native size, matching how the zoomable viewer (Pinchy) fits it.
+  const toScale = Math.min(1, viewport.width / width, viewport.height / height);
 
   const fromImage: Rect = {
     x: -crop_left * fromScale,


### PR DESCRIPTION
- [ ] Border radiuses aren't animated
- [ ] Remove AI slop comments
- [ ] Remove postgres function
- [ ] Test backfiller
- [ ] Ensure backwards compatibility with existing clients
- [ ] Ensure forwards-compatibility with new clients when the server lacks image geometry
- [ ] Consider putting `download_450_images` and `download_image`s in `duophoto/` directory
- [ ] Prefer events over refs
- [ ] Dragging the image with one finger while it's zoomed out should dismiss the image
- [ ] Does navigating back with a gesture still work on iOS?
- [ ] The back button should only appear on Desktop. Other platforms should use a swipe gesture to navigate back
- [ ] When I double click on desktop, can zooming in be animated?
- [ ] dragging left or right should go to the previous or next image. On desktop, pressing on the left or right hand side of the image should do the same. When there's more than one image, there should be a counter in the top right corner that says "n/m"
- [ ] "n/m" badge overlaps with statusbar
- [ ] Pressing the "escape" key should exit the image viewer on desktop
- [ ] It's not clear how navigation from image to image works on desktop. There's no affordances to suggest it.
- [ ] Exiting animation isn't smooth. When you drag the image off centre to dismiss it, the black background starts becoming transparent. When you finally let go, the background briefly transitions to being completely black again before becoming completely transparent as the image appears to return to its position on the profile.

---

Closes https://github.com/duolicious/duolicious/issues/1326