### PR TITLE
Fade the profile back button on mobile native

### DIFF
--- a/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
+++ b/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
@@ -884,7 +884,7 @@ const CurriedContent = ({navigationRef, navigation, route}: ProspectScreenProps 
     !isAnonymousViewer || Platform.OS === 'web'
       ? {
         layout: 'column',
-        transition: 'instant',
+        transition: Platform.OS === 'web' ? 'instant' : 'fade',
         onPress: () => navigationRef.current?.goBack(),
       }
       : null


### PR DESCRIPTION
On mobile native, the prospect profile screen claimed the global back button with `transition: 'instant'`, so the button popped in and out abruptly while the screen itself slid in and out. This claims it with `'fade'` on native so the button fades in when the profile opens and fades out when navigating away, matching the gallery's behavior. Web keeps `'instant'` and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)