### PR TITLE
Let the gallery page the album when the pressed photo has no geometry

### DIFF
--- a/frontend/components/enlargeable-image.tsx
+++ b/frontend/components/enlargeable-image.tsx
@@ -78,28 +78,38 @@ const EnlargeablePhoto = ({
       return;
     }
 
+    const fullAlbum: AlbumPhoto[] =
+      album && album.length
+        ? album
+        : [{ uuid: photoUuid, geometry: photoGeometry ?? null }];
+
     // Without a geometry there's nothing to uncrop the photo into, so the
-    // gallery just fades up instead.
+    // gallery opens without the morph.
     if (!photoGeometry || !ref.current) {
+      setExpandedPhoto({
+        photoUuid,
+        album: fullAlbum,
+        morph: null,
+        covered: false,
+      });
       return navigation.navigate('Gallery Screen', { photoUuid });
     }
 
-    const fullAlbum: AlbumPhoto[] =
-      album && album.length ? album : [{ uuid: photoUuid, geometry: photoGeometry }];
-
     // Measured at press time because the preview scrolls; a zero-sized
-    // measurement means there's nowhere to expand from, so fall back.
+    // measurement means there's nowhere to expand from.
     ref.current.measureInWindow((x, y, width, height) => {
-      if (width > 0 && height > 0) {
-        setExpandedPhoto({
-          photoUuid,
-          album: fullAlbum,
-          from: { x, y, width, height },
-          geometry: photoGeometry,
-          borderRadius: toBorderRadii(borderRadius),
-          covered: false,
-        });
-      }
+      setExpandedPhoto({
+        photoUuid,
+        album: fullAlbum,
+        morph: width > 0 && height > 0
+          ? {
+            from: { x, y, width, height },
+            geometry: photoGeometry,
+            borderRadius: toBorderRadii(borderRadius),
+          }
+          : null,
+        covered: false,
+      });
 
       navigation.navigate('Gallery Screen', { photoUuid });
     });

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -23,7 +23,7 @@ import { IMAGES_URL } from '../env/env';
 import { lerp, photoExpandFrame } from '../util/photos';
 import type { PhotoExpandFrame, Rect } from '../util/photos';
 import { getExpandedPhoto, setExpandedPhoto } from '../events/expanded-photo';
-import type { AlbumPhoto, ExpandedPhoto } from '../events/expanded-photo';
+import type { AlbumPhoto, ExpandedPhoto, ExpandedPhotoMorph } from '../events/expanded-photo';
 import { isMobile } from '../util/util';
 
 const DURATION_MS = 280;
@@ -52,7 +52,8 @@ type Phase = 'opening' | 'open' | 'closing';
 // that only one instance of the photo is ever apparent. The frame is linear in
 // `progress`, so its endpoints are computed once and lerped on the UI thread.
 const ExpandingPhoto = ({
-  expandedPhoto,
+  photoUuid,
+  morph,
   progress,
   container,
   zoom,
@@ -61,7 +62,8 @@ const ExpandingPhoto = ({
   openedX,
   onCovered,
 }: {
-  expandedPhoto: ExpandedPhoto,
+  photoUuid: string,
+  morph: ExpandedPhotoMorph,
   progress: SharedValue<number>,
   container: Rect,
   zoom: PinchyZoom,
@@ -72,7 +74,7 @@ const ExpandingPhoto = ({
   openedX: number,
   onCovered: () => void,
 }) => {
-  const { photoUuid, from, geometry, borderRadius } = expandedPhoto;
+  const { from, geometry, borderRadius } = morph;
 
   const [closed, opened] = useMemo((): [PhotoExpandFrame, PhotoExpandFrame] => {
     // `from` was measured in window coordinates, but this draws inside the
@@ -201,12 +203,13 @@ const GalleryScreen = ({
   const { photoUuid } = route.params;
 
   // Captured once: the press stashes this immediately before navigating. Deep
-  // links arrive without it, and photos whose geometry the server hasn't
-  // recorded can't be expanded, so both fall back to fading the gallery in.
+  // links arrive without it, which leaves a one-photo gallery.
   const [expandedPhoto] = useState<ExpandedPhoto | null>(() => {
     const e = getExpandedPhoto();
     return e?.photoUuid === photoUuid ? e : null;
   });
+
+  const morph = expandedPhoto?.morph ?? null;
 
   const album: AlbumPhoto[] = useMemo(
     () => expandedPhoto?.album ?? [{ uuid: photoUuid, geometry: null }],
@@ -232,10 +235,10 @@ const GalleryScreen = ({
   }, [album]);
 
   const [phase, setPhase] = useState<Phase>(
-    expandedPhoto ? 'opening' : 'open',
+    morph ? 'opening' : 'open',
   );
 
-  const progress = useSharedValue(expandedPhoto ? 0 : 1);
+  const progress = useSharedValue(morph ? 0 : 1);
 
   // Lives here rather than inside Pinchy so the photo can be animated out from
   // wherever the user pinched it to, after Pinchy itself has gone.
@@ -377,20 +380,20 @@ const GalleryScreen = ({
 
   // Until this screen has drawn the photo over the preview, the preview is
   // still the one on show and nothing may move.
-  const [isCovering, setIsCovering] = useState(!expandedPhoto);
+  const [isCovering, setIsCovering] = useState(!morph);
 
   const onCovered = useCallback(() => setIsCovering(true), []);
 
   // The square rendition comes from cache, so its load event is a formality -
   // but don't hang the animation on one that never arrives.
   useEffect(() => {
-    if (!expandedPhoto) return;
+    if (!morph) return;
     const timeout = setTimeout(onCovered, 250);
     return () => clearTimeout(timeout);
-  }, [expandedPhoto, onCovered]);
+  }, [morph, onCovered]);
 
   useEffect(() => {
-    if (!expandedPhoto) return;
+    if (!expandedPhoto || !morph) return;
     if (!isCovering) return;
     // Nothing is drawn over the preview until the container has been
     // measured, so hiding it before then would leave the photo missing.
@@ -428,7 +431,7 @@ const GalleryScreen = ({
   // away, there's nothing on the profile to morph back to.
   const onOpenedPhoto = index === openedIndex;
 
-  const morphOnClose = expandedPhoto !== null && onOpenedPhoto && !containerMoved;
+  const morphOnClose = morph !== null && onOpenedPhoto && !containerMoved;
 
   const close = useCallback((finish: () => void) => {
     if (isFinishing.current) return;
@@ -449,10 +452,10 @@ const GalleryScreen = ({
       return;
     }
 
-    // No preview to return to (a deep link, or we paged away from the opened
-    // photo): fade the whole gallery out. Let the hidden preview show again
-    // now, at the start of the fade, so the profile is already there as the
-    // viewer dissolves.
+    // No preview to morph back into (a deep link, a photo with no geometry,
+    // or we paged away from the opened photo): fade the whole gallery out.
+    // Let any hidden preview show again now, at the start of the fade, so the
+    // profile is already there as the viewer dissolves.
     setExpandedPhoto(null);
     fadeOut.value = withTiming(
       0,
@@ -526,9 +529,10 @@ const GalleryScreen = ({
           moment the pager's interactive copy mounts (opening) and unmounts
           (closing) - otherwise that hand-off flickers.
         */}
-        {expandedPhoto && container && onOpenedPhoto &&
+        {morph && container && onOpenedPhoto &&
           <ExpandingPhoto
-            expandedPhoto={expandedPhoto}
+            photoUuid={photoUuid}
+            morph={morph}
             progress={progress}
             container={container}
             zoom={zoom}

--- a/frontend/events/expanded-photo.tsx
+++ b/frontend/events/expanded-photo.tsx
@@ -18,23 +18,26 @@ type AlbumPhoto = {
   geometry: PhotoGeometry | null
 };
 
-// The photo the gallery is currently expanding out of, and back into when it
-// closes. Passing this through `route.params` would leak measured pixel
-// coordinates into the URL, so - as with `prospect-cache` - the press stashes
-// it here and the gallery reads it on mount. `null` while no photo is
-// expanded.
-type ExpandedPhoto = {
-  photoUuid: string
-
-  // Every photo of the same person, so the gallery can page between them.
-  album: AlbumPhoto[]
-
+type ExpandedPhotoMorph = {
   // Where the preview sits on screen, from `measureInWindow`.
   from: Rect
 
   geometry: PhotoGeometry
 
   borderRadius: BorderRadii
+};
+
+// The photo the gallery was opened from. Passing this through `route.params`
+// would leak measured pixel coordinates into the URL, so - as with
+// `prospect-cache` - the press stashes it here and the gallery reads it on
+// mount. `null` while the gallery is closed.
+type ExpandedPhoto = {
+  photoUuid: string
+
+  // Every photo of the same person, so the gallery can page between them.
+  album: AlbumPhoto[]
+
+  morph: ExpandedPhotoMorph | null
 
   // Whether the gallery has drawn its copy of the photo over the preview yet.
   // The preview only hides once this is set: the gallery doesn't paint on the
@@ -81,4 +84,5 @@ export type {
   AlbumPhoto,
   BorderRadii,
   ExpandedPhoto,
+  ExpandedPhotoMorph,
 };


### PR DESCRIPTION
Tapping a photo without recorded geometry used to navigate to the gallery without stashing anything, so the gallery fell back to a one-photo album — no paging, no counter — even when the person's other photos were right there. Until the crop backfill drains (and permanently, for the photos it can't recover), that made carousel availability depend on *which* photo you happened to tap first.

The fix restructures the `expanded-photo` stash to match what actually depends on what:

- the **album** rides along on every press — paging never needed the pressed photo's geometry
- only the **morph** (`from` rect + geometry + border radii), the part that genuinely can't exist without geometry or a measurable preview, is optional: `morph: ExpandedPhotoMorph | null`

The gallery gates each behaviour on the right field: `morph` drives the opening phase, the preview cover/hide handshake, `ExpandingPhoto`, and the morph-on-close; the album, pager, counter and chevrons work either way. A geometry-less press now opens the gallery without the expand animation but with the full carousel; closing takes the existing fade path, and the preview never hides (it was never covered). Deep links still get a one-photo gallery, as before — there's no stash to read.

`tsc` clean; the four gallery-related suites (34 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)