### PR TITLE
Archive conversations with partners last online over a month ago

### DIFF
--- a/backend/service/api/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/api/chat/messagestorage/inbox/__init__.py
@@ -1,6 +1,7 @@
 import traceback
 
 from batcher import Batcher
+from constants import LAST_ONLINE_DEFAULT_SECONDS
 from database import Row, Tx, api_tx, row_int, row_str
 from searchfilters import (
     Q_SEARCH_PARAMETERS_BY_UUID,
@@ -104,7 +105,9 @@ WITH viewer AS (
             prospect.activated AND prospect.shadow_banned_at IS NULL, FALSE
         ) AS is_prospect_activated,
         COALESCE(
-            prospect.last_online_time > NOW() - INTERVAL '1 month', FALSE
+            prospect.last_online_time >
+                NOW() - %(recently_online_seconds)s * INTERVAL '1 second',
+            FALSE
         ) AS is_prospect_recently_online,
         -- Only for the final SELECT's `matches_search_filters` probe; never
         -- sent to the client.
@@ -558,6 +561,7 @@ async def _fetch_inbox_conversations(
 
         params: dict[str, SearchParam] = dict(
             username=username,
+            recently_online_seconds=LAST_ONLINE_DEFAULT_SECONDS,
             **filters.params,
         )
         if prospect_username is not None:

--- a/backend/service/api/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/api/chat/messagestorage/inbox/__init__.py
@@ -103,6 +103,9 @@ WITH viewer AS (
         COALESCE(
             prospect.activated AND prospect.shadow_banned_at IS NULL, FALSE
         ) AS is_prospect_activated,
+        COALESCE(
+            prospect.last_online_time > NOW() - INTERVAL '1 month', FALSE
+        ) AS is_prospect_recently_online,
         -- Only for the final SELECT's `matches_search_filters` probe; never
         -- sent to the client.
         prospect.id AS prospect_id,
@@ -183,6 +186,8 @@ WITH viewer AS (
             WHEN
                     is_prospect_activated
                 AND
+                    is_prospect_recently_online
+                AND
                     NOT prospect_skipped_person
                 AND
                     NOT person_skipped_prospect
@@ -193,6 +198,8 @@ WITH viewer AS (
             THEN 'chats'
             WHEN
                     is_prospect_activated
+                AND
+                    is_prospect_recently_online
                 AND
                     NOT prospect_skipped_person
                 AND

--- a/backend/test/functionality6/xmpp-inbox-snapshot.sh
+++ b/backend/test/functionality6/xmpp-inbox-snapshot.sh
@@ -193,6 +193,23 @@ actual_snapshot=$(query_inbox_snapshot user1 | snapshot_conversations)
 diff -u --color <(echo "$actual_snapshot") <(jq -S '[.]' <<< "$expected_entry")
 
 
+echo "An intro from a sender last online over a month ago is archived"
+
+q "update person set last_online_time = now() - interval '2 months' where id = ${user2id}"
+
+actual_snapshot=$(query_inbox_snapshot user1 | snapshot_conversations)
+
+diff -u --color \
+  <(echo "$actual_snapshot") \
+  <(jq -S '[. | .location = "archive"]' <<< "$expected_entry")
+
+q "update person set last_online_time = now() where id = ${user2id}"
+
+actual_snapshot=$(query_inbox_snapshot user1 | snapshot_conversations)
+
+diff -u --color <(echo "$actual_snapshot") <(jq -S '[.]' <<< "$expected_entry")
+
+
 echo "A reply moves the conversation to chats on both sides"
 
 send_message user1 "$user1uuid" "$user2uuid" "reply from user 1"
@@ -287,3 +304,41 @@ q "update person set shadow_banned_at = now() where id = ${user2id}"
 actual_snapshot=$(query_inbox_snapshot user1 | snapshot_conversations)
 
 diff -u --color <(echo "$actual_snapshot") <(jq -S . <<< "$expected_snapshot")
+
+
+echo "A chat with a partner last online over a month ago is archived, info intact"
+
+q "update person set shadow_banned_at = null where id = ${user2id}"
+q "update person set last_online_time = now() - interval '2 months' where id = ${user2id}"
+
+actual_snapshot=$(query_inbox_snapshot user1 | snapshot_conversations)
+
+expected_snapshot=$(cat << EOF
+[
+  {
+    "image_blurhash": "my-blurhash",
+    "image_uuid": "my-photo-uuid",
+    "is_available": true,
+    "is_verified": false,
+    "last_message": "reply from user 1",
+    "last_message_read": true,
+    "last_message_timestamp": "redacted",
+    "location": "archive",
+    "match_percentage": 50,
+    "matches_search_filters": true,
+    "name": "user2",
+    "person_uuid": "${user2uuid}"
+  }
+]
+EOF
+)
+
+diff -u --color <(echo "$actual_snapshot") <(jq -S . <<< "$expected_snapshot")
+
+q "update person set last_online_time = now() where id = ${user2id}"
+
+actual_snapshot=$(query_inbox_snapshot user1 | snapshot_conversations)
+
+diff -u --color \
+  <(echo "$actual_snapshot") \
+  <(jq -S '[.[0] | .location = "chats"]' <<< "$expected_snapshot")


### PR DESCRIPTION
Since #1323 stopped automatically deactivating profiles, old conversations linger in the chats and intros sections of the inbox. This archives them instead when the other participant was last online over a month ago.

The inbox snapshot query's `conversation` CTE gains an `is_prospect_recently_online` flag (`person.last_online_time > NOW() - INTERVAL '1 month'`), and both the `chats` and `intros` branches of the `location` CASE now require it, so stale conversations fall through to `archive`. Unlike skip/shadow-ban archiving, `is_available` is untouched, so the partner's name, photo, and match percentage stay visible. No frontend change is needed: the app buckets purely on the server-sent `location`, and both the whole-inbox snapshot and per-message pushed inbox entries share this query, so a stale partner who comes back online and messages you returns to chats/intros.

The inbox snapshot functionality test now covers both transitions: an intro whose sender went stale is archived and returns to intros when they're active again, and an established chat with a stale partner is archived with info intact, returning to chats afterwards. Verified against the local test stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)