### PR TITLE
Keep unreplied intros in the inbox box

### DIFF
--- a/backend/service/api/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/api/chat/messagestorage/inbox/__init__.py
@@ -334,7 +334,6 @@ WITH upsert_sender AS (
     ON CONFLICT (luser, remote_bare_jid)
     DO UPDATE SET
         msg_id = EXCLUDED.msg_id,
-        box = 'chats',
         body = EXCLUDED.body,
         direction = EXCLUDED.direction,
         timestamp = EXCLUDED.timestamp,

--- a/backend/test/functionality6/xmpp.sh
+++ b/backend/test/functionality6/xmpp.sh
@@ -416,7 +416,7 @@ curl -X POST http://localhost:3001/send -H "Content-Type: application/json" -d "
 
 sleep 0.5
 
-curl -sX GET http://localhost:3001/pop | grep -qF '"body": "hello user 2"'
+curl -sX GET http://localhost:3001/pop | grep -qF '"body": "hello once more"'
 
 
 

--- a/backend/test/functionality6/xmpp.sh
+++ b/backend/test/functionality6/xmpp.sh
@@ -195,6 +195,28 @@ curl -sX GET http://localhost:3001/pop \
 
 
 
+echo "A second message without a reply stays in user 2's intros"
+
+send_message "$user1uuid" "$user1token" "$user2uuid" "hello once more" "id1b"
+
+sleep 4 # MongooseIM takes some time to flush messages to the DB
+
+curl -sX GET http://localhost:3001/pop \
+  | assert_any 'has("duo_message_delivered") and .duo_message_delivered["@id"] == "id1b"'
+
+[[ "$(q "select count(*) from inbox where \
+    luser = '${user1uuid}' and \
+    remote_bare_jid = '${user2uuid}@duolicious.app' and \
+    box = 'chats'")" = 1 ]]
+
+[[ "$(q "select count(*) from inbox where \
+    luser = '${user2uuid}' and \
+    remote_bare_jid = '${user1uuid}@duolicious.app' and \
+    box = 'inbox' and \
+    unread_count = 2")" = 1 ]]
+
+
+
 echo The push token user-x-token should be acknowledged and inserted into the database
 
 register_push_token "$user1uuid" "$user1token" 'user-x-token'
@@ -309,6 +331,11 @@ curl -sX GET http://localhost:3001/pop \
 
 [[ "$(q "select count(*) from mam_message where \
     body like '%hello user 2%'")" = 4 ]]
+
+[[ "$(q "select count(*) from inbox where \
+    luser = '${user3uuid}' and \
+    remote_bare_jid = '${user1uuid}@duolicious.app' and \
+    box = 'chats'")" = 1 ]]
 
 [[ "$(q " \
   select count(*) \


### PR DESCRIPTION
`Q_UPSERT_CONVERSATION`'s recipient branch set `box = 'chats'` on conflict, so a **second** message from the same sender reclassified the conversation as a chat even though the recipient never replied. Since `chats_notification` defaults to Immediately while `intros_notification` defaults to Daily, a sender who keeps messaging a dormant user produces one "You have a new message 😍" notification per message — the all-day email spam a user reported on Twitter after the visitor-notifications release (the visitors feature turned out to be unrelated: message-kind notifications require an unread message under 10 days old, and pre-existing accounts can't receive visitor notifications until a week after the deploy stamp).

## Change

Drop the `box = 'chats'` from `upsert_recipient`'s `ON CONFLICT` clause. An incoming message now never moves the recipient's conversation; their row reaches `chats` only via `upsert_sender` when they reply themselves. Reactions are untouched: reacting deliberately counts as engagement (it upserts `messaged` in the same transaction, and `xmpp-reaction-notifications.sh` pins the resulting `chats` placement), so `Q_SET_INBOX_REACTION` keeps its flip.

This also aligns the cron's intro/chat split with what the app shows: the inbox UI's `location` gating derives intros-vs-chats from `messaged`, so it never treated an unreplied conversation as a chat — only the notification pipeline did.

## Tests

- `xmpp.sh`: a second message without a reply leaves the recipient's row in `box = 'inbox'` with `unread_count = 2` (and the sender's in `chats`); after user 3 replies to user 1, user 3's own row is asserted to reach `chats`.
- Existing box expectations in `xmpp-inbox.sh` and `xmpp-reaction-notifications.sh` hold as-is: every `chats` row there comes from the user's own send or reaction.

## Verification

Replayed the real queries against a test DB: intro → recipient `inbox`/unread 1; second message → still `inbox`/unread 2; reaction without reply → `chats` (engagement, unchanged); reply → `chats`. Driving the notification cron over the same sequence: message 1 produces one intro email, messages 2 and 3 now produce nothing (previously each produced a chat-cadence email); follow-ups are governed by the intros Daily cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)