### PR TITLE
Show the gallery's back button on every platform again

### DIFF
--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -39,8 +39,8 @@ const dragBackdropOpacity = (x: number, y: number) => {
   return 1 - Math.min(1, dragDistance(x, y) / DISMISS_FADE_RANGE);
 };
 
-// The back button and click-to-navigate zones are desktop-web only; on mobile
-// (native or mobile web) navigation and dismissal are gestures.
+// The click-to-navigate zones are desktop-web only; on mobile (native or
+// mobile web) navigation is a gesture.
 const isDesktopWeb = Platform.OS === 'web' && !isMobile();
 
 // 'opening' and 'closing' show the photo mid-expansion and own the screen;
@@ -593,7 +593,7 @@ const GalleryScreen = ({
         }
 
         <StatusBarSpacer/>
-        {isDesktopWeb && <FloatingBackButton onPress={onPressBack}/>}
+        <FloatingBackButton onPress={onPressBack}/>
       </Reanimated.View>
     </View>
   );


### PR DESCRIPTION
1a24a32c gated the gallery's `FloatingBackButton` behind desktop web, leaving mobile with only the drag-to-dismiss gesture. This restores the button on every platform, as it was before the gallery rewrite. Closing via the button goes through the same `onPressBack` path as every other exit, so the morph/fade close animations are unaffected.

The desktop-only gate stays on the paging chevrons and edge-click zones, which remain gesture-driven on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)