### PR TITLE
Link the community guidelines from the web sidebar

### DIFF
--- a/frontend/components/navigation/web-bar-footer/web-bar-footer.web.tsx
+++ b/frontend/components/navigation/web-bar-footer/web-bar-footer.web.tsx
@@ -39,6 +39,46 @@ const SocialBadges = () => {
   );
 };
 
+const LegalLinks = () => {
+  return (
+    <ul
+      style={{
+        boxSizing: 'border-box',
+        flexWrap: 'wrap',
+        listStyleType: 'none',
+        width: '100%',
+        justifyContent: 'center',
+        display: 'flex',
+        gap: '12px',
+        border: 'none',
+        padding: '0',
+        margin: '0',
+      }}
+    >
+      {[
+        ['Guidelines', 'https://duolicious.app/guidelines/'],
+        ['Terms', 'https://duolicious.app/terms/'],
+        ['Privacy', 'https://duolicious.app/privacy/'],
+      ].map(([label, href]) =>
+        <li key={href}>
+          <a
+            target="_blank"
+            href={href}
+            style={{
+              color: 'white',
+              fontFamily: 'MontserratRegular',
+              fontSize: '13px',
+              textDecoration: 'none',
+            }}
+          >
+            {label}
+          </a>
+        </li>
+      )}
+    </ul>
+  );
+};
+
 const WebBarFooter = () => {
   return (
     <div
@@ -54,6 +94,7 @@ const WebBarFooter = () => {
     >
       <AppStoreBadges/>
       <SocialBadges/>
+      <LegalLinks/>
     </div>
   );
 };

--- a/frontend/components/navigation/web-bar-footer/web-bar-footer.web.tsx
+++ b/frontend/components/navigation/web-bar-footer/web-bar-footer.web.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { AppStoreBadges } from '../../badges/app-store/app-store';
 const twitterIcon = require('../../../assets/social/twitter-white.svg');
 const redditIcon = require('../../../assets/social/reddit-white.svg');
@@ -40,6 +41,8 @@ const SocialBadges = () => {
 };
 
 const LegalLinks = () => {
+  const [hoveredHref, setHoveredHref] = useState<string | null>(null);
+
   return (
     <ul
       style={{
@@ -64,11 +67,13 @@ const LegalLinks = () => {
           <a
             target="_blank"
             href={href}
+            onMouseEnter={() => setHoveredHref(href)}
+            onMouseLeave={() => setHoveredHref(null)}
             style={{
               color: 'white',
-              fontFamily: 'MontserratRegular',
-              fontSize: '13px',
-              textDecoration: 'none',
+              fontFamily: 'MontserratSemiBold',
+              fontSize: '15px',
+              textDecoration: hoveredHref === href ? 'underline' : 'none',
             }}
           >
             {label}

--- a/frontend/components/profile-tab.tsx
+++ b/frontend/components/profile-tab.tsx
@@ -882,6 +882,33 @@ const AboutDuolicious = () => {
         queries you have.
       </DefaultText>
 
+      <View
+        style={{
+          marginTop: 25,
+          flexDirection: 'row',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+          gap: 20,
+        }}
+      >
+        {([
+          ['Guidelines', 'https://duolicious.app/guidelines/'],
+          ['Terms', 'https://duolicious.app/terms/'],
+          ['Privacy', 'https://duolicious.app/privacy/'],
+        ] as const).map(([label, href]) =>
+          <DefaultText
+            key={href}
+            onPress={() => Linking.openURL(href)}
+            style={{
+              fontWeight: '600',
+              color: '#37f',
+            }}
+          >
+            {label}
+          </DefaultText>
+        )}
+      </View>
+
       {Platform.OS === 'web' &&
         <DefaultText
           style={{


### PR DESCRIPTION
Closes #1357

The web app's sidebar footer linked to the App Store, Play Store, Twitter, Reddit and GitHub, but not to the rules — you could only find them by opening `duolicious.app` in a separate tab.

This adds a row of text links (Guidelines / Terms / Privacy) beneath the social badges, styled to match the rest of the sidebar.

The sidebar footer is `.web.tsx`-only, so the same three links also go in the About section of the profile tab, which renders on every platform. That's where the GitHub and support-email links already live, and it uses the same `DefaultText` + `Linking.openURL` pattern.

Verified in the running app against the local backend: on desktop web at 1400px and 1100px viewports the sidebar row fits on one line, and in an iPhone 13 context the profile tab's About section shows the three links on one line beneath the support-email paragraph. The three `href`s resolve to `https://duolicious.app/{guidelines,terms,privacy}/`. `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
