### PR TITLE
Refresh search results when logged-out users play Q&A

### DIFF
--- a/frontend/events/anonymous-answers.tsx
+++ b/frontend/events/anonymous-answers.tsx
@@ -1,3 +1,5 @@
+import { markSearchResultsStale } from './stale-search-results';
+
 type AnonymousAnswer = {
   question_id: number
   answer: boolean | null
@@ -9,17 +11,20 @@ const anonymousAnswers: AnonymousAnswer[] = [];
 const addAnonymousAnswer = (answer: AnonymousAnswer): void => {
   removeAnonymousAnswer(answer.question_id);
   anonymousAnswers.push(answer);
+  markSearchResultsStale();
 };
 
 const removeAnonymousAnswer = (questionId: number): void => {
   const i = anonymousAnswers.findIndex(a => a.question_id === questionId);
   if (i !== -1) {
     anonymousAnswers.splice(i, 1);
+    markSearchResultsStale();
   }
 };
 
 const clearAnonymousAnswers = (): void => {
   anonymousAnswers.length = 0;
+  markSearchResultsStale();
 };
 
 export {


### PR DESCRIPTION
Currently `markSearchResultsStale` only fires for signed-in users: every Q&A write goes through `api/answer`, which flags the search tab’s cached results so it refetches the next time it’s focused.

Logged-out web users answer into `events/anonymous-answers`, and those answers are what rank `/public-search` (both the quiz card stack’s prospects and the search tab pass them as the `answers` param). Nothing flagged the cache, so after playing Q&A their search results kept showing the old ranking until they hit refresh by hand.

This flags the results from the anonymous-answer store itself — the choke point all of those mutations already go through — so adding, undoing, or clearing an anonymous answer behaves like the signed-in path.

`clearAnonymousAnswers` runs on sign-in, where the tab refetches anyway because `isPublic` flips; flagging there keeps the rule uniform rather than relying on that.

Verified with `tsc --noEmit`; no behavior change for signed-in users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)