### PR TITLE
Show that the last sent message is delivered

### DIFF
--- a/frontend/components/conversation-screen/chat-message.tsx
+++ b/frontend/components/conversation-screen/chat-message.tsx
@@ -44,6 +44,7 @@ import {
   TextBlock,
 } from './quote';
 import { usePartnerAnswer } from '../../chat/application-layer/hooks/partner-answer';
+import { useReadReceipt } from '../../chat/application-layer/hooks/read-receipt';
 import { AnsweredQuizCard } from '../quiz-card';
 import * as Haptics from 'expo-haptics';
 import { useSignedInUser } from '../../events/signed-in-user';
@@ -316,11 +317,13 @@ const ChatMessage = ({
   personUuid,
   name,
   avatarUuid,
+  isLastMessage,
 }: {
   messageId: string
   personUuid: string
   name: string | undefined
   avatarUuid: string | null | undefined
+  isLastMessage: boolean
 }) => {
   const { appTheme } = useAppTheme();
   const opacity = useSharedValue(0);
@@ -339,6 +342,7 @@ const ChatMessage = ({
   } = useAnchorMeasurement();
   const message = useMessage(messageId);
   const [signedInUser] = useSignedInUser();
+  const readAt = useReadReceipt(personUuid);
 
   const chatMessage =
     message && message.message.type !== 'typing'
@@ -558,6 +562,12 @@ const ChatMessage = ({
   const { fromCurrentUser } = message.message;
   const shownAvatarUuid = fromCurrentUser ? undefined : avatarUuid;
 
+  const doShowDeliveryReceipt =
+    isLastMessage &&
+    fromCurrentUser &&
+    message.status === 'sent' &&
+    !readAt;
+
   return (
     <View
       style={[
@@ -743,7 +753,7 @@ const ChatMessage = ({
           }}
         />
       }
-      {doShowTimestamp &&
+      {(doShowTimestamp || doShowDeliveryReceipt) &&
         <DefaultText
           selectable={true}
           style={{

--- a/frontend/components/conversation-screen/conversation-screen.tsx
+++ b/frontend/components/conversation-screen/conversation-screen.tsx
@@ -902,7 +902,7 @@ const ConversationScreen = ({navigation, route}: NativeStackScreenProps<RootPara
               }
             </>
           }
-          {messageIds.length > 0 && [... new Set(messageIds)].map((messageId, i) => {
+          {messageIds.length > 0 && [... new Set(messageIds)].map((messageId, i, ids) => {
             const [previousMessage, message] = [
               getMessage(messageIds[i - 1]),
               getMessage(messageId)];
@@ -920,6 +920,7 @@ const ConversationScreen = ({navigation, route}: NativeStackScreenProps<RootPara
                   personUuid={personUuid}
                   name={name}
                   avatarUuid={photoUuid}
+                  isLastMessage={i === ids.length - 1}
                 />
               </Fragment>
             );


### PR DESCRIPTION
Closes #1363

The delivery timestamp under a speech bubble only appeared when the user pressed the bubble. Now it shows automatically under the user's last message, and hides once the other person reads it — at which point the read receipt below the conversation (`Read <time>`) takes over.

`ChatMessage` takes a new `isLastMessage` prop and renders the existing timestamp line when the message is the conversation's last one, was sent by the current user, has status `sent`, and `useReadReceipt` reports no read yet.

Notes:
- Non-gold users never receive read receipts, so their last sent message keeps showing `Delivered <time>` with the `Get read receipts` upsell below it. That reads correctly — delivered and read are different facts — but it is a new two-line arrangement for them.
- Pressing the last sent bubble no longer toggles its timestamp off, since the line is shown unconditionally there.
- Not verified in the running app: the local backend stack was down, so this is typechecked only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)