### PR TITLE
Sign out all sessions on account deactivation

### DIFF
--- a/backend/person/__init__.py
+++ b/backend/person/__init__.py
@@ -1010,7 +1010,10 @@ async def post_deactivate(s: t.SessionInfo) -> None:
     params = dict(person_id=s.person_id)
 
     async with api_tx() as tx:
-        await tx.execute(Q_POST_DEACTIVATE, params)
+        row_tx = await tx.execute(Q_POST_DEACTIVATE, params)
+        rows = await row_tx.fetchall()
+
+    await sign_out(r['session_token_hash'] for r in rows)
 
 async def get_profile_info(s: t.SessionInfo) -> object:
     params = dict(person_id=s.person_id)

--- a/backend/person/__init__.py
+++ b/backend/person/__init__.py
@@ -1013,7 +1013,8 @@ async def post_deactivate(s: t.SessionInfo) -> None:
         row_tx = await tx.execute(Q_POST_DEACTIVATE, params)
         rows = await row_tx.fetchall()
 
-    await sign_out(r['session_token_hash'] for r in rows)
+    for row in rows:
+        await sessioncache.delete_session(row['session_token_hash'])
 
 async def get_profile_info(s: t.SessionInfo) -> object:
     params = dict(person_id=s.person_id)

--- a/backend/person/sql/__init__.py
+++ b/backend/person/sql/__init__.py
@@ -1364,8 +1364,18 @@ WITH updated_person AS (
         person_club.club_name = club.name
     AND
         person_club.person_id IN (SELECT id FROM updated_person)
+), deleted_duo_session AS (
+    DELETE FROM
+        duo_session
+    WHERE
+        person_id = %(person_id)s
+    RETURNING
+        session_token_hash
 )
-SELECT 1
+SELECT
+    session_token_hash
+FROM
+    deleted_duo_session
 """
 
 Q_GET_PROFILE_INFO = f"""

--- a/backend/sessioncache/__init__.py
+++ b/backend/sessioncache/__init__.py
@@ -22,10 +22,11 @@ mutations that change them invalidate the entry explicitly via
   * search-preference update  -> `pending_club_name`    (get_search)
                                  cleared
   * account deletion / ban    -> sessions cascade-deleted (delete_or_ban_account)
+  * account deactivation      -> sessions deleted        (post_deactivate)
 
-Person-level deletions (account deletion, admin bans) remove sessions by
-`person_id`, which would otherwise leave the cache — keyed by token hash —
-with no key to evict. They handle this by reading the
+Person-level deletions (account deletion, admin bans, deactivation) remove
+sessions by `person_id`, which would otherwise leave the cache — keyed by
+token hash — with no key to evict. They handle this by reading the
 affected `session_token_hash`es before the delete and evicting every one, so a
 person's *other* devices are covered too, not just the calling session.
 

--- a/backend/test/functionality1/deactivate-session-cache.sh
+++ b/backend/test/functionality1/deactivate-session-cache.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "$script_dir"
+
+source ../util/setup.sh
+
+set -xe
+
+q "delete from duo_session"
+q "delete from person"
+
+../util/create-user.sh user1 0 0
+
+assume_role user1
+c GET '/search-clubs?q=my-club'
+token_a="$SESSION_TOKEN"
+
+assume_role user1
+c GET '/search-clubs?q=my-club'
+token_b="$SESSION_TOKEN"
+
+[[ "$(q "select count(*) from duo_session where signed_in")" -eq 3 ]]
+
+c POST /deactivate
+
+[[ "$(q "select count(*) from duo_session")" -eq 0 ]]
+[[ "$(q "select count(*) from person where activated")" -eq 0 ]]
+
+SESSION_TOKEN="$token_b"
+! c GET '/search-clubs?q=my-club' || exit 1
+
+SESSION_TOKEN="$token_a"
+! c GET '/search-clubs?q=my-club' || exit 1
+
+assume_role user1
+
+[[ "$(q "select count(*) from person where activated")" -eq 1 ]]
+
+c GET '/search-clubs?q=my-club'


### PR DESCRIPTION
## Problem

Users report that `person.activated` has been `false` on their account for weeks while they remain signed in, unaware their profile is invisible.

The cause: `POST /deactivate` flips `person.activated` but leaves every `duo_session` row in place. Nothing in the authenticated request path checks `activated` (neither the `session()` auth dependency nor `/check-session-token` reads it), and the only code that sets it back to `TRUE` is the sign-in flow. So anyone signed in on more than one device who deactivates on one of them stays fully signed in on the others indefinitely — the app works normally there, but their profile is hidden from search and the feed.

Account deletion and admin bans already handle this correctly (sessions deleted, cache evicted), and the removed `autodeactivate2` cron did too for automatic deactivations (#1323). Settings-driven deactivation was the one path that never invalidated sessions.

## Fix

`Q_POST_DEACTIVATE` now deletes all of the person's `duo_session` rows in the same transaction that flips the flag, returning the deleted `session_token_hash`es so `post_deactivate` can evict them from the Redis session cache via `sign_out`, mirroring `delete_or_ban_account`. The session delete is keyed on `person_id` rather than on the flag flip, so calling `/deactivate` on an already-deactivated account still clears any lingering sessions.

New test: `test/functionality1/deactivate-session-cache.sh`, mirroring `delete-account-session-cache.sh` — deactivating on one device rejects both devices' tokens immediately (not after the cache TTL), and signing back in reactivates.

## Backfill

Users already in this state keep their stale sessions until they next sign out, so the DB needs a one-off backfill.

Count affected users (deactivated but still holding sessions):

```sql
SELECT COUNT(DISTINCT duo_session.person_id)
FROM duo_session
JOIN person ON person.id = duo_session.person_id
WHERE NOT person.activated;
```

Sanity check — deactivated users who were recently online shouldn't be possible once this ships:

```sql
SELECT COUNT(*)
FROM person
WHERE NOT activated
AND last_online_time > now() - interval '7 days';
```

Delete the stale sessions:

```sql
DELETE FROM duo_session
USING person
WHERE person.id = duo_session.person_id
AND NOT person.activated;
```

No Redis eviction is needed for the backfill: `SESSION_CACHE_TTL_SECONDS` is 60, so any cached entries for the deleted sessions expire within a minute.

Affected users will be signed out everywhere and, on next sign-in, reactivated by the existing sign-in flow — which is also the remedy for anyone currently stuck in the invisible state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)