### PR TITLE
Throttle "Played Q&A" feed events

### DIFF
--- a/backend/constants/__init__.py
+++ b/backend/constants/__init__.py
@@ -38,9 +38,14 @@ MAX_SIGNED_IN_SESSIONS = 100
 
 # Refreshing someone's 'answered-question' feed event on every public answer
 # would rewrite their (heavily indexed) person row once per swipe while they
-# play Q&A. Refreshing at most this often caps that churn; the advertised
-# question is at most this stale.
-ANSWERED_QUESTION_EVENT_REFRESH_SECONDS = 60 * 60  # 1 hour
+# play Q&A, and flood the feed with Q&A answers. Refreshing at most this often
+# caps that churn; the advertised question is at most this stale.
+ANSWERED_QUESTION_EVENT_REFRESH_SECONDS = 60 * 60 * 24  # 1 day
+
+# The first questions in the quiz are shown to everyone in the same order, so
+# advertising them in the feed would surface the same handful of answers over
+# and over. Questions with an id at or below this aren't advertised.
+ANSWERED_QUESTION_EVENT_MIN_QUESTION_ID = 10
 
 # Club SEO page tunables. Shared by person/sql (API reads) and
 # service/cron/clubseo/sql (cron aggregation); kept in this dependency-free

--- a/backend/qanda/__init__.py
+++ b/backend/qanda/__init__.py
@@ -26,7 +26,10 @@ import numpy
 import psycopg
 from answerspush import publish_answer_update
 from batcher import Batcher
-from constants import ANSWERED_QUESTION_EVENT_REFRESH_SECONDS
+from constants import (
+    ANSWERED_QUESTION_EVENT_MIN_QUESTION_ID,
+    ANSWERED_QUESTION_EVENT_REFRESH_SECONDS,
+)
 from database import Row, Tx, api_tx
 import duotypes as t
 from qanda import personality
@@ -261,7 +264,9 @@ async def _set_answer(
 
     is_visible = not delete and answer is not None and bool(public)
 
-    if write_event and is_visible:
+    advertise = is_visible and question_id > ANSWERED_QUESTION_EVENT_MIN_QUESTION_ID
+
+    if write_event and advertise:
         await tx.execute(Q_SET_ANSWERED_QUESTION_EVENT, dict(
             person_id=person_id,
             question_id=question_id,

--- a/backend/test/functionality1/feed-v2.sh
+++ b/backend/test/functionality1/feed-v2.sh
@@ -746,7 +746,9 @@ test_answered_question () {
   q "update person set privacy_verification_level_id = 1"
   q "update person set background_color = '#aaaaaa'"
 
-  question_id=10
+  # Above the first-10 quiz questions, which are deliberately kept out of the
+  # feed (see ANSWERED_QUESTION_EVENT_MIN_QUESTION_ID).
+  question_id=11
   question_text=$(q "select question from question where id = ${question_id}")
   question_topic=$(q "select topic from question where id = ${question_id}")
 


### PR DESCRIPTION
Closes #1374

The feed was getting flooded with Q&A answers. Two changes to reduce the noise:

- **Refresh at most once per day.** `ANSWERED_QUESTION_EVENT_REFRESH_SECONDS` goes from 1 hour to 1 day, so a user playing Q&A no longer surfaces a fresh `answered-question` feed item every few answers.
- **Skip the first 10 quiz questions.** Questions with `id <= 10` are shown to everyone in the same order as they appear first in the quiz, so advertising them would surface the same handful of answers over and over. A new `ANSWERED_QUESTION_EVENT_MIN_QUESTION_ID` constant guards `_set_answer` from writing the event for those. The answers stay visible on profiles and in the yes/no piles — theyre just not turned into feed events.

Test `test_answered_question` in `feed-v2.sh` was pinned to `question_id=10`; it now uses `question_id=11` so it still exercises the advertised path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)