### PR TITLE
Match photo crops on edges so detail and mattes stop being rejected

### DIFF
--- a/backend/duophoto/__init__.py
+++ b/backend/duophoto/__init__.py
@@ -53,28 +53,60 @@ def photo_geometry_params(geometry: PhotoGeometry) -> dict[str, int]:
 
 # Progressively finer widths (px) for `find_crop`: a coarse scan of the whole
 # range, then narrow windows around the previous winner, so the cost stays flat
-# as the photo gets bigger.
+# as the photo gets bigger. Capped at the square's own resolution in
+# `find_crop`: comparing above it compares interpolation rather than content.
 MATCH_SCALES = (64, 256, 1024)
 
-# Mean per-pixel difference (0-255) above which `find_crop`'s best offset isn't
-# believable. Callers that act on the result should treat anything worse as "no
-# match" rather than record a crop that would make the photo jump when
-# expanded.
-DEFAULT_MAX_MATCH_DIFFERENCE = 24.0
+# Mismatch (0-100, an anti-correlation) above which `find_crop`'s best offset
+# isn't believable. Callers that act on the result should treat anything worse
+# as "no match" rather than record a crop that would make the photo jump when
+# expanded. Over 130 photos the backfill had skipped, correct offsets scored a
+# median of 17 and never worse than 75; a square belonging to a different photo
+# never scored better than 81, so the two populations don't overlap.
+DEFAULT_MAX_MATCH_DIFFERENCE = 75.0
 
 def _greyscale(image: Image.Image, size: tuple[int, int]) -> numpy.ndarray:
     resized = image.convert('L').resize(size, Image.Resampling.BILINEAR)
     return numpy.asarray(resized, dtype=numpy.float32)
 
-# A transparent upload's renditions can disagree about the matte: the pipeline
-# flattened alpha onto white for some renditions and black for others. Pixel
-# pairs at opposite extremes are the matte disagreeing, not the photo, so they
-# don't count towards the difference; `MIN_COMPARABLE_FRACTION` stops a window
-# with almost no photo in it from being judged on the scraps that remain.
-MATTE_LOW = 15.0
-MATTE_HIGH = 240.0
-MIN_COMPARABLE_FRACTION = 0.25
+# Renditions of the same photo agree about where its edges are and disagree
+# about almost everything else. Brightness drifts between encodes; a transparent
+# upload's renditions were flattened onto whatever colour happened to sit under
+# the alpha, so the same frame comes back white in one and black, grey or orange
+# in another. Matching edges rather than pixels sidesteps all of it: a flat matte
+# has no edges to contribute whatever its colour, and the subject's silhouette
+# against it is an edge in both.
+#
+# Sobel rather than a bare difference of neighbours: the smoothing the operator
+# carries is what keeps JPEG ringing and single-pixel texture - which the two
+# renditions were never going to agree about - from swamping the real edges.
+def _blur(pixels: numpy.ndarray, axis: int) -> numpy.ndarray:
+    shifted = numpy.moveaxis(pixels, axis, 0)
+    blurred = shifted.copy()
+    blurred[1:-1] = (shifted[:-2] + 2 * shifted[1:-1] + shifted[2:]) / 4.0
 
+    return numpy.moveaxis(blurred, 0, axis)
+
+def _slope(pixels: numpy.ndarray, axis: int) -> numpy.ndarray:
+    shifted = numpy.moveaxis(pixels, axis, 0)
+    sloped = numpy.zeros_like(shifted)
+    sloped[1:-1] = shifted[2:] - shifted[:-2]
+
+    return numpy.moveaxis(sloped, 0, axis)
+
+def _edges(pixels: numpy.ndarray) -> numpy.ndarray:
+    return numpy.hypot(
+        _slope(_blur(pixels, axis=0), axis=1),
+        _slope(_blur(pixels, axis=1), axis=0),
+    )
+
+# Correlation rather than a mean absolute difference, because the two renditions
+# are never the same picture pixel for pixel: the square has been through a
+# smaller JPEG, so its edges are softer and shorter than the original's even
+# where they're in exactly the right place. An absolute difference reads that
+# softening as disagreement and grows with the resolution it's measured at,
+# which made the score depend on how big the photo was rather than on whether
+# the crop was right. Both arguments are `_edges` output.
 def _difference(
     original: numpy.ndarray,
     square: numpy.ndarray,
@@ -92,17 +124,17 @@ def _difference(
     if window.shape != square.shape:
         return None
 
-    inverted_matte = (
-        ((window >= MATTE_HIGH) & (square <= MATTE_LOW))
-        | ((window <= MATTE_LOW) & (square >= MATTE_HIGH))
-    )
+    ours = window - window.mean()
+    theirs = square - square.mean()
 
-    comparable = ~inverted_matte
+    norm = numpy.sqrt(float((ours * ours).sum()) * float((theirs * theirs).sum()))
 
-    if float(comparable.mean()) < MIN_COMPARABLE_FRACTION:
+    # One of the two is a flat expanse with no edges at all, so there's nothing
+    # to line up and no offset is more believable than any other.
+    if norm <= 0.0:
         return None
 
-    return float(numpy.abs(window - square)[comparable].mean())
+    return (1.0 - float((ours * theirs).sum()) / norm) * 100.0
 
 # The scan quantises offsets to the match resolution, so above the finest
 # `MATCH_SCALES` entry the winner is only exact to `1 / scale` original px.
@@ -173,7 +205,7 @@ def find_crop(
     best_difference = float('inf')
 
     for scale_size in MATCH_SCALES:
-        size = min(scale_size, min_dim)
+        size = min(scale_size, min_dim, min(square.size))
         scale = size / min_dim
 
         scaled = (
@@ -181,8 +213,8 @@ def find_crop(
             max(size, round(height * scale)),
         )
 
-        original_pixels = _greyscale(original, scaled)
-        square_pixels = _greyscale(square, (size, size))
+        original_pixels = _edges(_greyscale(original, scaled))
+        square_pixels = _edges(_greyscale(square, (size, size)))
 
         limit = (scaled[0] if horizontal else scaled[1]) - size
 

--- a/backend/duophoto/fixtures.py
+++ b/backend/duophoto/fixtures.py
@@ -20,6 +20,24 @@ def photo(width: int, height: int, seed: int) -> Image.Image:
 
     return image
 
+# Fine detail rather than broad shapes: hair, foliage, fabric weave. The 450
+# square can't hold it, so the two renditions of the same frame genuinely differ
+# pixel for pixel however well the crop is aligned.
+def detailed_photo(width: int, height: int, seed: int) -> Image.Image:
+    rng = random.Random(seed)
+    image = photo(width, height, seed)
+    draw = ImageDraw.Draw(image)
+
+    for _ in range(45000):
+        x, y = rng.randint(0, width), rng.randint(0, height)
+        draw.line(
+            [x, y, x + rng.randint(-14, 14), y + rng.randint(-14, 14)],
+            fill=(rng.randint(0, 255), rng.randint(0, 255), rng.randint(0, 255)),
+            width=2,
+        )
+
+    return image
+
 def jpeg(image: Image.Image) -> bytes:
     buffer = io.BytesIO()
     image.save(buffer, format='jpeg', quality=85, subsampling=2)
@@ -64,18 +82,22 @@ def flatten(image: Image.Image, matte: tuple[int, int, int]) -> Image.Image:
     return canvas
 
 # Renditions as the historical pipeline left them for transparent uploads: the
-# original matted onto one colour, the square crop onto another.
+# original matted onto one colour, the square crop onto another. The colours
+# aren't fixed in prod - whatever RGB sat under the alpha channel is what the
+# rendition kept - so they're a parameter here too.
 def mismatched_matte_renditions(
     original: Image.Image,
     crop_left: int,
     crop_top: int,
+    original_matte: tuple[int, int, int] = (255, 255, 255),
+    square_matte: tuple[int, int, int] = (0, 0, 0),
 ) -> tuple[bytes, bytes]:
     min_dim = min(original.size)
-    square = flatten(original, (0, 0, 0)).crop((
+    square = flatten(original, square_matte).crop((
         crop_left,
         crop_top,
         crop_left + min_dim,
         crop_top + min_dim,
     )).resize((450, 450))
 
-    return jpeg(flatten(original, (255, 255, 255))), jpeg(square)
+    return jpeg(flatten(original, original_matte)), jpeg(square)

--- a/backend/duophoto/test_init.py
+++ b/backend/duophoto/test_init.py
@@ -7,6 +7,7 @@ from duophoto import (
     photo_geometry,
 )
 from duophoto.fixtures import (
+    detailed_photo,
     flatten,
     jpeg,
     mismatched_matte_renditions,
@@ -128,6 +129,22 @@ class TestFindCrop(unittest.TestCase):
             self.TOLERANCE_PX,
         )
 
+    def test_accepts_a_detailed_photo_the_square_cannot_hold(self) -> None:
+        # The square is 450px, so a finely textured photo's renditions can't
+        # agree pixel for pixel however well the crop lines up: one is sharp
+        # and the other has been through a smaller JPEG. Scoring that as
+        # disagreement rejected photos for being detailed.
+        original = detailed_photo(800, 1200, seed=11)
+        original_bytes, square_bytes = renditions(original, 0, 250)
+
+        geometry, difference = find_crop(
+            _image(original_bytes),
+            _image(square_bytes),
+        )
+
+        self.assertLessEqual(abs(geometry.crop_top - 250), self.TOLERANCE_PX)
+        self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
+
     def test_reports_a_bad_match_rather_than_guessing(self) -> None:
         # A square that isn't from this photo at all. The reported difference
         # is what stops the backfill recording a crop that would make the
@@ -156,6 +173,57 @@ class TestFindCropWithMismatchedMattes(unittest.TestCase):
         )
 
         self.assertLessEqual(abs(geometry.crop_top - 250), TestFindCrop.TOLERANCE_PX)
+        self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
+
+    def test_recovers_a_crop_whatever_colours_the_mattes_are(self) -> None:
+        # Nothing chose these colours: an alpha-0 pixel keeps whatever RGB the
+        # upload happened to store under it, so the matte comes back grey,
+        # orange or green as readily as white. Matching can't be told which
+        # colours to expect.
+        for original_matte in [
+            (127, 127, 127),
+            (244, 172, 78),
+            (25, 238, 25),
+            (255, 255, 255),
+        ]:
+            with self.subTest(matte=original_matte):
+                original = transparent_photo(800, 1200, seed=6)
+                original_bytes, square_bytes = mismatched_matte_renditions(
+                    original,
+                    crop_left=0,
+                    crop_top=250,
+                    original_matte=original_matte,
+                    square_matte=(0, 0, 0),
+                )
+
+                geometry, difference = find_crop(
+                    _image(original_bytes),
+                    _image(square_bytes),
+                )
+
+                self.assertLessEqual(
+                    abs(geometry.crop_top - 250),
+                    TestFindCrop.TOLERANCE_PX,
+                )
+                self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
+
+    def test_recovers_a_crop_of_a_photo_that_is_mostly_matte(self) -> None:
+        # A small subject on a big transparent canvas: most of the frame is
+        # matte, so judging the match on the pixels the mattes agree about
+        # leaves too few to judge on and the crop was abandoned.
+        original = Image.new('RGBA', (900, 1400), (0, 0, 0, 0))
+        original.paste(transparent_photo(300, 300, seed=7), (300, 700))
+
+        original_bytes, square_bytes = mismatched_matte_renditions(
+            original, crop_left=0, crop_top=420,
+        )
+
+        geometry, difference = find_crop(
+            _image(original_bytes),
+            _image(square_bytes),
+        )
+
+        self.assertLessEqual(abs(geometry.crop_top - 420), TestFindCrop.TOLERANCE_PX)
         self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
 
     def test_still_rejects_an_unrelated_pair_with_mismatched_mattes(self) -> None:


### PR DESCRIPTION
#1335 fixed one shape of this and the backfill still skips a large backlog. Sampling 130 of the photos from the latest run and re-running them locally, **129 have a correct crop that the matcher already finds** — `find_crop` locates the right offset and the score condemns it. Two separate defects do that.

## The score was measured at a resolution the square doesn't have

`find_crop` returns the difference from the finest `MATCH_SCALES` entry (1024px), a scale that exists for offset *precision*. The square rendition is 450px, so above that we compare the original's real detail against the square's upsampled blur. The number then tracks how big and sharp the photo is rather than whether the crop is right — at the *same, correct* offset:

| photo | 64px | 256px | 1024px |
|---|---|---|---|
| `5a5e9578` (960×1280) | 4.5 | 2.9 | **90.9** |
| `44c516e8` (746×582) | 6.8 | 3.0 | **72.7** |
| `0f1627fa` (588×755) | 1.3 | 4.0 | **40.8** |
| `ed0fd2b1` (900×1323) | 1.1 | 3.0 | **24.0** |

These are not near-misses: correlation between the crop and the square is 0.998–0.9995 and the means agree to a tenth of a grey level. It bites hardest when `min(width, height)` lands between 450 and ~1024, where the original isn't downscaled at all and only the square gets stretched. On synthetic ground truth it rejects **20 of 120** ordinary, correctly-matched crops.

## The matte isn't white

#1335 assumed transparent uploads come back white-against-black. Nothing chooses that colour — an alpha-0 pixel keeps whatever RGB was stored under it — so in prod, sampling the original underneath the square's matte:

| photo | matte in `original-` | | photo | matte in `original-` |
|---|---|---|---|---|
| `2f881dfc` | grey `(128,128,127)` | | `074e6a2e` | orange `(244,172,78)` |
| `e5e413bd` | green `(25,238,25)` | | `429891dc` | pale blue `(220,237,244)` |

The white/black mask doesn't touch any of them. And where the matte does happen to be white but covers more than 75% of the frame, `MIN_COMPARABLE_FRACTION` discards the window as unjudgeable — that's every `(inf)` line in the report.

## The fix

Match normalised **edges** rather than raw pixels, and score with a correlation rather than a mean absolute difference. This drops the matte special-case entirely instead of extending it:

- a flat matte contributes no edges whatever its colour, so the two renditions can disagree about it freely;
- the subject's silhouette against the matte is a strong edge in *both*, so it helps rather than hurts;
- a correlation doesn't penalise the square for being softer than the original, so the score stops depending on resolution;
- Sobel's built-in smoothing keeps JPEG ringing and pixel-scale texture from swamping real edges (it moved the real-photo median from 16.7 to 8.7 and cost nothing at the rejection end).

`MATCH_SCALES` is also capped at the square's own resolution, so we never compare interpolation against content again.

## Results

Across the 130 sampled photos (30 + an independent 100):

| | recovered | median score | worst accepted |
|---|---|---|---|
| before | 0/130 | — | — |
| after | **129/130** | 17 | 74.4 |

Every accepted offset was checked independently — comparing the crop at the claimed offset against the square on the pixels the square says are photo, versus every other offset. **0 of 129 was beaten by a different offset.**

Mismatched pairs (an original against 200 other photos' squares) never scored better than **85.3**, against a threshold of 75 and a worst real match of 74.4 — the populations don't overlap. The one holdout, `0248d507`, is 250×256: its span is 6px, so the crop is very nearly the whole photo either way.

Synthetic ground truth (600 cases, crop cut at a known offset, four matte colours): offset error median 0px, p90 1px; **0 rejected**, versus 20/120 (clean), 34/120 (white matte) and 120/120 (grey and orange mattes) before.

## Tests

Three new tests, each failing on `main` and passing here — one per root cause: a detailed photo the 450 square can't hold, mattes in four colours, and a photo that's mostly matte. The 15 existing tests, including #1335's, pass unchanged. `service/cron/photocrop/test_init.py` couldn't run locally (`psycopg_pool` isn't installed in this environment) — that's pre-existing and unrelated to the change, and it doesn't touch the threshold.

After deploying, the skipped photos can be requeued as before:

```sql
update photo set crop_attempted_at = null where width is null;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)