### PR TITLE
Ignore mismatched mattes when recovering photo crops

### DIFF
--- a/backend/duophoto/__init__.py
+++ b/backend/duophoto/__init__.py
@@ -66,6 +66,15 @@ def _greyscale(image: Image.Image, size: tuple[int, int]) -> numpy.ndarray:
     resized = image.convert('L').resize(size, Image.Resampling.BILINEAR)
     return numpy.asarray(resized, dtype=numpy.float32)
 
+# A transparent upload's renditions can disagree about the matte: the pipeline
+# flattened alpha onto white for some renditions and black for others. Pixel
+# pairs at opposite extremes are the matte disagreeing, not the photo, so they
+# don't count towards the difference; `MIN_COMPARABLE_FRACTION` stops a window
+# with almost no photo in it from being judged on the scraps that remain.
+MATTE_LOW = 15.0
+MATTE_HIGH = 240.0
+MIN_COMPARABLE_FRACTION = 0.25
+
 def _difference(
     original: numpy.ndarray,
     square: numpy.ndarray,
@@ -83,7 +92,17 @@ def _difference(
     if window.shape != square.shape:
         return None
 
-    return float(numpy.abs(window - square).mean())
+    inverted_matte = (
+        ((window >= MATTE_HIGH) & (square <= MATTE_LOW))
+        | ((window <= MATTE_LOW) & (square >= MATTE_HIGH))
+    )
+
+    comparable = ~inverted_matte
+
+    if float(comparable.mean()) < MIN_COMPARABLE_FRACTION:
+        return None
+
+    return float(numpy.abs(window - square)[comparable].mean())
 
 # The scan quantises offsets to the match resolution, so above the finest
 # `MATCH_SCALES` entry the winner is only exact to `1 / scale` original px.

--- a/backend/duophoto/fixtures.py
+++ b/backend/duophoto/fixtures.py
@@ -40,3 +40,42 @@ def renditions(
     )).resize((450, 450))
 
     return jpeg(original), jpeg(square)
+
+# A transparent upload: a subject over an alpha-0 background, which JPEG can't
+# hold, so each rendition flattens it onto some matte colour.
+def transparent_photo(width: int, height: int, seed: int) -> Image.Image:
+    rng = random.Random(seed)
+    image = Image.new('RGBA', (width, height), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(image)
+
+    for _ in range(120):
+        x = rng.randint(width // 6, 5 * width // 6)
+        y = rng.randint(height // 6, 5 * height // 6)
+        draw.ellipse(
+            [x, y, x + rng.randint(15, 90), y + rng.randint(15, 90)],
+            fill=(rng.randint(30, 220), rng.randint(30, 220), rng.randint(30, 220), 255),
+        )
+
+    return image
+
+def flatten(image: Image.Image, matte: tuple[int, int, int]) -> Image.Image:
+    canvas = Image.new('RGB', image.size, matte)
+    canvas.paste(image, mask=image.getchannel('A'))
+    return canvas
+
+# Renditions as the historical pipeline left them for transparent uploads: the
+# original matted onto one colour, the square crop onto another.
+def mismatched_matte_renditions(
+    original: Image.Image,
+    crop_left: int,
+    crop_top: int,
+) -> tuple[bytes, bytes]:
+    min_dim = min(original.size)
+    square = flatten(original, (0, 0, 0)).crop((
+        crop_left,
+        crop_top,
+        crop_left + min_dim,
+        crop_top + min_dim,
+    )).resize((450, 450))
+
+    return jpeg(flatten(original, (255, 255, 255))), jpeg(square)

--- a/backend/duophoto/test_init.py
+++ b/backend/duophoto/test_init.py
@@ -6,7 +6,14 @@ from duophoto import (
     orient_image,
     photo_geometry,
 )
-from duophoto.fixtures import jpeg, photo, renditions
+from duophoto.fixtures import (
+    flatten,
+    jpeg,
+    mismatched_matte_renditions,
+    photo,
+    renditions,
+    transparent_photo,
+)
 from PIL import Image
 import io
 import unittest
@@ -129,6 +136,44 @@ class TestFindCrop(unittest.TestCase):
         unrelated = _image(jpeg(photo(800, 800, seed=2).resize((450, 450))))
 
         _, difference = find_crop(original, unrelated)
+
+        self.assertGreater(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
+
+class TestFindCropWithMismatchedMattes(unittest.TestCase):
+    # The pipeline flattened transparent uploads onto white for the original
+    # and black for the square renditions, so at the true offset most of the
+    # frame disagrees at full amplitude. The difference must see through the
+    # matte or every transparent upload's crop is rejected.
+    def test_recovers_a_crop_despite_mismatched_mattes(self) -> None:
+        original = transparent_photo(800, 1200, seed=3)
+        original_bytes, square_bytes = mismatched_matte_renditions(
+            original, crop_left=0, crop_top=250,
+        )
+
+        geometry, difference = find_crop(
+            _image(original_bytes),
+            _image(square_bytes),
+        )
+
+        self.assertLessEqual(abs(geometry.crop_top - 250), TestFindCrop.TOLERANCE_PX)
+        self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
+
+    def test_still_rejects_an_unrelated_pair_with_mismatched_mattes(self) -> None:
+        original = jpeg(flatten(transparent_photo(1200, 800, seed=4), (255, 255, 255)))
+        unrelated = jpeg(
+            flatten(transparent_photo(800, 800, seed=5), (0, 0, 0)).resize((450, 450))
+        )
+
+        _, difference = find_crop(_image(original), _image(unrelated))
+
+        self.assertGreater(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
+
+    def test_reports_a_pair_with_no_comparable_pixels_as_unmatchable(self) -> None:
+        # Pure white against pure black: entirely matte, nothing to match on.
+        white = jpeg(Image.new('RGB', (800, 1200), (255, 255, 255)))
+        black = jpeg(Image.new('RGB', (450, 450), (0, 0, 0)))
+
+        _, difference = find_crop(_image(white), _image(black))
 
         self.assertGreater(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
 


### PR DESCRIPTION
The photocrop backfill has been skipping transparent uploads. Their renditions were flattened onto different matte colours by the pipeline — white for `original-`, black for the squares — so `find_crop` locates the correct offset, but the mean pixel difference is dominated by the background disagreeing at full amplitude and blows past `DEFAULT_MAX_MATCH_DIFFERENCE`.

Two skipped photos from prod, re-run locally:

| photo | matte area | before | after |
|---|---|---|---|
| `000ae3d2` (186×281) | 36% | 37.2 → skipped | 3.5 → accepted, `crop_top=47` |
| `00c6233a` (533×982) | 44% | 119.8 → skipped | 11.3 → accepted, `crop_top=0` |

In both cases the *offset* the matcher found was already correct; only the score condemned it.

The fix, in `_difference`: pixel pairs at opposite extremes (≥240 against ≤15) are the matte disagreeing, not the photo, so they're excluded from the mean. A window with under 25% comparable pixels is treated as unmatchable rather than judged on the scraps — pure-matte pairs still report no match. Wrong offsets still score high because subject-against-matte pairs are mid-tone against an extreme, which the mask doesn't touch; on `00c6233a`, wrong offsets score 69+ under the new metric.

Tests: a transparent-upload fixture (`transparent_photo` / `mismatched_matte_renditions`) plus three cases — the crop is recovered through the matte mismatch, an unrelated mismatched-matte pair is still rejected, and an all-matte pair reports no match.

After deploying, the already-skipped photos can be requeued with:

```sql
update photo set crop_attempted_at = null where width is null;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)