### PR TITLE
Fix dragging a zoomed-in gallery photo on desktop web (#1385)

### DIFF
--- a/frontend/components/fill-image.tsx
+++ b/frontend/components/fill-image.tsx
@@ -21,6 +21,7 @@ const FillImage = ({
     placeholderContentFit="fill"
     transition={0}
     cachePolicy="memory-disk"
+    draggable={false}
     onLoad={onLoad}
   />
 );


### PR DESCRIPTION
Fixes #1385.

## Diagnosis

The gallery zoom/pan is a react-native-gesture-handler `Gesture.Pan()`. On web, RNGH drives gestures off Pointer Events (mouse included), so mouse-dragging *should* pan a zoomed-in photo.

But the photo renders via `FillImage` → expo-image, which emits a bare `<img>` with no `draggable` attribute. An `<img>` is **draggable by default** in desktop browsers, so mouse-down-and-move starts the browser's native image drag-and-drop — firing `dragstart` / `pointercancel`, which tears down the pan gesture before it can move the photo.

Touch input has no native image drag, so **native and mobile web work**; only **desktop web** breaks. Drag-to-dismiss and drag-to-page are broken by the same cause, but they have fallbacks (chevrons, edge-tap zones, arrow keys, Escape). Zoomed-in panning is the only drag with no alternative, so it's the one users noticed.

## Fix

Pass `draggable={false}` through `FillImage`, which every gallery layer flows through. expo-image forwards it straight to the `<img>`, and the prop is inert on native — a one-line, platform-safe change. It also restores drag-to-dismiss and drag-to-page on desktop web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)