### PR TITLE
Reorder online-status setting and push offline immediately on hide

### DIFF
--- a/backend/person/__init__.py
+++ b/backend/person/__init__.py
@@ -24,7 +24,7 @@ from commonsql import *
 from qanda import _flush_session_answers
 from constants import VISITOR_ONLINE_TIMEOUT_SECONDS
 from service.api.chat.chatutil import REDIS_WORKER_CLIENT
-from service.api.chat.online import redis_publish_offline
+from service.api.chat.online import redis_publish_online_status
 from visitorspush import publish_visit
 from person.template import otp_template
 import traceback
@@ -1590,14 +1590,11 @@ async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> objec
         if q1: await tx.execute(q1, params)
         if q2: await tx.execute(q2, params)
 
-    if (
-        field_name == 'show_my_online_status' and
-        field_value == 'No' and
-        s.person_uuid is not None
-    ):
-        await redis_publish_offline(
+    if field_name == 'show_my_online_status' and s.person_uuid is not None:
+        await redis_publish_online_status(
             redis_client=REDIS_WORKER_CLIENT,
             username=s.person_uuid,
+            visible=field_value == 'Yes',
         )
 
     if uuid and base64_file and crop_size:

--- a/backend/person/__init__.py
+++ b/backend/person/__init__.py
@@ -24,7 +24,7 @@ from commonsql import *
 from qanda import _flush_session_answers
 from constants import VISITOR_ONLINE_TIMEOUT_SECONDS
 from service.api.chat.chatutil import REDIS_WORKER_CLIENT
-from service.api.chat.online import redis_publish_online_status
+from service.api.chat.online import redis_publish_online
 from visitorspush import publish_visit
 from person.template import otp_template
 import traceback
@@ -1591,7 +1591,7 @@ async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> objec
         if q2: await tx.execute(q2, params)
 
     if field_name == 'show_my_online_status' and s.person_uuid is not None:
-        await redis_publish_online_status(
+        await redis_publish_online(
             redis_client=REDIS_WORKER_CLIENT,
             username=s.person_uuid,
             visible=field_value == 'Yes',

--- a/backend/person/__init__.py
+++ b/backend/person/__init__.py
@@ -23,6 +23,8 @@ from search.sql import Q_UPSERT_SEARCH_PREFERENCE_CLUB
 from commonsql import *
 from qanda import _flush_session_answers
 from constants import VISITOR_ONLINE_TIMEOUT_SECONDS
+from service.api.chat.chatutil import REDIS_WORKER_CLIENT
+from service.api.chat.online import redis_publish_offline
 from visitorspush import publish_visit
 from person.template import otp_template
 import traceback
@@ -1587,6 +1589,16 @@ async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> objec
     async with api_tx() as tx:
         if q1: await tx.execute(q1, params)
         if q2: await tx.execute(q2, params)
+
+    if (
+        field_name == 'show_my_online_status' and
+        field_value == 'No' and
+        s.person_uuid is not None
+    ):
+        await redis_publish_offline(
+            redis_client=REDIS_WORKER_CLIENT,
+            username=s.person_uuid,
+        )
 
     if uuid and base64_file and crop_size:
         try:

--- a/backend/service/api/chat/online/__init__.py
+++ b/backend/service/api/chat/online/__init__.py
@@ -176,24 +176,21 @@ def _presence_status(hidden: bool, online: bool) -> OnlineStatus:
 async def redis_publish_online(
     redis_client: redis.Redis,
     username: str,
-    online: bool
+    *,
+    online: bool | None = None,
+    visible: bool | None = None,
 ) -> None:
-    to_id = await fetch_id_from_username(username)
-    hidden = to_id is not None and await fetch_hides_online_status(to_id)
+    if visible is None:
+        to_id = await fetch_id_from_username(username)
+        hidden = to_id is not None and await fetch_hides_online_status(to_id)
+    else:
+        hidden = not visible
+
+    if online is None:
+        online = await redis_has_subscribers(redis_client, username)
 
     await _redis_publish_status(
         redis_client, username, _presence_status(hidden=hidden, online=online))
-
-
-async def redis_publish_online_status(
-    redis_client: redis.Redis,
-    username: str,
-    visible: bool,
-) -> None:
-    online = await redis_has_subscribers(redis_client, username)
-
-    await _redis_publish_status(
-        redis_client, username, _presence_status(hidden=not visible, online=online))
 
 async def should_subscribe(from_username: str | None, to_username: str) -> bool:
     if from_username is None:

--- a/backend/service/api/chat/online/__init__.py
+++ b/backend/service/api/chat/online/__init__.py
@@ -165,21 +165,24 @@ async def _redis_publish_status(
         await pipe.execute()
 
 
+def _presence_status(hidden: bool, online: bool) -> OnlineStatus:
+    if hidden:
+        return OnlineStatus.OFFLINE
+    if online:
+        return OnlineStatus.ONLINE
+    return OnlineStatus.ONLINE_RECENTLY
+
+
 async def redis_publish_online(
     redis_client: redis.Redis,
     username: str,
     online: bool
 ) -> None:
     to_id = await fetch_id_from_username(username)
+    hidden = to_id is not None and await fetch_hides_online_status(to_id)
 
-    if to_id is not None and await fetch_hides_online_status(to_id):
-        status = OnlineStatus.OFFLINE
-    elif online:
-        status = OnlineStatus.ONLINE
-    else:
-        status = OnlineStatus.ONLINE_RECENTLY
-
-    await _redis_publish_status(redis_client, username, status)
+    await _redis_publish_status(
+        redis_client, username, _presence_status(hidden=hidden, online=online))
 
 
 async def redis_publish_online_status(
@@ -187,14 +190,10 @@ async def redis_publish_online_status(
     username: str,
     visible: bool,
 ) -> None:
-    if not visible:
-        status = OnlineStatus.OFFLINE
-    elif await redis_has_subscribers(redis_client, username):
-        status = OnlineStatus.ONLINE
-    else:
-        status = OnlineStatus.ONLINE_RECENTLY
+    online = await redis_has_subscribers(redis_client, username)
 
-    await _redis_publish_status(redis_client, username, status)
+    await _redis_publish_status(
+        redis_client, username, _presence_status(hidden=not visible, online=online))
 
 async def should_subscribe(from_username: str | None, to_username: str) -> bool:
     if from_username is None:

--- a/backend/service/api/chat/online/__init__.py
+++ b/backend/service/api/chat/online/__init__.py
@@ -151,16 +151,11 @@ async def _redis_unsubscribe_online(
     await pubsub.unsubscribe(key)
     await pubsub.unsubscribe(answers_channel(username))
 
-async def redis_publish_online(
+async def _redis_publish_status(
     redis_client: redis.Redis,
     username: str,
-    online: bool
+    status: str,
 ) -> None:
-    status = (
-        OnlineStatus.ONLINE.value
-        if online
-        else OnlineStatus.ONLINE_RECENTLY.value)
-
     key = FMT_KEY.format(username=username)
     val = to_bus(OnlineEvent(username=username, status=status))
 
@@ -168,6 +163,31 @@ async def redis_publish_online(
         pipe.publish(key, val)
         pipe.set(key, val, ex=ONLINE_RECENTLY_SECONDS)
         await pipe.execute()
+
+
+async def redis_publish_online(
+    redis_client: redis.Redis,
+    username: str,
+    online: bool
+) -> None:
+    to_id = await fetch_id_from_username(username)
+
+    if to_id is not None and await fetch_hides_online_status(to_id):
+        status = OnlineStatus.OFFLINE.value
+    elif online:
+        status = OnlineStatus.ONLINE.value
+    else:
+        status = OnlineStatus.ONLINE_RECENTLY.value
+
+    await _redis_publish_status(redis_client, username, status)
+
+
+async def redis_publish_offline(
+    redis_client: redis.Redis,
+    username: str,
+) -> None:
+    await _redis_publish_status(
+        redis_client, username, OnlineStatus.OFFLINE.value)
 
 async def should_subscribe(from_username: str | None, to_username: str) -> bool:
     if from_username is None:

--- a/backend/service/api/chat/online/__init__.py
+++ b/backend/service/api/chat/online/__init__.py
@@ -154,10 +154,10 @@ async def _redis_unsubscribe_online(
 async def _redis_publish_status(
     redis_client: redis.Redis,
     username: str,
-    status: str,
+    status: OnlineStatus,
 ) -> None:
     key = FMT_KEY.format(username=username)
-    val = to_bus(OnlineEvent(username=username, status=status))
+    val = to_bus(OnlineEvent(username=username, status=status.value))
 
     async with redis_client.pipeline(transaction=True) as pipe:
         pipe.publish(key, val)
@@ -173,11 +173,11 @@ async def redis_publish_online(
     to_id = await fetch_id_from_username(username)
 
     if to_id is not None and await fetch_hides_online_status(to_id):
-        status = OnlineStatus.OFFLINE.value
+        status = OnlineStatus.OFFLINE
     elif online:
-        status = OnlineStatus.ONLINE.value
+        status = OnlineStatus.ONLINE
     else:
-        status = OnlineStatus.ONLINE_RECENTLY.value
+        status = OnlineStatus.ONLINE_RECENTLY
 
     await _redis_publish_status(redis_client, username, status)
 
@@ -188,11 +188,11 @@ async def redis_publish_online_status(
     visible: bool,
 ) -> None:
     if not visible:
-        status = OnlineStatus.OFFLINE.value
+        status = OnlineStatus.OFFLINE
     elif await redis_has_subscribers(redis_client, username):
-        status = OnlineStatus.ONLINE.value
+        status = OnlineStatus.ONLINE
     else:
-        status = OnlineStatus.ONLINE_RECENTLY.value
+        status = OnlineStatus.ONLINE_RECENTLY
 
     await _redis_publish_status(redis_client, username, status)
 

--- a/backend/service/api/chat/online/__init__.py
+++ b/backend/service/api/chat/online/__init__.py
@@ -182,12 +182,19 @@ async def redis_publish_online(
     await _redis_publish_status(redis_client, username, status)
 
 
-async def redis_publish_offline(
+async def redis_publish_online_status(
     redis_client: redis.Redis,
     username: str,
+    visible: bool,
 ) -> None:
-    await _redis_publish_status(
-        redis_client, username, OnlineStatus.OFFLINE.value)
+    if not visible:
+        status = OnlineStatus.OFFLINE.value
+    elif await redis_has_subscribers(redis_client, username):
+        status = OnlineStatus.ONLINE.value
+    else:
+        status = OnlineStatus.ONLINE_RECENTLY.value
+
+    await _redis_publish_status(redis_client, username, status)
 
 async def should_subscribe(from_username: str | None, to_username: str) -> bool:
     if from_username is None:

--- a/backend/test/functionality6/xmpp-online-public-profile.sh
+++ b/backend/test/functionality6/xmpp-online-public-profile.sh
@@ -250,3 +250,15 @@ echo "$offline_events" | grep -q "$pub_uuid" \
   || { echo "Expected pub's offline event to reach the subscriber"; exit 1; }
 echo "$offline_events" | grep -q offline \
   || { echo "Expected pub to be reported offline after hiding"; exit 1; }
+
+echo "Un-hiding online status re-publishes their status to subscribers"
+
+drain
+jc PATCH /profile-info -d '{ "show_my_online_status": "Yes" }'
+sleep 1
+unhidden_events=$(curl -sX GET http://localhost:3001/pop)
+
+echo "$unhidden_events" | grep -q "$pub_uuid" \
+  || { echo "Expected pub's status event to reach the subscriber after un-hiding"; exit 1; }
+echo "$unhidden_events" | grep -q offline \
+  && { echo "Did not expect pub to be offline after un-hiding"; exit 1; } || true

--- a/backend/test/functionality6/xmpp-online-public-profile.sh
+++ b/backend/test/functionality6/xmpp-online-public-profile.sh
@@ -227,3 +227,26 @@ echo "$events" | grep -q "$capb_uuid" \
 
 echo "$events" | grep -q "$pub_uuid" \
   && { echo "Did not expect an online event for the evicted profile"; exit 1; } || true
+
+echo "Hiding online status pushes an immediate offline event to subscribers"
+
+chat_auth "$viewer_uuid" "$viewer_token"
+sleep 1
+assert_subscribed "$(subscribe_and_pop "$pub_uuid")"
+
+drain
+publish_online "$pub_uuid"
+sleep 1
+curl -sX GET http://localhost:3001/pop | grep -q "$pub_uuid" \
+  || { echo "Expected pub's online event to reach the subscriber"; exit 1; }
+
+drain
+assume_role pub
+jc PATCH /profile-info -d '{ "show_my_online_status": "No" }'
+sleep 1
+offline_events=$(curl -sX GET http://localhost:3001/pop)
+
+echo "$offline_events" | grep -q "$pub_uuid" \
+  || { echo "Expected pub's offline event to reach the subscriber"; exit 1; }
+echo "$offline_events" | grep -q offline \
+  || { echo "Expected pub to be reported offline after hiding"; exit 1; }

--- a/frontend/data/option-groups.tsx
+++ b/frontend/data/option-groups.tsx
@@ -2059,33 +2059,6 @@ const defaultSearchFilters = (): SearchFilters => {
 
 const privacySettingsOptionGroups: OptionGroup<OptionGroupInputs>[] = [
   {
-    title: 'Show My Online Status',
-    Icon: ({ color = 'black' }) => (
-      <FontAwesomeIcon
-        icon={faCircle}
-        size={14}
-        style={{ color }}
-      />
-    ),
-    description: "With this option set to ‘No’, other people won’t see your online indicator or when you were last online, and you won’t appear when they filter their search for people who are online now. You can still appear when they filter by less recent activity, though.",
-    input: {
-      buttons: {
-        values: yesNo,
-        submit: async (showMyOnlineStatus: string) => {
-          const ok = (
-            await japi(
-              'patch',
-              '/profile-info',
-              { show_my_online_status: showMyOnlineStatus }
-            )
-          ).ok;
-          if (ok) patchProfileInfo({ show_my_online_status: showMyOnlineStatus });
-          return ok;
-        },
-      }
-    },
-  },
-  {
     title: 'Public Profile',
     Icon: ({ color = 'black' }) => (
       <FontAwesomeIcon
@@ -2114,6 +2087,33 @@ const privacySettingsOptionGroups: OptionGroup<OptionGroupInputs>[] = [
             )
           ).ok;
           if (ok) patchProfileInfo({ public_profile: publicProfile });
+          return ok;
+        },
+      }
+    },
+  },
+  {
+    title: 'Show My Online Status',
+    Icon: ({ color = 'black' }) => (
+      <FontAwesomeIcon
+        icon={faCircle}
+        size={14}
+        style={{ color }}
+      />
+    ),
+    description: "With this option set to ‘No’, other people won’t see your online indicator or when you were last online, and you won’t appear when they filter their search for people who are online now. You can still appear when they filter by less recent activity, though.",
+    input: {
+      buttons: {
+        values: yesNo,
+        submit: async (showMyOnlineStatus: string) => {
+          const ok = (
+            await japi(
+              'patch',
+              '/profile-info',
+              { show_my_online_status: showMyOnlineStatus }
+            )
+          ).ok;
+          if (ok) patchProfileInfo({ show_my_online_status: showMyOnlineStatus });
           return ok;
         },
       }


### PR DESCRIPTION
Follow-up to #1384.

## What

1. **Reorder** — "Show My Online Status" now sits **after** "Public Profile" in the privacy settings list (previously first).
2. **Immediate presence update on toggle** — changing the setting now pushes the user's status to already-subscribed clients right away, in both directions:
   - **No** → subscribers immediately see the user go **offline**.
   - **Yes** → subscribers immediately see the user's real presence again (**online** if they have a live connection, otherwise **online-recently**), instead of waiting for the next heartbeat.

## Why #2 is more than a one-line publish

`should_subscribe` already blocks *new* subscriptions to a hidden user, but clients that subscribed *before* the user hid kept receiving that user's online heartbeats. Two pieces close the gap:

- **Gate `redis_publish_online`** on `show_my_online_status`: a hidden user always publishes `offline`, regardless of the `online` flag. Without this, the periodic online heartbeat (every `LAST_UPDATE_INTERVAL_SECONDS`) from the user's own connection would flip them back to online within minutes, undoing the hide. The lookup goes through the cached `fetch_id_from_username` (cached indefinitely) + `fetch_hides_online_status` (5s TTL), so the hot heartbeat path adds at most one lightweight indexed read per user per heartbeat interval.
- **Publish immediately from the PATCH handler** (`person.patch_profile_info`) via `redis_publish_online_status(visible=…)`, so subscribers flip the instant the setting is saved. This path derives the status from the **just-written value** (`visible = field_value == 'Yes'`) rather than reading `fetch_hides_online_status`, so it isn't subject to that helper's 5s cache lag right after the write. For the un-hide case it reflects real connectivity via `redis_has_subscribers`.

Net effect: hiding takes subscribers offline immediately and stays offline (the heartbeat can't resurrect a hidden user); un-hiding restores presence immediately.

## Import note

`person` now imports `service.api.chat.online`. Verified there's no circular import: only `service/api/__init__.py` imports `person`, and nothing in the chat subsystem imports `person` or names from `service.api`'s `__init__`, so importing the chat subsystem during `person`'s import completes without looping back. The chat subsystem is already imported at module-load time today, so importing it slightly earlier is side-effect-safe.

## Tests

- `functionality6/xmpp-online-public-profile.sh`: a subscriber sees `pub` come online, then — when `pub` PATCHes the setting to **No** — immediately receives an **offline** event; and when `pub` PATCHes back to **Yes**, immediately receives a non-offline presence event.

## Verification status

`tsc --noEmit` and `mypy` pass. I could **not** run `functionality6` locally (it needs the host-run `:3001` chat harness, and the running containers are built from the pre-follow-up code), so the new shell assertions are written to match the file's existing proven patterns but haven't been executed — worth a run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
