### PR TITLE
Don't ask for a store review after a Gold purchase

### DIFF
--- a/frontend/components/modal/point-of-sale-modal.tsx
+++ b/frontend/components/modal/point-of-sale-modal.tsx
@@ -13,7 +13,6 @@ import { AppStoreBadges } from '../badges/app-store/app-store';
 import { listen, notify } from '../../events/events';
 import { setSignedInUser } from '../../events/signed-in-user';
 import { getCurrentOfferingCached } from '../../purchases/purchases';
-import { maybeRequestReview } from '../../store-review/store-review';
 import { pluralize, isMobileWeb } from '../../util/util';
 
 const cardPadding = 20;
@@ -188,8 +187,6 @@ const Offering = ({
     });
 
     onPressClose();
-
-    maybeRequestReview(1000);
   };
 
   const isCompact = isMobileWeb() && windowHeight < 620;


### PR DESCRIPTION
Ratings have slightly declined since #1274 started prompting for a Google Play or App Store review right after a user buys a Gold subscription. This removes that prompt.

The other `maybeRequestReview` call site — after a conversation passes 45 messages — is left in place, as is the `store-review` module itself.

Closes #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)