### PR TITLE
Stop losing sharply peaked crop matches, and near-square ones

### DIFF
--- a/backend/duophoto/__init__.py
+++ b/backend/duophoto/__init__.py
@@ -53,28 +53,60 @@ def photo_geometry_params(geometry: PhotoGeometry) -> dict[str, int]:
 
 # Progressively finer widths (px) for `find_crop`: a coarse scan of the whole
 # range, then narrow windows around the previous winner, so the cost stays flat
-# as the photo gets bigger.
+# as the photo gets bigger. Capped at the square's own resolution in
+# `find_crop`: comparing above it compares interpolation rather than content.
 MATCH_SCALES = (64, 256, 1024)
 
-# Mean per-pixel difference (0-255) above which `find_crop`'s best offset isn't
-# believable. Callers that act on the result should treat anything worse as "no
-# match" rather than record a crop that would make the photo jump when
-# expanded.
-DEFAULT_MAX_MATCH_DIFFERENCE = 24.0
+# Mismatch (0-100, an anti-correlation) above which `find_crop`'s best offset
+# isn't believable. Callers that act on the result should treat anything worse
+# as "no match" rather than record a crop that would make the photo jump when
+# expanded. Over 130 photos the backfill had skipped, correct offsets scored a
+# median of 17 and never worse than 75; a square belonging to a different photo
+# never scored better than 81, so the two populations don't overlap.
+DEFAULT_MAX_MATCH_DIFFERENCE = 75.0
 
 def _greyscale(image: Image.Image, size: tuple[int, int]) -> numpy.ndarray:
     resized = image.convert('L').resize(size, Image.Resampling.BILINEAR)
     return numpy.asarray(resized, dtype=numpy.float32)
 
-# A transparent upload's renditions can disagree about the matte: the pipeline
-# flattened alpha onto white for some renditions and black for others. Pixel
-# pairs at opposite extremes are the matte disagreeing, not the photo, so they
-# don't count towards the difference; `MIN_COMPARABLE_FRACTION` stops a window
-# with almost no photo in it from being judged on the scraps that remain.
-MATTE_LOW = 15.0
-MATTE_HIGH = 240.0
-MIN_COMPARABLE_FRACTION = 0.25
+# Renditions of the same photo agree about where its edges are and disagree
+# about almost everything else. Brightness drifts between encodes; a transparent
+# upload's renditions were flattened onto whatever colour happened to sit under
+# the alpha, so the same frame comes back white in one and black, grey or orange
+# in another. Matching edges rather than pixels sidesteps all of it: a flat matte
+# has no edges to contribute whatever its colour, and the subject's silhouette
+# against it is an edge in both.
+#
+# Sobel rather than a bare difference of neighbours: the smoothing the operator
+# carries is what keeps JPEG ringing and single-pixel texture - which the two
+# renditions were never going to agree about - from swamping the real edges.
+def _blur(pixels: numpy.ndarray, axis: int) -> numpy.ndarray:
+    shifted = numpy.moveaxis(pixels, axis, 0)
+    blurred = shifted.copy()
+    blurred[1:-1] = (shifted[:-2] + 2 * shifted[1:-1] + shifted[2:]) / 4.0
 
+    return numpy.moveaxis(blurred, 0, axis)
+
+def _slope(pixels: numpy.ndarray, axis: int) -> numpy.ndarray:
+    shifted = numpy.moveaxis(pixels, axis, 0)
+    sloped = numpy.zeros_like(shifted)
+    sloped[1:-1] = shifted[2:] - shifted[:-2]
+
+    return numpy.moveaxis(sloped, 0, axis)
+
+def _edges(pixels: numpy.ndarray) -> numpy.ndarray:
+    return numpy.hypot(
+        _slope(_blur(pixels, axis=0), axis=1),
+        _slope(_blur(pixels, axis=1), axis=0),
+    )
+
+# Correlation rather than a mean absolute difference, because the two renditions
+# are never the same picture pixel for pixel: the square has been through a
+# smaller JPEG, so its edges are softer and shorter than the original's even
+# where they're in exactly the right place. An absolute difference reads that
+# softening as disagreement and grows with the resolution it's measured at,
+# which made the score depend on how big the photo was rather than on whether
+# the crop was right. Both arguments are `_edges` output.
 def _difference(
     original: numpy.ndarray,
     square: numpy.ndarray,
@@ -92,17 +124,17 @@ def _difference(
     if window.shape != square.shape:
         return None
 
-    inverted_matte = (
-        ((window >= MATTE_HIGH) & (square <= MATTE_LOW))
-        | ((window <= MATTE_LOW) & (square >= MATTE_HIGH))
-    )
+    ours = window - window.mean()
+    theirs = square - square.mean()
 
-    comparable = ~inverted_matte
+    norm = numpy.sqrt(float((ours * ours).sum()) * float((theirs * theirs).sum()))
 
-    if float(comparable.mean()) < MIN_COMPARABLE_FRACTION:
+    # One of the two is a flat expanse with no edges at all, so there's nothing
+    # to line up and no offset is more believable than any other.
+    if norm <= 0.0:
         return None
 
-    return float(numpy.abs(window - square)[comparable].mean())
+    return (1.0 - float((ours * theirs).sum()) / norm) * 100.0
 
 # The scan quantises offsets to the match resolution, so above the finest
 # `MATCH_SCALES` entry the winner is only exact to `1 / scale` original px.
@@ -173,7 +205,7 @@ def find_crop(
     best_difference = float('inf')
 
     for scale_size in MATCH_SCALES:
-        size = min(scale_size, min_dim)
+        size = min(scale_size, min_dim, min(square.size))
         scale = size / min_dim
 
         scaled = (
@@ -181,8 +213,8 @@ def find_crop(
             max(size, round(height * scale)),
         )
 
-        original_pixels = _greyscale(original, scaled)
-        square_pixels = _greyscale(square, (size, size))
+        original_pixels = _edges(_greyscale(original, scaled))
+        square_pixels = _edges(_greyscale(square, (size, size)))
 
         limit = (scaled[0] if horizontal else scaled[1]) - size
 

--- a/backend/duophoto/__init__.py
+++ b/backend/duophoto/__init__.py
@@ -61,9 +61,39 @@ MATCH_SCALES = (64, 256, 1024)
 # isn't believable. Callers that act on the result should treat anything worse
 # as "no match" rather than record a crop that would make the photo jump when
 # expanded. Over 130 photos the backfill had skipped, correct offsets scored a
-# median of 17 and never worse than 75; a square belonging to a different photo
-# never scored better than 81, so the two populations don't overlap.
+# median of 17 and never worse than 75; across 680 pairings of an original with
+# a different photo's square, nothing scored better than 80.
 DEFAULT_MAX_MATCH_DIFFERENCE = 75.0
+
+# How far the square can slide, as a fraction of the frame, before which offset
+# we pick starts to matter. A photo 520px on its short side and 521 on its long
+# one has exactly two candidate crops one pixel apart: there is no answer that
+# would make it jump, so there's nothing for a match score to protect against.
+# Demanding a convincing match there just rejects photos whose crop was never in
+# question - and a near-square photo is where the matcher has the least to go on,
+# because every candidate window looks like every other.
+#
+# This is the one path that records a crop nothing confirmed, so what it costs
+# is worth stating: the recorded offset can be wrong by the whole span, and the
+# span is what this bounds. At a twentieth, the worst a photo can do on expand
+# is shift by a twentieth of its frame - against not animating at all, which is
+# what these photos do today.
+NEGLIGIBLE_SPAN_FRACTION = 0.05
+
+# The single place that decides whether a recovered crop is worth recording, so
+# the backfill can't drift from what the tests pin down.
+def is_crop_believable(
+    geometry: PhotoGeometry,
+    difference: float,
+    max_difference: float = DEFAULT_MAX_MATCH_DIFFERENCE,
+) -> bool:
+    shorter = min(geometry.width, geometry.height)
+    span = max(geometry.width, geometry.height) - shorter
+
+    return (
+        difference <= max_difference
+        or span <= NEGLIGIBLE_SPAN_FRACTION * shorter
+    )
 
 def _greyscale(image: Image.Image, size: tuple[int, int]) -> numpy.ndarray:
     resized = image.convert('L').resize(size, Image.Resampling.BILINEAR)
@@ -236,10 +266,14 @@ def find_crop(
                 best_offset = offset
                 best_difference = difference
 
-        lo = max(0, best_offset - stride)
-        hi = min(span, best_offset + stride)
+        # Two strides rather than one: a coarse scan can only place the winner
+        # to within a stride, so a window of exactly one stride can sit just
+        # off a sharply peaked minimum and the next scale, searching only
+        # inside it, never gets back to the real one.
+        lo = max(0, best_offset - 2 * stride)
+        hi = min(span, best_offset + 2 * stride)
 
-    best_offset = _refined_offset(
+    refined = _refined_offset(
         original_pixels,
         square_pixels,
         scale,
@@ -249,4 +283,18 @@ def find_crop(
         span,
     )
 
-    return geometry_at(best_offset), best_difference
+    # Score the offset actually being returned. Refinement moves it after the
+    # scan recorded its difference, and on a sharply peaked match the two can
+    # disagree wildly - which is a photo skipped over a number describing an
+    # offset nobody is proposing.
+    refined_difference = _difference(
+        original_pixels,
+        square_pixels,
+        min(limit, max(0, round(refined * scale))),
+        horizontal,
+    )
+
+    if refined_difference is None or refined_difference > best_difference:
+        return geometry_at(best_offset), best_difference
+
+    return geometry_at(refined), refined_difference

--- a/backend/duophoto/fixtures.py
+++ b/backend/duophoto/fixtures.py
@@ -20,6 +20,24 @@ def photo(width: int, height: int, seed: int) -> Image.Image:
 
     return image
 
+# Fine detail rather than broad shapes: hair, foliage, fabric weave. The 450
+# square can't hold it, so the two renditions of the same frame genuinely differ
+# pixel for pixel however well the crop is aligned.
+def detailed_photo(width: int, height: int, seed: int) -> Image.Image:
+    rng = random.Random(seed)
+    image = photo(width, height, seed)
+    draw = ImageDraw.Draw(image)
+
+    for _ in range(45000):
+        x, y = rng.randint(0, width), rng.randint(0, height)
+        draw.line(
+            [x, y, x + rng.randint(-14, 14), y + rng.randint(-14, 14)],
+            fill=(rng.randint(0, 255), rng.randint(0, 255), rng.randint(0, 255)),
+            width=2,
+        )
+
+    return image
+
 def jpeg(image: Image.Image) -> bytes:
     buffer = io.BytesIO()
     image.save(buffer, format='jpeg', quality=85, subsampling=2)
@@ -64,18 +82,22 @@ def flatten(image: Image.Image, matte: tuple[int, int, int]) -> Image.Image:
     return canvas
 
 # Renditions as the historical pipeline left them for transparent uploads: the
-# original matted onto one colour, the square crop onto another.
+# original matted onto one colour, the square crop onto another. The colours
+# aren't fixed in prod - whatever RGB sat under the alpha channel is what the
+# rendition kept - so they're a parameter here too.
 def mismatched_matte_renditions(
     original: Image.Image,
     crop_left: int,
     crop_top: int,
+    original_matte: tuple[int, int, int] = (255, 255, 255),
+    square_matte: tuple[int, int, int] = (0, 0, 0),
 ) -> tuple[bytes, bytes]:
     min_dim = min(original.size)
-    square = flatten(original, (0, 0, 0)).crop((
+    square = flatten(original, square_matte).crop((
         crop_left,
         crop_top,
         crop_left + min_dim,
         crop_top + min_dim,
     )).resize((450, 450))
 
-    return jpeg(flatten(original, (255, 255, 255))), jpeg(square)
+    return jpeg(flatten(original, original_matte)), jpeg(square)

--- a/backend/duophoto/fixtures.py
+++ b/backend/duophoto/fixtures.py
@@ -38,6 +38,29 @@ def detailed_photo(width: int, height: int, seed: int) -> Image.Image:
 
     return image
 
+# Brickwork, blinds, a knitted jumper. A repeating pattern makes the match fall
+# away steeply either side of the true offset, so a coarse scan lands near it
+# rather than on it and the finer scans have to be able to walk back.
+def patterned_photo(width: int, height: int, seed: int) -> Image.Image:
+    rng = random.Random(seed)
+    image = photo(width, height, seed)
+    draw = ImageDraw.Draw(image)
+
+    for y in range(0, height, 4):
+        draw.line([0, y, width, y], fill=(240, 240, 240), width=1)
+
+    for x in range(0, width, 4):
+        draw.line([x, 0, x, height], fill=(20, 20, 20), width=1)
+
+    for _ in range(400):
+        x, y = rng.randint(0, width), rng.randint(0, height)
+        draw.ellipse(
+            [x, y, x + rng.randint(4, 20), y + rng.randint(4, 20)],
+            fill=(rng.randint(0, 255), rng.randint(0, 255), rng.randint(0, 255)),
+        )
+
+    return image
+
 def jpeg(image: Image.Image) -> bytes:
     buffer = io.BytesIO()
     image.save(buffer, format='jpeg', quality=85, subsampling=2)

--- a/backend/duophoto/test_init.py
+++ b/backend/duophoto/test_init.py
@@ -7,6 +7,7 @@ from duophoto import (
     photo_geometry,
 )
 from duophoto.fixtures import (
+    detailed_photo,
     flatten,
     jpeg,
     mismatched_matte_renditions,
@@ -128,6 +129,22 @@ class TestFindCrop(unittest.TestCase):
             self.TOLERANCE_PX,
         )
 
+    def test_accepts_a_detailed_photo_the_square_cannot_hold(self) -> None:
+        # The square is 450px, so a finely textured photo's renditions can't
+        # agree pixel for pixel however well the crop lines up: one is sharp
+        # and the other has been through a smaller JPEG. Scoring that as
+        # disagreement rejected photos for being detailed.
+        original = detailed_photo(800, 1200, seed=11)
+        original_bytes, square_bytes = renditions(original, 0, 250)
+
+        geometry, difference = find_crop(
+            _image(original_bytes),
+            _image(square_bytes),
+        )
+
+        self.assertLessEqual(abs(geometry.crop_top - 250), self.TOLERANCE_PX)
+        self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
+
     def test_reports_a_bad_match_rather_than_guessing(self) -> None:
         # A square that isn't from this photo at all. The reported difference
         # is what stops the backfill recording a crop that would make the
@@ -156,6 +173,57 @@ class TestFindCropWithMismatchedMattes(unittest.TestCase):
         )
 
         self.assertLessEqual(abs(geometry.crop_top - 250), TestFindCrop.TOLERANCE_PX)
+        self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
+
+    def test_recovers_a_crop_whatever_colours_the_mattes_are(self) -> None:
+        # Nothing chose these colours: an alpha-0 pixel keeps whatever RGB the
+        # upload happened to store under it, so the matte comes back grey,
+        # orange or green as readily as white. Matching can't be told which
+        # colours to expect.
+        for original_matte in [
+            (127, 127, 127),
+            (244, 172, 78),
+            (25, 238, 25),
+            (255, 255, 255),
+        ]:
+            with self.subTest(matte=original_matte):
+                original = transparent_photo(800, 1200, seed=6)
+                original_bytes, square_bytes = mismatched_matte_renditions(
+                    original,
+                    crop_left=0,
+                    crop_top=250,
+                    original_matte=original_matte,
+                    square_matte=(0, 0, 0),
+                )
+
+                geometry, difference = find_crop(
+                    _image(original_bytes),
+                    _image(square_bytes),
+                )
+
+                self.assertLessEqual(
+                    abs(geometry.crop_top - 250),
+                    TestFindCrop.TOLERANCE_PX,
+                )
+                self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
+
+    def test_recovers_a_crop_of_a_photo_that_is_mostly_matte(self) -> None:
+        # A small subject on a big transparent canvas: most of the frame is
+        # matte, so judging the match on the pixels the mattes agree about
+        # leaves too few to judge on and the crop was abandoned.
+        original = Image.new('RGBA', (900, 1400), (0, 0, 0, 0))
+        original.paste(transparent_photo(300, 300, seed=7), (300, 700))
+
+        original_bytes, square_bytes = mismatched_matte_renditions(
+            original, crop_left=0, crop_top=420,
+        )
+
+        geometry, difference = find_crop(
+            _image(original_bytes),
+            _image(square_bytes),
+        )
+
+        self.assertLessEqual(abs(geometry.crop_top - 420), TestFindCrop.TOLERANCE_PX)
         self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
 
     def test_still_rejects_an_unrelated_pair_with_mismatched_mattes(self) -> None:

--- a/backend/duophoto/test_init.py
+++ b/backend/duophoto/test_init.py
@@ -3,6 +3,7 @@ from duophoto import (
     CropSize,
     PhotoGeometry,
     find_crop,
+    is_crop_believable,
     orient_image,
     photo_geometry,
 )
@@ -11,6 +12,7 @@ from duophoto.fixtures import (
     flatten,
     jpeg,
     mismatched_matte_renditions,
+    patterned_photo,
     photo,
     renditions,
     transparent_photo,
@@ -145,6 +147,51 @@ class TestFindCrop(unittest.TestCase):
         self.assertLessEqual(abs(geometry.crop_top - 250), self.TOLERANCE_PX)
         self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
 
+    def test_recovers_a_crop_whose_match_falls_away_steeply(self) -> None:
+        # A repeating pattern makes the difference spike a pixel either side of
+        # the truth. The coarse scan lands near the answer rather than on it,
+        # and a search window of one stride could sit just off the real minimum
+        # with no way back - leaving a photo skipped, at an offset whose score
+        # described somewhere else entirely.
+        original = patterned_photo(1200, 1448, seed=13)
+        original_bytes, square_bytes = renditions(original, 0, 246)
+
+        geometry, difference = find_crop(
+            _image(original_bytes),
+            _image(square_bytes),
+        )
+
+        # Looser than TOLERANCE_PX: at this pattern's period neighbouring
+        # offsets really are near-indistinguishable, which is the point.
+        self.assertLessEqual(abs(geometry.crop_top - 246), 4)
+        self.assertLess(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
+
+    def test_scores_the_offset_it_actually_returns(self) -> None:
+        # Refinement moves the offset after the scan recorded its difference,
+        # so the two could describe different places. Re-cutting the square at
+        # the offset it returned has to reproduce the score it reported.
+        original = patterned_photo(1200, 1448, seed=14)
+        original_bytes, square_bytes = renditions(original, 0, 246)
+
+        geometry, difference = find_crop(
+            _image(original_bytes),
+            _image(square_bytes),
+        )
+
+        _, at_returned_offset = find_crop(
+            _image(original_bytes),
+            _image(jpeg(
+                original.crop((
+                    geometry.crop_left,
+                    geometry.crop_top,
+                    geometry.crop_left + 1200,
+                    geometry.crop_top + 1200,
+                )).resize((450, 450))
+            )),
+        )
+
+        self.assertAlmostEqual(difference, at_returned_offset, delta=5.0)
+
     def test_reports_a_bad_match_rather_than_guessing(self) -> None:
         # A square that isn't from this photo at all. The reported difference
         # is what stops the backfill recording a crop that would make the
@@ -155,6 +202,34 @@ class TestFindCrop(unittest.TestCase):
         _, difference = find_crop(original, unrelated)
 
         self.assertGreater(difference, DEFAULT_MAX_MATCH_DIFFERENCE)
+
+class TestIsCropBelievable(unittest.TestCase):
+    def test_trusts_a_convincing_match(self) -> None:
+        geometry = PhotoGeometry(width=1200, height=800, crop_top=0, crop_left=200)
+
+        self.assertTrue(is_crop_believable(geometry, 12.0))
+        self.assertFalse(is_crop_believable(geometry, 90.0))
+
+    def test_records_a_near_square_crop_the_matcher_cannot_confirm(self) -> None:
+        # 521 against 520: two candidate crops, one pixel apart. There is no
+        # answer here that would make the photo jump, so a weak score is not a
+        # reason to leave the photo without geometry - and a near-square photo
+        # is where the matcher has least to distinguish offsets by.
+        geometry = PhotoGeometry(width=520, height=521, crop_top=1, crop_left=0)
+
+        self.assertTrue(is_crop_believable(geometry, 90.0))
+
+    def test_still_demands_a_match_once_the_crop_can_move(self) -> None:
+        # A tenth of the frame is enough to put a different subject in it.
+        geometry = PhotoGeometry(width=1100, height=1000, crop_top=0, crop_left=50)
+
+        self.assertFalse(is_crop_believable(geometry, 90.0))
+
+    def test_takes_the_threshold_the_caller_configured(self) -> None:
+        geometry = PhotoGeometry(width=1200, height=800, crop_top=0, crop_left=200)
+
+        self.assertFalse(is_crop_believable(geometry, 40.0, max_difference=30.0))
+        self.assertTrue(is_crop_believable(geometry, 40.0, max_difference=50.0))
 
 class TestFindCropWithMismatchedMattes(unittest.TestCase):
     # The pipeline flattened transparent uploads onto white for the original

--- a/backend/service/cron/photocrop/__init__.py
+++ b/backend/service/cron/photocrop/__init__.py
@@ -3,6 +3,7 @@ from duophoto import (
     DEFAULT_MAX_MATCH_DIFFERENCE,
     PhotoGeometry,
     find_crop,
+    is_crop_believable,
     photo_geometry_params,
 )
 from service.cron.photocrop.sql import *
@@ -73,7 +74,7 @@ def _geometry_of(
         print(f'photocrop: {uuid} could not be matched:', e)
         return None
 
-    if difference > MAX_MATCH_DIFFERENCE:
+    if not is_crop_believable(geometry, difference, MAX_MATCH_DIFFERENCE):
         print(f'photocrop: {uuid} matched too poorly ({difference:.1f}); skipping')
         return None
 


### PR DESCRIPTION
Follow-up to #1368. I pulled the 22 photos from your log and split them by cause — the two categories are unrelated.

## The 15 "missing a rendition" ones aren't a matching problem

`original-` is **404 for all fifteen**. Nine have no renditions at all:

| photo | `original-` | `450-` | `900-` |
|---|---|---|---|
| `07032cc2`, `18e89c6d`, `55a06e1e` | 404 | 200 | 200 |
| `0146b06a`, `1c5f35e3` | 404 | 404 | 200 |
| `067b899c`, `09cdd396`, `3d2212a7`, `51c573a1`, `5774026b`, `7b0ea743`, `85b51b7a`, `9548f135`, `b1e6a0bb`, `c3b7b4d4` | 404 | 404 | 404 |

There is no original to find a crop inside, so no matcher change reaches these. They're already marked `crop_attempted_at` and drop out of the queue; they only reappear because the requeue SQL clears it. **I haven't changed anything here** — recording a fabricated geometry would be worse than recording none, and the rows with zero surviving renditions look like a data-cleanup question rather than a crop one. Flagging it for you rather than guessing.

## The 6 real match failures

Of these, **five had the correct offset already** — checked independently by comparing the crop at the claimed offset against the square, versus every other offset. Three fixes:

**1. The search window was one stride wide.** Between scales the search narrows to the winner ±1 stride, but a coarse scan can only place the winner *to within* a stride. On a photo whose match falls away steeply either side of the truth, the window sits just off the real minimum and the finer scans, searching only inside it, never get back. `daacfa40`: the true offset scored 0.75 at 64px and 0.94 at 192px, but the scan walked to 238 and reported **76.63**. Two strides: **1.83 at offset 248**.

**2. The returned score described a different offset than the returned geometry.** `_refined_offset` moves the offset *after* the scan recorded `best_difference`, and the two were never reconciled. On a sharp peak they disagree wildly — one pixel changed `daacfa40`'s score from 0.94 to 27.67 — so a good crop was skipped over a number nobody was proposing. Now the refined offset is re-scored, and whichever offset actually scores better is the one returned. (Pre-existing; #1368 didn't introduce it.)

**3. Near-square photos are judged on a crop that can't move.** `e9025599` is 520×521 — a span of **one pixel**, two candidate crops. There is no answer that would make it jump, so there's nothing for a match score to protect against; and it's precisely where the matcher has least to work with, because every candidate window looks like every other. `is_crop_believable` puts this next to the threshold so the backfill has one place to ask.

| photo | size | span | before | after |
|---|---|---|---|---|
| `daacfa40` | 1200×1448 | 248 | 76.6 @238 | **1.8 @248** |
| `e9025599` | 520×521 | 1 (0.2%) | 86.9 | **recorded — span rule** |
| `0248d507` | 250×256 | 6 (2.4%) | 80.5 | **recorded — span rule** |
| `c6fb19fb` | 750×650 | 100 | 76.5 @49 *(offset right)* | still skipped |
| `a4b8347d` | 127×147 | 20 | 86.7 | still skipped |
| `e3000946` | 300×472 | 172 | 107.5 | still skipped |

`c6fb19fb` is the frustrating one: its offset is correct and it scores 76.5 against a threshold of 75. I did **not** raise the threshold for it — across 680 pairings of an original with a different photo's square the lowest score is 80.1, so there are only five points of room and spending them on one photo isn't a trade worth making. `e3000946` scores 61 even under an independent measure; its square carries 2.5× the edge energy of its original, so the two renditions genuinely disagree.

## Results

Over the 136 real photos (the 130 from #1368 plus these 6): **133 record geometry, up from 130.**

| | accepted | via score | via span rule | rejected |
|---|---|---|---|---|
| real photos | 133/136 | 130 | 3 | 3 |
| mismatched pairs | 100/680 | **0** | 100 | 580 |

The score path stays perfectly clean — **no mismatched pair passes on score**. Every one of the 100 passes through the span rule, and there the cost is bounded by construction rather than by luck: the recorded offset can be wrong by at most the span, and the rule only fires when the span is under a twentieth of the frame (worst observed: 4.71%). Against those photos not animating at all today, that seemed the right side to err on — but it is a real trade and I'd rather you saw it stated than buried.

Widening the window also *improved* precision on synthetic ground truth (600 cases, four matte colours): worst offset error **9px, down from 31**; median 0, p90 1px, 0 rejected.

## Tests

Two new `find_crop` tests, both failing on #1368's code and passing here — a repeating-pattern photo whose match peak is sharp, and a check that re-cutting the square at the returned offset reproduces the returned score. Plus four for `is_crop_believable`. New `patterned_photo` fixture. All 24 pass; `service/cron/photocrop/test_init.py` still can't run locally (`psycopg_pool` missing) as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)