### PR TITLE
Quieten chat disconnect race and back off flapping reconnects

### DIFF
--- a/backend/service/api/asgi.py
+++ b/backend/service/api/asgi.py
@@ -5,6 +5,7 @@ The routes themselves are attached in `service.api` (the package `__init__`),
 which imports this `app`. `service.api:app` is the uvicorn entry point.
 """
 
+import logging
 import os
 
 import constants
@@ -31,6 +32,13 @@ from service.api.routing import DuoRoute
 from service.lifespan import app_lifespan
 
 CORS_ORIGINS = os.environ.get('DUO_CORS_ORIGINS', '*')
+
+# Uvicorn's log config only covers its own loggers; give the app's loggers a
+# root handler in the same level-prefixed style.
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s:     %(asctime)s %(name)s: %(message)s',
+)
 
 app = FastAPI(lifespan=app_lifespan)
 

--- a/backend/service/api/chat/__init__.py
+++ b/backend/service/api/chat/__init__.py
@@ -119,6 +119,7 @@ from starlette.websockets import WebSocketState
 from service.api.ratelimit import (
     RateLimitExceeded,
     check_chat_connect_limit,
+    client_ip,
 )
 import json
 from service.api.chat.verification import (
@@ -713,13 +714,22 @@ async def process_text(
 
 
 async def process_websocket_messages(websocket: WebSocket) -> None:
+    ip = client_ip(websocket)
+
     try:
         await check_chat_connect_limit(websocket)
     except RateLimitExceeded:
+        print(
+            datetime.utcnow(),
+            f'Chat connection rejected: rate limited; ip={ip}'
+        )
         await websocket.close(code=1013)
         return
 
     await websocket.accept(subprotocol='json')
+
+    connected_at = datetime.utcnow()
+    disconnect_reason = 'unknown'
 
     session = Session()
 
@@ -748,6 +758,7 @@ async def process_websocket_messages(websocket: WebSocket) -> None:
             # websocket's application_state to DISCONNECTED, after which
             # `receive_text` raises RuntimeError instead of WebSocketDisconnect.
             if websocket.application_state != WebSocketState.CONNECTED:
+                disconnect_reason = 'client disconnected during send'
                 break
 
             text = await websocket.receive_text()
@@ -780,17 +791,28 @@ async def process_websocket_messages(websocket: WebSocket) -> None:
             if not is_subscribed_by_username and session.username:
                 await pubsub.subscribe(session.username)
                 is_subscribed_by_username = True
-    except WebSocketDisconnect:
-        pass
+    except WebSocketDisconnect as e:
+        disconnect_reason = f'client disconnected (code={e.code})'
     except asyncio.CancelledError:
+        disconnect_reason = 'cancelled at shutdown'
         raise
     except:
+        disconnect_reason = 'exception'
         print(
             datetime.utcnow(),
             f"Exception while processing for username: {session.username}"
         )
         print(traceback.format_exc())
     finally:
+        duration = (datetime.utcnow() - connected_at).total_seconds()
+        print(
+            datetime.utcnow(),
+            f'Chat connection closed: '
+            f'ip={ip}; '
+            f'username={session.username}; '
+            f'duration={duration:.1f}s; '
+            f'reason={disconnect_reason}'
+        )
         if update_online_task:
             update_online_task.cancel()
 

--- a/backend/service/api/chat/__init__.py
+++ b/backend/service/api/chat/__init__.py
@@ -2,8 +2,8 @@ import dataclasses
 from database import api_tx
 import asyncio
 import duohash
+import logging
 import regex
-import traceback
 import sys
 from websockets.exceptions import ConnectionClosedError
 from async_lru_cache import AsyncLruCache
@@ -148,6 +148,8 @@ AND
     sign_up_time < now() - (interval '1 day') / power(verification_level_id, 2)
 """
 
+logger = logging.getLogger(__name__)
+
 MAX_MESSAGE_LEN = 5000
 
 NON_ALPHANUMERIC_RE = regex.compile(r'[^\p{L}\p{N}]')
@@ -180,7 +182,7 @@ async def redis_forward_to_websocket(
     except WebSocketDisconnect:
         pass
     except:
-        print(traceback.format_exc())
+        logger.exception('Exception while forwarding to the websocket')
 
 
 def normalize_message(message_str: str) -> str:
@@ -719,10 +721,7 @@ async def process_websocket_messages(websocket: WebSocket) -> None:
     try:
         await check_chat_connect_limit(websocket)
     except RateLimitExceeded:
-        print(
-            datetime.utcnow(),
-            f'Chat connection rejected: rate limited; ip={ip}'
-        )
+        logger.info(f'Chat connection rejected: rate limited; ip={ip}')
         await websocket.close(code=1013)
         return
 
@@ -734,8 +733,7 @@ async def process_websocket_messages(websocket: WebSocket) -> None:
 
     def log_closed(reason: str) -> None:
         duration = (datetime.utcnow() - connected_at).total_seconds()
-        print(
-            datetime.utcnow(),
+        logger.info(
             f'Chat connection closed: '
             f'ip={ip}; '
             f'username={session.username}; '
@@ -808,11 +806,8 @@ async def process_websocket_messages(websocket: WebSocket) -> None:
         raise
     except:
         log_closed('exception')
-        print(
-            datetime.utcnow(),
-            f"Exception while processing for username: {session.username}"
-        )
-        print(traceback.format_exc())
+        logger.exception(
+            f'Exception while processing for username: {session.username}')
     finally:
         if update_online_task:
             update_online_task.cancel()
@@ -831,7 +826,7 @@ async def process_websocket_messages(websocket: WebSocket) -> None:
                 try:
                     await pubsub.unsubscribe(session.username)
                 except:
-                    print(traceback.format_exc())
+                    logger.exception('Exception while unsubscribing')
 
             try:
                 await update_online_once(

--- a/backend/service/api/chat/__init__.py
+++ b/backend/service/api/chat/__init__.py
@@ -115,6 +115,7 @@ from service.api.chat.audiomessage import (
 )
 import redis.asyncio as redis
 from fastapi import WebSocket, WebSocketDisconnect
+from starlette.websockets import WebSocketState
 import json
 from service.api.chat.verification import (
     verification_required,
@@ -171,6 +172,8 @@ async def redis_forward_to_websocket(
             await websocket.send_text(data)
     except asyncio.CancelledError:
         raise
+    except WebSocketDisconnect:
+        pass
     except:
         print(traceback.format_exc())
 
@@ -731,6 +734,12 @@ async def process_websocket_messages(websocket: WebSocket) -> None:
 
     try:
         while True:
+            # A send that failed in `redis_forward_to_websocket` flips the
+            # websocket's application_state to DISCONNECTED, after which
+            # `receive_text` raises RuntimeError instead of WebSocketDisconnect.
+            if websocket.application_state != WebSocketState.CONNECTED:
+                break
+
             text = await websocket.receive_text()
 
             await asyncio.shield(

--- a/backend/service/api/chat/__init__.py
+++ b/backend/service/api/chat/__init__.py
@@ -729,9 +729,19 @@ async def process_websocket_messages(websocket: WebSocket) -> None:
     await websocket.accept(subprotocol='json')
 
     connected_at = datetime.utcnow()
-    disconnect_reason = 'unknown'
 
     session = Session()
+
+    def log_closed(reason: str) -> None:
+        duration = (datetime.utcnow() - connected_at).total_seconds()
+        print(
+            datetime.utcnow(),
+            f'Chat connection closed: '
+            f'ip={ip}; '
+            f'username={session.username}; '
+            f'duration={duration:.1f}s; '
+            f'reason={reason}'
+        )
 
     redis_websocket_client: redis.Redis = redis.Redis(
             host=REDIS_HOST,
@@ -758,7 +768,7 @@ async def process_websocket_messages(websocket: WebSocket) -> None:
             # websocket's application_state to DISCONNECTED, after which
             # `receive_text` raises RuntimeError instead of WebSocketDisconnect.
             if websocket.application_state != WebSocketState.CONNECTED:
-                disconnect_reason = 'client disconnected during send'
+                log_closed('client disconnected during send')
                 break
 
             text = await websocket.receive_text()
@@ -792,27 +802,18 @@ async def process_websocket_messages(websocket: WebSocket) -> None:
                 await pubsub.subscribe(session.username)
                 is_subscribed_by_username = True
     except WebSocketDisconnect as e:
-        disconnect_reason = f'client disconnected (code={e.code})'
+        log_closed(f'client disconnected (code={e.code})')
     except asyncio.CancelledError:
-        disconnect_reason = 'cancelled at shutdown'
+        log_closed('cancelled at shutdown')
         raise
     except:
-        disconnect_reason = 'exception'
+        log_closed('exception')
         print(
             datetime.utcnow(),
             f"Exception while processing for username: {session.username}"
         )
         print(traceback.format_exc())
     finally:
-        duration = (datetime.utcnow() - connected_at).total_seconds()
-        print(
-            datetime.utcnow(),
-            f'Chat connection closed: '
-            f'ip={ip}; '
-            f'username={session.username}; '
-            f'duration={duration:.1f}s; '
-            f'reason={disconnect_reason}'
-        )
         if update_online_task:
             update_online_task.cancel()
 

--- a/backend/service/api/chat/__init__.py
+++ b/backend/service/api/chat/__init__.py
@@ -116,6 +116,10 @@ from service.api.chat.audiomessage import (
 import redis.asyncio as redis
 from fastapi import WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
+from service.api.ratelimit import (
+    RateLimitExceeded,
+    check_chat_connect_limit,
+)
 import json
 from service.api.chat.verification import (
     verification_required,
@@ -709,6 +713,12 @@ async def process_text(
 
 
 async def process_websocket_messages(websocket: WebSocket) -> None:
+    try:
+        await check_chat_connect_limit(websocket)
+    except RateLimitExceeded:
+        await websocket.close(code=1013)
+        return
+
     await websocket.accept(subprotocol='json')
 
     session = Session()

--- a/backend/service/api/mocking.py
+++ b/backend/service/api/mocking.py
@@ -10,7 +10,7 @@ import time
 from functools import lru_cache
 from pathlib import Path
 
-from starlette.requests import Request
+from starlette.requests import HTTPConnection
 
 _input_dir = Path(__file__).parent.parent.parent / 'test' / 'input'
 
@@ -40,11 +40,11 @@ def enable_mocking() -> bool:
 
 # `request` is accepted (and ignored) so these match the uniform
 # `exempt_when(request)` signature the rate limiter calls them with.
-def disable_ip_rate_limit(request: Request | None = None) -> bool:
+def disable_ip_rate_limit(request: HTTPConnection | None = None) -> bool:
     return enable_mocking() and _file_says_enabled(disable_ip_rate_limit_file)
 
 
-def disable_account_rate_limit(request: Request | None = None) -> bool:
+def disable_account_rate_limit(request: HTTPConnection | None = None) -> bool:
     return enable_mocking() and _file_says_enabled(disable_account_rate_limit_file)
 
 

--- a/backend/service/api/ratelimit.py
+++ b/backend/service/api/ratelimit.py
@@ -18,7 +18,7 @@ from collections.abc import Awaitable, Callable
 from limits import parse_many
 from limits.aio.strategies import FixedWindowRateLimiter
 from limits.storage import storage_from_string
-from starlette.requests import Request
+from starlette.requests import HTTPConnection, Request
 
 from antiabuse.antispam.signupemail import normalize_email
 from service.api.mocking import (
@@ -35,11 +35,12 @@ REDIS_PORT: int = int(os.environ.get("DUO_REDIS_PORT", 6379))
 # Request address helpers
 # ---------------------------------------------------------------------------
 
-def client_ip(request: Request) -> str | None:
+def client_ip(request: HTTPConnection) -> str | None:
     """The requesting client's IP, honouring X-Forwarded-For with a single
     trusted hop (the right-most entry, matching the old werkzeug
     ProxyFix(x_for=1)), falling back to the socket peer. No mock override --
-    this is the real address used for ban / firehol checks."""
+    this is the real address used for ban / firehol checks. Accepts websockets
+    too (`HTTPConnection` is the base of both `Request` and `WebSocket`)."""
     xff = request.headers.get('x-forwarded-for')
     if xff:
         parts = [p.strip() for p in xff.split(',') if p.strip()]
@@ -48,7 +49,7 @@ def client_ip(request: Request) -> str | None:
     return request.client.host if request.client else None
 
 
-def _is_private_ip(request: Request) -> bool:
+def _is_private_ip(request: HTTPConnection) -> bool:
     """Whether the requesting IP is private (and so exempt from the default
     per-endpoint limits)."""
     if disable_ip_rate_limit():
@@ -61,7 +62,7 @@ def _is_private_ip(request: Request) -> bool:
         return False
 
 
-def _get_remote_address(request: Request) -> str:
+def _get_remote_address(request: HTTPConnection) -> str:
     """The IP used for rate-limit keys (mock-aware, 127.0.0.1 if none found)."""
     return mock_ip_address() or client_ip(request) or "127.0.0.1"
 
@@ -76,8 +77,8 @@ class RateLimitExceeded(Exception):
 
 LimitValue = str | Callable[[], str]
 ScopeArg = str | Callable[[], str] | None
-KeyFunc = Callable[[Request], str]
-ExemptWhen = Callable[[Request], bool]
+KeyFunc = Callable[[HTTPConnection], str]
+ExemptWhen = Callable[[HTTPConnection], bool]
 
 
 class Limiter:
@@ -95,7 +96,7 @@ class Limiter:
 
     async def check(
         self,
-        request: Request,
+        request: HTTPConnection,
         limit_value: LimitValue,
         scope: ScopeArg = None,
         key_func: KeyFunc | None = None,
@@ -154,6 +155,11 @@ verify_rate_limit = "8 per day"
 # per-account.
 export_data_rate_limit = "3 per day"
 
+# Per-IP cap on /chat websocket connection attempts. A healthy client holds
+# one connection, so this is generous even for NAT-shared addresses, but it
+# stops a flapping client from reconnecting once a second indefinitely.
+chat_connect_rate_limit = "20 per minute"
+
 limiter = Limiter(
     _get_remote_address,
     default_limits=[default_limits],
@@ -162,7 +168,7 @@ limiter = Limiter(
 )
 
 
-def limiter_account(request: Request) -> str:
+def limiter_account(request: HTTPConnection) -> str:
     email = getattr(request.state, 'normalized_email', None)
     return email if isinstance(email, str) else _get_remote_address(request)
 
@@ -231,6 +237,17 @@ async def check_otp_send_limits(request: Request, email: str) -> None:
         scope='otp_email',
         key_func=lambda _: normalize_email(email),
         exempt_when=disable_account_rate_limit,
+    )
+
+
+async def check_chat_connect_limit(websocket: HTTPConnection) -> None:
+    """Enforce `chat_connect_rate_limit` for a websocket handshake, keyed on
+    the client IP. Called before the connection is accepted."""
+    await limiter.check(
+        websocket,
+        chat_connect_rate_limit,
+        scope='chat_connect',
+        exempt_when=_is_private_ip,
     )
 
 

--- a/frontend/api/api.tsx
+++ b/frontend/api/api.tsx
@@ -3,7 +3,7 @@ import {
 } from '../env/env';
 import * as _ from "lodash";
 import { sessionToken } from '../kv-storage/session-token';
-import { delay } from '../util/util';
+import { delay, makeBackoff } from '../util/util';
 import { notify } from '../events/events';
 import { ValidationErrorToast, SOMETHING_WENT_WRONG } from '../components/toast';
 
@@ -55,6 +55,7 @@ const api = async <T = unknown>(
   let json: T | undefined;
   let text: string | undefined;
   let numRetries = 0;
+  const retryBackoff = makeBackoff();
 
   while (maxRetries === undefined || numRetries <= maxRetries) {
     [response, json] = [undefined, undefined];
@@ -100,14 +101,13 @@ const api = async <T = unknown>(
         break;
       }
     } catch (error) {
-      const timeoutSeconds =
-        Math.round(4 * Math.min(32, Math.pow(1.7, numRetries++))) +
-        Math.round(4 * Math.random());
+      numRetries++;
+      const jitteredDelayMs = retryBackoff.next();
 
       // TODO: There should be a message in the UI saying "you're offline" or something
-      console.log(`Waiting ${timeoutSeconds} seconds and trying again; Caught error while fetching ${url}`, error);
+      console.log(`Waiting ${(jitteredDelayMs / 1000).toFixed(1)} seconds and trying again; Caught error while fetching ${url}`, error);
 
-      await delay(timeoutSeconds * 1000);
+      await delay(jitteredDelayMs);
     } finally {
       // cancel the timeout whether there was an error or not
       clearTimeout(timeoutId);

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -1,6 +1,10 @@
 import { CHAT_URL } from '../env/env';
 import { listen, notify } from '../events/events';
-import { delay, jsonParseSilently } from '../util/util';
+import {
+  delay,
+  jsonParseSilently,
+  makeBackoff,
+} from '../util/util';
 import { AppState, AppStateStatus, Platform } from 'react-native';
 
 type Pong = {
@@ -13,12 +17,9 @@ const EV_CHAT_WS_OPEN = 'chat-ws-open';
 const EV_CHAT_WS_RECEIVE = 'chat-ws-receive';
 const EV_CHAT_WS_SEND_CLOSE = 'chat-ws-send-close';
 
-const reconnectDelayStep = 1000;
-const maxReconnectDelay = 30000;
-const initialReconnectDelay = 0;
 const stableConnectionMs = 10000;
 const backgroundedCloseGraceMs = 5000;
-let reconnectDelay = initialReconnectDelay;
+const reconnectBackoff = makeBackoff();
 let backgroundedCloseTimeout: ReturnType<typeof setTimeout> | undefined;
 
 const pong: Pong = {
@@ -59,10 +60,7 @@ const connectChatWebSocket = (): void => {
   let resetDelayTimeout: ReturnType<typeof setTimeout> | undefined;
 
   ws.onopen = () => {
-    resetDelayTimeout = setTimeout(
-      () => { reconnectDelay = initialReconnectDelay; },
-      stableConnectionMs,
-    );
+    resetDelayTimeout = setTimeout(reconnectBackoff.reset, stableConnectionMs);
     notify(EV_CHAT_WS_OPEN);
   };
 
@@ -82,13 +80,7 @@ const connectChatWebSocket = (): void => {
       expectedClose = false;
       connectChatWebSocket();
     } else {
-      setTimeout(() => {
-        reconnectDelay = Math.min(
-          2 * (reconnectDelay + reconnectDelayStep),
-          maxReconnectDelay
-        );
-        connectChatWebSocket();
-      }, reconnectDelay);
+      setTimeout(connectChatWebSocket, reconnectBackoff.next());
     }
   };
 

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -16,6 +16,7 @@ const EV_CHAT_WS_SEND_CLOSE = 'chat-ws-send-close';
 const reconnectDelayStep = 1000;
 const maxReconnectDelay = 30000;
 const initialReconnectDelay = 0;
+const stableConnectionMs = 10000;
 let reconnectDelay = initialReconnectDelay;
 
 const pong: Pong = {
@@ -45,8 +46,10 @@ const connectChatWebSocket = (): void => {
 
   ws = new WebSocket(CHAT_URL, ['json']);
 
+  let openedAt: number | null = null;
+
   ws.onopen = () => {
-    reconnectDelay = initialReconnectDelay;
+    openedAt = Date.now();
     notify(EV_CHAT_WS_OPEN);
   };
 
@@ -60,6 +63,9 @@ const connectChatWebSocket = (): void => {
   ws.onclose = (event: CloseEvent) => {
     notify<CloseEvent>(EV_CHAT_WS_CLOSE, event);
     ws = null;
+    if (openedAt !== null && Date.now() - openedAt >= stableConnectionMs) {
+      reconnectDelay = initialReconnectDelay;
+    }
     setTimeout(() => {
       reconnectDelay = Math.min(
         2 * (reconnectDelay + reconnectDelayStep),

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -46,10 +46,13 @@ const connectChatWebSocket = (): void => {
 
   ws = new WebSocket(CHAT_URL, ['json']);
 
-  let openedAt: number | null = null;
+  let resetDelayTimeout: ReturnType<typeof setTimeout> | undefined;
 
   ws.onopen = () => {
-    openedAt = Date.now();
+    resetDelayTimeout = setTimeout(
+      () => { reconnectDelay = initialReconnectDelay; },
+      stableConnectionMs,
+    );
     notify(EV_CHAT_WS_OPEN);
   };
 
@@ -61,11 +64,9 @@ const connectChatWebSocket = (): void => {
   // If not, the ping mechanism should still restart the connection, though more
   // slowly.
   ws.onclose = (event: CloseEvent) => {
+    clearTimeout(resetDelayTimeout);
     notify<CloseEvent>(EV_CHAT_WS_CLOSE, event);
     ws = null;
-    if (openedAt !== null && Date.now() - openedAt >= stableConnectionMs) {
-      reconnectDelay = initialReconnectDelay;
-    }
     setTimeout(() => {
       reconnectDelay = Math.min(
         2 * (reconnectDelay + reconnectDelayStep),

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -27,10 +27,18 @@ const pong: Pong = {
 let lastEnteredActiveState =  new Date();
 
 let ws: WebSocket | null = null;
+let expectedClose = false;
 
-listen(EV_CHAT_WS_SEND_CLOSE, () => {
-  ws?.close();
-});
+const closeChatWebSocket = (): void => {
+  if (!ws) {
+    return;
+  }
+
+  expectedClose = true;
+  ws.close();
+};
+
+listen(EV_CHAT_WS_SEND_CLOSE, closeChatWebSocket);
 
 const isBackgrounded = (state: AppStateStatus): boolean =>
   Platform.OS !== 'web' && ['background', 'inactive'].includes(state);
@@ -67,13 +75,19 @@ const connectChatWebSocket = (): void => {
     clearTimeout(resetDelayTimeout);
     notify<CloseEvent>(EV_CHAT_WS_CLOSE, event);
     ws = null;
-    setTimeout(() => {
-      reconnectDelay = Math.min(
-        2 * (reconnectDelay + reconnectDelayStep),
-        maxReconnectDelay
-      );
+
+    if (expectedClose) {
+      expectedClose = false;
       connectChatWebSocket();
-    }, reconnectDelay);
+    } else {
+      setTimeout(() => {
+        reconnectDelay = Math.min(
+          2 * (reconnectDelay + reconnectDelayStep),
+          maxReconnectDelay
+        );
+        connectChatWebSocket();
+      }, reconnectDelay);
+    }
   };
 
   ws.onerror = () => {
@@ -251,7 +265,7 @@ const onChangeAppState = (state: AppStateStatus) => {
   }
 
   if (isBackgrounded(state)) {
-    ws?.close();
+    closeChatWebSocket();
   }
 };
 

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -17,7 +17,9 @@ const reconnectDelayStep = 1000;
 const maxReconnectDelay = 30000;
 const initialReconnectDelay = 0;
 const stableConnectionMs = 10000;
+const backgroundedCloseGraceMs = 5000;
 let reconnectDelay = initialReconnectDelay;
+let backgroundedCloseTimeout: ReturnType<typeof setTimeout> | undefined;
 
 const pong: Pong = {
   preferredInterval: 10000,
@@ -258,14 +260,25 @@ const pingServerForever = async () => {
   };
 };
 
+const closeIfStillBackgrounded = (): void => {
+  if (isBackgrounded(AppState.currentState)) {
+    closeChatWebSocket();
+  }
+};
+
 const onChangeAppState = (state: AppStateStatus) => {
   if (state === 'active') {
     lastEnteredActiveState = new Date();
+    clearTimeout(backgroundedCloseTimeout);
     connectChatWebSocket();
   }
 
   if (isBackgrounded(state)) {
-    closeChatWebSocket();
+    clearTimeout(backgroundedCloseTimeout);
+    backgroundedCloseTimeout = setTimeout(
+      closeIfStillBackgrounded,
+      backgroundedCloseGraceMs,
+    );
   }
 };
 

--- a/frontend/components/conversation-screen/conversation-screen.tsx
+++ b/frontend/components/conversation-screen/conversation-screen.tsx
@@ -672,12 +672,12 @@ const ConversationScreen = ({navigation, route}: NativeStackScreenProps<RootPara
       return;
     }
 
-  if (
-    Platform.OS !== 'web' &&
-    ['background', 'inactive'].includes(AppState.currentState)
-  ) {
-    return;
-  }
+    if (
+      Platform.OS !== 'web' &&
+      ['background', 'inactive'].includes(AppState.currentState)
+    ) {
+      return;
+    }
 
     await markDisplayed(personUuid, lastMessage.message.id);
   }, [_.last(messageIds)]);

--- a/frontend/notifications/notifications.tsx
+++ b/frontend/notifications/notifications.tsx
@@ -22,10 +22,10 @@ const refreshWebPushOnWeb = async (): Promise<MaybeToken> => {
 
 
 const requestPermissionOnMobile = async (): Promise<MaybeToken> => {
-  const { status } = await Notifications.getPermissionsAsync();
+  const current = await Notifications.getPermissionsAsync();
   const finalStatus =
-    status === 'granted' ?
-    status :
+    current.granted || !current.canAskAgain ?
+    current.status :
     (await Notifications.requestPermissionsAsync()).status;
 
   if (finalStatus !== 'granted') {

--- a/frontend/notifications/notifications.tsx
+++ b/frontend/notifications/notifications.tsx
@@ -9,6 +9,7 @@ import { delay } from '../util/util';
 type MaybeToken = { token: string | null } | null;
 const expoPushTokenMaxAttempts = 3;
 const expoPushTokenInitialRetryDelayMs = 1000;
+let hasAskedPermissionThisSession = false;
 
 const refreshWebPushOnWeb = async (): Promise<MaybeToken> => {
   if (Platform.OS !== 'web') {
@@ -23,10 +24,20 @@ const refreshWebPushOnWeb = async (): Promise<MaybeToken> => {
 
 const requestPermissionOnMobile = async (): Promise<MaybeToken> => {
   const current = await Notifications.getPermissionsAsync();
+
+  const shouldAsk =
+    !current.granted &&
+    current.canAskAgain &&
+    !hasAskedPermissionThisSession;
+
+  if (shouldAsk) {
+    hasAskedPermissionThisSession = true;
+  }
+
   const finalStatus =
-    current.granted || !current.canAskAgain ?
-    current.status :
-    (await Notifications.requestPermissionsAsync()).status;
+    shouldAsk ?
+    (await Notifications.requestPermissionsAsync()).status :
+    current.status;
 
   if (finalStatus !== 'granted') {
     console.error('Failed to get push token for push notification!');

--- a/frontend/util/util.tsx
+++ b/frontend/util/util.tsx
@@ -122,6 +122,23 @@ const getShortElapsedTime = (start: Date) => {
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+const backoffDelayStepMs = 1000;
+const maxBackoffDelayMs = 30000;
+
+const makeBackoff = () => {
+  let delayMs = 0;
+
+  return {
+    next: (): number => {
+      delayMs = Math.min(2 * (delayMs + backoffDelayStepMs), maxBackoffDelayMs);
+      return Math.random() * delayMs;
+    },
+    reset: (): void => {
+      delayMs = 0;
+    },
+  };
+};
+
 const deleteFromArray = <T,>(array: T[], element: T): T[] => {
   let index = array.indexOf(element);
   if (index !== -1) {
@@ -412,6 +429,7 @@ export {
   compareArrays,
   delay,
   deleteFromArray,
+  makeBackoff,
   friendlyDate,
   friendlyTimeAgo,
   friendlyTimestamp,


### PR DESCRIPTION
## Problem

Production logs show a repeating pair of tracebacks (`WebSocketDisconnect` in `redis_forward_to_websocket`, then `RuntimeError: WebSocket is not connected. Need to call "accept" first.` in `process_websocket_messages`), sometimes at ~1/second for a single user. The flapping began with the 32.9.1 Android release.

Both tracebacks are one benign event: the client's TCP connection drops while a redis-forwarded message is in flight. The failed send makes Starlette flip `application_state` to `DISCONNECTED` and raise `WebSocketDisconnect(1006)`, which the forwarder's bare `except` printed. The receive loop then calls `receive_text()`, which raises `RuntimeError` (not `WebSocketDisconnect`) because the state is no longer `CONNECTED`, so it skipped the `except WebSocketDisconnect` handler and hit the catch-all printer.

The ~1/second reconnect frequency traces back to aed8ec22 (32.9.1), which made every AppState `'background'` event close the websocket and every `'active'` event reconnect it immediately, while `onopen` reset the reconnect backoff to zero. Any source of rapid background/active flapping therefore became connection flapping with no backoff.

The suspected flapping driver (unverified on a device yet, but consistent with all observations — Android-only, new accounts, ~1–1.7s cycles that each complete authentication): every reconnect re-authenticates, authentication re-runs `requestPermissionsAsync()` whenever notification permission isn't granted, and on Android a request for a permanently-denied permission bounces through the system permission activity invisibly — pausing the app's Activity and firing exactly the `'background'`/`'active'` pair that closes and reopens the socket.

## Fixes

- **Backend:** `redis_forward_to_websocket` treats `WebSocketDisconnect` as a normal close, and the receive loop exits when `application_state` is no longer `CONNECTED` instead of tripping the misleading `RuntimeError`. Cleanup in `finally` is unchanged.
- **Frontend:** the reconnect backoff only resets once a connection has stayed open for 10 seconds (via a timer started in `onopen` and cleared in `onclose`). Recovery after a genuine outage is still immediate, but short-lived connections now back off exponentially to the existing 30-second cap.
- **Frontend:** deliberate closes (logout, app-backgrounding) no longer feed the backoff. They set an `expectedClose` flag and reconnect immediately: logout still gets its anonymous replacement socket for public online-status subscriptions, and the backgrounded reconnect attempt stays a no-op until the app is active again. Close-event codes weren't usable for this since client- and server-initiated clean closes are indistinguishable across browsers and React Native.
- **Frontend:** the backgrounded close now waits five seconds and is cancelled if the app returns to active, so transient blips (permission dialogs, share sheets, quick app switches) no longer cycle the connection; and `requestPermissionsAsync()` is skipped when the permission is permanently denied (`canAskAgain === false`), removing the suspected loop driver.
- **Backend:** `/chat` handshakes are rate-limited to 20 per minute per IP (`chat_connect_rate_limit`, alongside the other named policies in `ratelimit.py`) before the connection is accepted, so a flapping client no longer costs authentication, redis pubsub setup, and an inbox query on every cycle. Rejected handshakes never fire the client's `onopen`, so old clients' reconnect backoff engages and their attempt rate self-throttles. Private addresses stay exempt (which also covers the test harness), and the existing `Limiter` is reused by retyping its helpers from `Request` to `HTTPConnection`, the shared base of `Request` and `WebSocket`.

- **Backend:** every closed `/chat` connection now logs one line with the client IP, username, connection duration, and disconnect reason (client disconnect with close code, failed concurrent send, shutdown, or exception), and rate-limited handshake rejections are logged with the IP. These use stdlib `logging` via a module logger (uvicorn's config only covers its own loggers, so the ASGI entry now installs a root handler in the same level-prefixed style); the chat module's `print` sites were converted too, with `logger.exception` replacing the manual traceback prints.

## Testing

- `backend/mypy.sh` passes over the full backend.
- `npx tsc --noEmit` passes in `frontend/`.
- Frontend jest suites touching the websocket layer (`read-receipt`, `online`, `conversations`) pass.
- Still to do: reproduce on a real Android 13+ device (deny the notification permission twice, watch for the connect/auth/close loop) to confirm the permission-request blip is the driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
