### PR TITLE
Show the intros filter button to anyone with at least one intro

### DIFF
--- a/frontend/chat/application-layer/hooks/conversations.test.tsx
+++ b/frontend/chat/application-layer/hooks/conversations.test.tsx
@@ -18,7 +18,6 @@ jest.mock('../../../notifications/notifications', () => ({
 }));
 
 import {
-  MIN_INTROS_TO_APPLY_SEARCH_FILTERS,
   computeConversationIds,
   sortConversations,
 } from './conversations';
@@ -52,19 +51,7 @@ const match50new      = conversation('match50new',      50, new Date(3000), true
 const match99filtered = conversation('match99filtered', 99, new Date(2000), false);
 const match10filtered = conversation('match10filtered', 10, new Date(4000), false);
 
-// Matching filler intros to lift the section past the size at which applying
-// search filters kicks in. Match percentages 60-65 and timestamps 5000-5005
-// slot between the named conversations above.
-const filler = Array.from(
-  { length: MIN_INTROS_TO_APPLY_SEARCH_FILTERS - 4 },
-  (_, i) => conversation(`filler${i}`, 60 + i, new Date(5000 + i), true),
-);
-
-const fillerByMatch  = [...filler].reverse().map((c) => c.personUuid);
-const fillerByLatest = [...filler].reverse().map((c) => c.personUuid);
-
-const fewIntros  = [match90old, match50new, match99filtered, match10filtered];
-const manyIntros = [...fewIntros, ...filler];
+const intros = [match90old, match50new, match99filtered, match10filtered];
 
 const ids = (cs: Conversation[]) => cs.map((c) => c.personUuid);
 
@@ -80,56 +67,55 @@ const inboxOf = (intros: Conversation[]): Inbox => ({
 
 describe('sortConversations', () => {
   it('ignores search filters when not applying them', () => {
-    expect(ids(sortConversations(manyIntros, 'intros', 'match', false))).toEqual(
-      ['match99filtered', 'match90old', ...fillerByMatch, 'match50new', 'match10filtered']);
+    expect(ids(sortConversations(intros, 'intros', 'match', false))).toEqual(
+      ['match99filtered', 'match90old', 'match50new', 'match10filtered']);
 
-    expect(ids(sortConversations(manyIntros, 'intros', 'latest', false))).toEqual(
-      [...fillerByLatest, 'match10filtered', 'match50new', 'match99filtered', 'match90old']);
+    expect(ids(sortConversations(intros, 'intros', 'latest', false))).toEqual(
+      ['match10filtered', 'match50new', 'match99filtered', 'match90old']);
   });
 
   it('sinks intros from outside search filters when applying them', () => {
-    expect(ids(sortConversations(manyIntros, 'intros', 'match', true))).toEqual(
-      ['match90old', ...fillerByMatch, 'match50new', 'match99filtered', 'match10filtered']);
+    expect(ids(sortConversations(intros, 'intros', 'match', true))).toEqual(
+      ['match90old', 'match50new', 'match99filtered', 'match10filtered']);
 
-    expect(ids(sortConversations(manyIntros, 'intros', 'latest', true))).toEqual(
-      [...fillerByLatest, 'match50new', 'match90old', 'match10filtered', 'match99filtered']);
-  });
-
-  it('never sinks small intros sections, where triage isn\'t needed', () => {
-    expect(ids(sortConversations(fewIntros, 'intros', 'match', true))).toEqual(
-      ids(sortConversations(fewIntros, 'intros', 'match', false)));
-
-    expect(ids(sortConversations(fewIntros, 'intros', 'latest', true))).toEqual(
-      ids(sortConversations(fewIntros, 'intros', 'latest', false)));
+    expect(ids(sortConversations(intros, 'intros', 'latest', true))).toEqual(
+      ['match50new', 'match90old', 'match10filtered', 'match99filtered']);
   });
 
   it('never sinks chats or archived conversations', () => {
-    expect(ids(sortConversations(manyIntros, 'chats', 'latest', true))).toEqual(
-      ids(sortConversations(manyIntros, 'chats', 'latest', false)));
+    expect(ids(sortConversations(intros, 'chats', 'latest', true))).toEqual(
+      ids(sortConversations(intros, 'chats', 'latest', false)));
 
-    expect(ids(sortConversations(manyIntros, 'archive', 'latest', true))).toEqual(
-      ids(sortConversations(manyIntros, 'archive', 'latest', false)));
+    expect(ids(sortConversations(intros, 'archive', 'latest', true))).toEqual(
+      ids(sortConversations(intros, 'archive', 'latest', false)));
   });
 });
 
 describe('computeConversationIds', () => {
   it('splits the list exactly where the sunk intros begin', () => {
     const computed = computeConversationIds(
-      inboxOf(manyIntros), 'intros', 'match', true);
+      inboxOf(intros), 'intros', 'match', true);
 
-    expect(computed?.numIntrosWithinFilters).toBe(manyIntros.length - 2);
-    expect(computed?.ids.slice(manyIntros.length - 2)).toEqual(
+    expect(computed?.numIntrosWithinFilters).toBe(2);
+    expect(computed?.ids.slice(2)).toEqual(
       ['match99filtered', 'match10filtered']);
+  });
+
+  it('splits a section holding a single intro', () => {
+    const computed = computeConversationIds(
+      inboxOf([match99filtered]), 'intros', 'match', true);
+
+    expect(computed?.numIntrosWithinFilters).toBe(0);
   });
 
   it('reports no split when the intros aren\'t sunk', () => {
     const noSplit = [
       // Filters not applied
-      computeConversationIds(inboxOf(manyIntros), 'intros', 'match', false),
-      // Section too small to triage
-      computeConversationIds(inboxOf(fewIntros), 'intros', 'match', true),
+      computeConversationIds(inboxOf(intros), 'intros', 'match', false),
+      // No intros to triage
+      computeConversationIds(inboxOf([]), 'intros', 'match', true),
       // Not the intros section
-      computeConversationIds(inboxOf(manyIntros), 'chats', 'latest', true),
+      computeConversationIds(inboxOf(intros), 'chats', 'latest', true),
     ];
 
     noSplit.forEach((computed) =>

--- a/frontend/chat/application-layer/hooks/conversations.tsx
+++ b/frontend/chat/application-layer/hooks/conversations.tsx
@@ -5,10 +5,6 @@ import { listen } from '../../../events/events';
 import * as _ from 'lodash';
 
 
-const MIN_INTROS_TO_APPLY_SEARCH_FILTERS = 10;
-
-// Intros sections smaller than the minimum aren't worth triaging, so applying
-// search filters only reorders (and divides) sections at least that big.
 const shouldApplySearchFilters = (
   conversations: Conversation[],
   section: 'intros' | 'chats' | 'archive',
@@ -16,7 +12,7 @@ const shouldApplySearchFilters = (
 ): boolean =>
   section === 'intros' &&
   applySearchFilters &&
-  conversations.length >= MIN_INTROS_TO_APPLY_SEARCH_FILTERS;
+  conversations.length > 0;
 
 const getSection = (sectionIndex: number, showArchive: boolean) => {
   if (showArchive) {
@@ -235,7 +231,6 @@ const useConversations = () => {
 };
 
 export {
-  MIN_INTROS_TO_APPLY_SEARCH_FILTERS,
   computeConversationIds,
   sortConversations,
   useConversations,

--- a/frontend/chat/application-layer/hooks/conversations.tsx
+++ b/frontend/chat/application-layer/hooks/conversations.tsx
@@ -5,6 +5,8 @@ import { listen } from '../../../events/events';
 import * as _ from 'lodash';
 
 
+const MIN_INTROS_TO_APPLY_SEARCH_FILTERS = 1;
+
 const shouldApplySearchFilters = (
   conversations: Conversation[],
   section: 'intros' | 'chats' | 'archive',
@@ -12,7 +14,7 @@ const shouldApplySearchFilters = (
 ): boolean =>
   section === 'intros' &&
   applySearchFilters &&
-  conversations.length > 0;
+  conversations.length >= MIN_INTROS_TO_APPLY_SEARCH_FILTERS;
 
 const getSection = (sectionIndex: number, showArchive: boolean) => {
   if (showArchive) {
@@ -231,6 +233,7 @@ const useConversations = () => {
 };
 
 export {
+  MIN_INTROS_TO_APPLY_SEARCH_FILTERS,
   computeConversationIds,
   sortConversations,
   useConversations,

--- a/frontend/components/inbox-tab.tsx
+++ b/frontend/components/inbox-tab.tsx
@@ -22,6 +22,7 @@ import { DefaultText } from './default-text';
 import { ButtonGroup } from './button-group';
 import { useInboxStats } from '../chat/application-layer/hooks/inbox-stats';
 import {
+  MIN_INTROS_TO_APPLY_SEARCH_FILTERS,
   useConversations,
 } from '../chat/application-layer/hooks/conversations';
 import { TopNavBarButton } from './top-nav-bar-button';
@@ -132,7 +133,7 @@ const InboxTab = () => {
 
   const canApplySearchFilters =
     sectionIndex === 0 &&
-    numIntros > 0;
+    numIntros >= MIN_INTROS_TO_APPLY_SEARCH_FILTERS;
 
   const introsNumericalLabel = (
     numUnreadIntros ?

--- a/frontend/components/inbox-tab.tsx
+++ b/frontend/components/inbox-tab.tsx
@@ -22,7 +22,6 @@ import { DefaultText } from './default-text';
 import { ButtonGroup } from './button-group';
 import { useInboxStats } from '../chat/application-layer/hooks/inbox-stats';
 import {
-  MIN_INTROS_TO_APPLY_SEARCH_FILTERS,
   useConversations,
 } from '../chat/application-layer/hooks/conversations';
 import { TopNavBarButton } from './top-nav-bar-button';
@@ -133,7 +132,7 @@ const InboxTab = () => {
 
   const canApplySearchFilters =
     sectionIndex === 0 &&
-    numIntros >= MIN_INTROS_TO_APPLY_SEARCH_FILTERS;
+    numIntros > 0;
 
   const introsNumericalLabel = (
     numUnreadIntros ?


### PR DESCRIPTION
Closes #1362

The intros filter button was gated on `MIN_INTROS_TO_APPLY_SEARCH_FILTERS = 10`, and so was the sorting behaviour behind it. Users with fewer than 10 intros never saw the button and never learnt that search filters can triage their intros.

The constant drops to `1`, so both gates now amount to the intros section being non-empty:

- `shouldApplySearchFilters` in `frontend/chat/application-layer/hooks/conversations.tsx`.
- `canApplySearchFilters` in `frontend/components/inbox-tab.tsx`, where `numIntros` is `inbox.intros.conversations.length` — the same list the sort gate sees, so the button can't appear over a section the sort would refuse to triage.

The unit tests dropped their filler intros — they only existed to lift fixtures past the old threshold — and gained a case covering a single-intro section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
