### PR TITLE
Show blurhashes and a spinner in the gallery on slow connections

### DIFF
--- a/frontend/components/enlargeable-image.tsx
+++ b/frontend/components/enlargeable-image.tsx
@@ -85,6 +85,7 @@ const EnlargeablePhoto = memo(({
           uuid: photoUuid,
           extraExts: photoExtraExts ?? [],
           geometry: photoGeometry ?? null,
+          blurhash: photoBlurhash ?? null,
         }];
 
     // Without a geometry there's nothing to uncrop the photo into, so the
@@ -117,7 +118,7 @@ const EnlargeablePhoto = memo(({
 
       navigation.navigate('Gallery Screen', { photoUuid });
     });
-  }, [photoUuid, photoExtraExts, photoGeometry, album, borderRadius, navigation]);
+  }, [photoUuid, photoExtraExts, photoBlurhash, photoGeometry, album, borderRadius, navigation]);
 
   const prefetchEnlargedImage = useCallback(() => {
     const enlargedUri = photoUri(photoUuid, 'original', photoExtraExts);

--- a/frontend/components/fill-image.tsx
+++ b/frontend/components/fill-image.tsx
@@ -6,15 +6,19 @@ import { Image as ExpoImage } from 'expo-image';
 // edge.
 const FillImage = ({
   uri,
+  blurhash,
   onLoad,
 }: {
   uri: string
+  blurhash?: string | null
   onLoad?: () => void
 }) => (
   <ExpoImage
     source={{ uri }}
     style={StyleSheet.absoluteFill}
     contentFit="fill"
+    placeholder={blurhash ? { blurhash } : undefined}
+    placeholderContentFit="fill"
     transition={0}
     cachePolicy="memory-disk"
     onLoad={onLoad}

--- a/frontend/components/gallery-screen.tsx
+++ b/frontend/components/gallery-screen.tsx
@@ -63,6 +63,7 @@ type Phase = 'opening' | 'open' | 'closing';
 const ExpandingPhoto = ({
   photoUuid,
   photoExtraExts,
+  photoBlurhash,
   morph,
   progress,
   container,
@@ -74,6 +75,7 @@ const ExpandingPhoto = ({
 }: {
   photoUuid: string,
   photoExtraExts: string[],
+  photoBlurhash: string | null,
   morph: ExpandedPhotoMorph,
   progress: SharedValue<number>,
   container: Rect,
@@ -160,6 +162,7 @@ const ExpandingPhoto = ({
         <Reanimated.View style={[styles.image, imageStyle]}>
           <FillImage
             uri={photoUri(photoUuid, 'original', photoExtraExts)}
+            blurhash={photoBlurhash}
             onLoad={onCovered}
           />
         </Reanimated.View>
@@ -177,6 +180,7 @@ const ExpandingPhoto = ({
       <Reanimated.View style={[styles.image, cropStyle]}>
         <FillImage
           uri={photoUri(photoUuid, 900)}
+          blurhash={photoBlurhash}
           onLoad={onCovered}
         />
       </Reanimated.View>
@@ -247,7 +251,7 @@ const GalleryScreen = ({
 
   const album: AlbumPhoto[] = useMemo(
     () => expandedPhoto?.album
-      ?? [{ uuid: photoUuid, extraExts: [], geometry: null }],
+      ?? [{ uuid: photoUuid, extraExts: [], geometry: null, blurhash: null }],
     [expandedPhoto, photoUuid],
   );
   const openedIndex = useMemo(
@@ -590,6 +594,7 @@ const GalleryScreen = ({
           <ExpandingPhoto
             photoUuid={photoUuid}
             photoExtraExts={album[openedIndex].extraExts}
+            photoBlurhash={album[openedIndex].blurhash}
             morph={morph}
             progress={progress}
             container={container}
@@ -611,7 +616,8 @@ const GalleryScreen = ({
                 <Pinchy
                   uuid={photo.uuid}
                   extraExts={photo.extraExts}
-                  naturalSize={photo.geometry ?? undefined}
+                  blurhash={photo.blurhash}
+                  geometry={photo.geometry ?? undefined}
                   zoom={i === index ? zoom : identityZoom}
                   dismiss={i === index ? dismiss : undefined}
                   onDismiss={i === index ? onDismiss : undefined}

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from 'react';
 import {
+  ActivityIndicator,
   Image,
   ImageStyle,
   StyleSheet,
@@ -28,6 +29,7 @@ import Animated, {
 import type { SharedValue } from 'react-native-reanimated';
 import { FillImage } from './fill-image';
 import { hasGifExtraExt, photoUri } from '../util/photos';
+import type { PhotoGeometry } from '../util/photos';
 import {
   constrainPosition,
   dragDismissRadius,
@@ -74,39 +76,76 @@ const fitWithin = (
   return { width, height };
 };
 
+// Where the square rendition sits within the fitted original, in the fitted
+// frame's pixels - the same placement the gallery's expanding photo gives its
+// crop layer.
+const cropRectWithin = (
+  geometry: PhotoGeometry,
+  imageWidth: number,
+): { left: number, top: number, width: number, height: number } => {
+  const scale = imageWidth / geometry.width;
+  const minDim = Math.min(geometry.width, geometry.height);
+  return {
+    left: geometry.crop_left * scale,
+    top: geometry.crop_top * scale,
+    width: minDim * scale,
+    height: minDim * scale,
+  };
+};
+
 const FitWithinScreenImage = ({
   source,
+  cropUri,
+  blurhash,
   isGif,
   animatedStyle,
   onUpdateImageSize,
-  naturalSize,
+  geometry,
   viewport,
 }: {
   source: { uri: string };
+  cropUri: string | null;
+  blurhash: string | null;
   isGif: boolean;
   animatedStyle: AnimatedStyle<ImageStyle>;
   onUpdateImageSize: (size: { imageWidth: number, imageHeight: number }) => void;
-  naturalSize?: { width: number, height: number };
+  geometry?: PhotoGeometry;
   viewport: { width: number, height: number };
 }) => {
   const isFetchingSize = useRef(false);
   const [imageSize, setImageSize] = useState(
-    naturalSize ?? {width: 0, height: 0},
+    geometry ?? {width: 0, height: 0},
   );
   const { width: viewportWidth, height: viewportHeight } = viewport;
 
   // Fit synchronously from the known size, so a photo the caller reports the
   // dimensions of paints on its first frame - no spinner flash when a new page
   // mounts.
-  const initialFit = naturalSize && naturalSize.width && naturalSize.height
-    ? fitWithin(naturalSize, viewportWidth, viewportHeight)
+  const initialFit = geometry && geometry.width && geometry.height
+    ? fitWithin(geometry, viewportWidth, viewportHeight)
     : null;
   const [imageWidth, setImageWidth] = useState<number | null>(initialFit?.width ?? null);
   const [imageHeight, setImageHeight] = useState<number | null>(initialFit?.height ?? null);
 
+  // On a slow connection the original can take long enough that a correctly
+  // sized but still-empty photo reads as broken; the spinner says it's
+  // loading. It waits out a grace period so a cache hit shows no spinner
+  // flash.
+  const [originalLoaded, setOriginalLoaded] = useState(false);
+  const [spinnerDelayElapsed, setSpinnerDelayElapsed] = useState(false);
+
+  const onOriginalLoad = useCallback(() => setOriginalLoaded(true), []);
+
   useEffect(() => {
-    if (naturalSize) {
-      setImageSize(naturalSize);
+    const timeout = setTimeout(() => setSpinnerDelayElapsed(true), 500);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  const showSpinner = spinnerDelayElapsed && !originalLoaded;
+
+  useEffect(() => {
+    if (geometry) {
+      setImageSize(geometry);
       return;
     }
 
@@ -119,7 +158,7 @@ const FitWithinScreenImage = ({
       setImageSize({width, height});
       isFetchingSize.current = false;
     });
-  }, [source.uri, naturalSize?.width, naturalSize?.height]);
+  }, [source.uri, geometry?.width, geometry?.height]);
 
   useEffect(() => {
     if (!imageSize.width || !imageSize.height) return;
@@ -138,6 +177,12 @@ const FitWithinScreenImage = ({
     viewportHeight
   ]);
 
+  const spinner = showSpinner && (
+    <View style={styles.spinnerOverlay} pointerEvents="none">
+      <ActivityIndicator size="large" color="white"/>
+    </View>
+  );
+
   if (imageWidth && imageHeight && isGif) {
     return (
       <Animated.View
@@ -146,18 +191,40 @@ const FitWithinScreenImage = ({
           { width: imageWidth, height: imageHeight, overflow: 'hidden' },
         ]}
       >
-        <FillImage uri={source.uri} />
+        <FillImage
+          uri={source.uri}
+          blurhash={blurhash}
+          onLoad={onOriginalLoad}
+        />
+        {spinner}
       </Animated.View>
     );
   }
 
   if (imageWidth && imageHeight) {
     return (
-      <Animated.Image
-        source={source}
-        style={[animatedStyle, { width: imageWidth, height: imageHeight }]}
-        resizeMode="contain"
-      />
+      <Animated.View
+        style={[
+          animatedStyle,
+          { width: imageWidth, height: imageHeight, overflow: 'hidden' },
+        ]}
+      >
+        {/*
+          The square rendition - usually cached from the profile - and its
+          blurhash under it, sitting exactly where the crop lines up within
+          the original, so there's a photo to show while the original
+          downloads. The original covers them when it arrives.
+        */}
+        {geometry && cropUri &&
+          <View
+            style={[styles.crop, cropRectWithin(geometry, imageWidth)]}
+          >
+            <FillImage uri={cropUri} blurhash={blurhash} />
+          </View>
+        }
+        <FillImage uri={source.uri} onLoad={onOriginalLoad} />
+        {spinner}
+      </Animated.View>
     );
   }
 
@@ -195,10 +262,11 @@ type PinchyPage = {
   justNavigated: SharedValue<boolean>
 };
 
-const Pinchy = ({uuid, extraExts, naturalSize, viewport, zoom, dismiss, onDismiss, page, onNavigate, onTapEdge, backgroundColor = 'black'}: {
+const Pinchy = ({uuid, extraExts, blurhash, geometry, viewport, zoom, dismiss, onDismiss, page, onNavigate, onTapEdge, backgroundColor = 'black'}: {
   uuid: string,
   extraExts: string[],
-  naturalSize?: { width: number, height: number },
+  blurhash?: string | null,
+  geometry?: PhotoGeometry,
   // The box to fit the photo within and centre it in.
   viewport: { width: number, height: number },
   zoom: PinchyZoom,
@@ -524,10 +592,12 @@ const Pinchy = ({uuid, extraExts, naturalSize, viewport, zoom, dismiss, onDismis
       <View style={[styles.container, { backgroundColor }]}>
         <FitWithinScreenImage
           source={{ uri: photoUri(uuid, 'original', extraExts) }}
+          cropUri={hasGifExtraExt(extraExts) ? null : photoUri(uuid, 900)}
+          blurhash={blurhash ?? null}
           isGif={hasGifExtraExt(extraExts)}
           animatedStyle={animatedStyle}
           onUpdateImageSize={onUpdateImageSize}
-          naturalSize={naturalSize}
+          geometry={geometry}
           viewport={{ width: viewportWidth, height: viewportHeight }}
         />
       </View>
@@ -545,6 +615,14 @@ const styles = StyleSheet.create({
     zIndex: 999,
     // @ts-ignore
     touchAction: 'none',
+  },
+  crop: {
+    position: 'absolute',
+  },
+  spinnerOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });
 

--- a/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
+++ b/frontend/components/prospect-profile-screen/prospect-profile-screen.tsx
@@ -101,11 +101,13 @@ const buildAlbum = (
   uuids: string[] | undefined,
   extraExts: string[][] | undefined,
   geometries: (PhotoGeometry | null)[] | undefined,
+  blurhashes: string[] | undefined,
 ): AlbumPhoto[] =>
   (uuids ?? []).map((uuid, i) => ({
     uuid,
     extraExts: extraExts?.[i] ?? [],
     geometry: geometries?.[i] ?? null,
+    blurhash: blurhashes?.[i] ?? null,
   }));
 
 const primaryPhotoBigScreenRadii = { bottomLeft: 12, bottomRight: 12 };
@@ -988,8 +990,14 @@ const CurriedContent = ({navigationRef, navigation, route}: ProspectScreenProps 
       data?.photo_uuids,
       data?.photo_extra_exts,
       data?.photo_geometries,
+      data?.photo_blurhashes,
     ),
-    [data?.photo_uuids, data?.photo_extra_exts, data?.photo_geometries],
+    [
+      data?.photo_uuids,
+      data?.photo_extra_exts,
+      data?.photo_geometries,
+      data?.photo_blurhashes,
+    ],
   );
 
   const photoUuid0 = (() => {
@@ -1357,8 +1365,14 @@ const Body = ({
       data?.photo_uuids,
       data?.photo_extra_exts,
       data?.photo_geometries,
+      data?.photo_blurhashes,
     ),
-    [data?.photo_uuids, data?.photo_extra_exts, data?.photo_geometries],
+    [
+      data?.photo_uuids,
+      data?.photo_extra_exts,
+      data?.photo_geometries,
+      data?.photo_blurhashes,
+    ],
   );
 
   const profilePhoto = (position: number) => (

--- a/frontend/events/expanded-photo.tsx
+++ b/frontend/events/expanded-photo.tsx
@@ -23,6 +23,7 @@ type AlbumPhoto = {
   uuid: string
   extraExts: string[]
   geometry: PhotoGeometry | null
+  blurhash: string | null
 };
 
 type ExpandedPhotoMorph = {


### PR DESCRIPTION
Fixes #1361.

## Problem

The gallery ([introduced in #1329](https://github.com/duolicious/duolicious/pull/1329)) opened onto a blank screen when a profile photo was tapped before its full-size renditions had loaded. Three failures stacked up:

- The open **morph animated nothing** — its layers drew the 900px and original renditions, neither of which was in cache.
- Its 250ms fallback timeout marked the preview `covered` anyway, which **hid the preview and its blurhash**, so the last visible pixels vanished.
- **Pinchy showed no spinner** — with geometry known it sized the image synchronously and skipped the loading branch, rendering a correctly-sized but empty image while a multi-megabyte original downloaded.

Drag-to-dismiss still worked on the blank screen, which is why dragging dimmed and brightened it.

## Fix

Emulate Instagram's progressive-enhancement model: always show the best available representation and enhance it in place.

- **Thread the blurhash through `AlbumPhoto`**, populated from the API's `photo_blurhashes` at every album-construction site, and paint it under every rendition the gallery draws via a new `placeholder` prop on `FillImage`.
- **The open morph now animates the blurhash.** Since the preview was already showing that exact blurhash as a square, the hand-off when it hides is pixel-identical even with zero bytes downloaded — no more vanishing photo.
- **Pinchy layers blurhash → square 900 → original.** The square rendition (usually cached from the profile) is placed at the crop's exact rectangle within the contain-fitted original — the same placement the expanding photo uses — so a sharp-ish photo shows immediately and the morph→Pinchy hand-off matches.
- **A spinner overlay** (`ActivityIndicator`) fades in after a grace period when there's still nothing but the blurhash, so a slow load reads as loading rather than broken.

The blurhash is generated from the cropped square rendition, so it's placed at the crop rect rather than stretched over the full frame. Full-frame placeholder coverage would need a separate blurhash computed from the uncropped original (plus a backfill of existing photos) and isn't worth it for a placeholder that's only visible during load.

## Testing

- `tsc --noEmit` clean; all 16 jest suites / 191 tests pass (including gallery-restore, gallery-linking, pinchy).
- End-to-end visual verification against a throttled connection is still pending — the local backend containers weren't running. Worth a manual pass on a real slow connection before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
