### PR TITLE
Retry requests and reconnect chat as soon as the network returns

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -63,7 +63,7 @@ import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { ErrorBoundary } from './components/error-boundary';
 import { TooltipListener } from './components/tooltip';
 import { VerificationCameraModal } from './components/verification-camera';
-import { listen, notify } from './events/events';
+import { notify, useDerivedEvent } from './events/events';
 import { setActiveConversation } from './chat/conversation-priority';
 import { PointOfSaleModal } from './components/modal/point-of-sale-modal';
 import { DateOfBirthConfirmationModal } from './components/modal/date-of-birth-confirmation-modal';
@@ -107,11 +107,17 @@ const navigationContainerRef = createNavigationContainerRef<ParamListBase>();
 const App = () => {
   const [initialState, setInitialState] = useState<InitialState | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
+  const [localReady, setLocalReady] = useState(false);
   const [serverStatus, setServerStatus] = useState<ServerStatus>("ok");
   const [signedInUser] = useSignedInUser();
   const [bannerVisible, setBannerVisible] = useState(false);
   const [bannerProspectHandle, setBannerProspectHandle] = useState<string | undefined>(undefined);
   const pendingPostLoginStateRef = useRef<PartialState<NavigationState> | null>(null);
+  const isOffline = useDerivedEvent<boolean, boolean>(
+    EV_NETWORK_IS_ONLINE,
+    (isOnline) => isOnline === false,
+    [],
+  );
   useAppThemeLoader();
   const { appTheme } = useAppTheme();
 
@@ -346,9 +352,19 @@ const App = () => {
   }, [serverStatus]);
 
   const loadApp = useCallback(async () => {
-    await Promise.all([
+    // The splash screen may hide once the work that doesn't need the network
+    // is done; the network-dependent work below can stall indefinitely
+    // offline, which is what the `isOffline` arm of the hide condition
+    // bypasses.
+    const localWork = Promise.all([
       loadFonts(),
       lockScreenOrientation(),
+    ])
+      .catch((e) => console.warn(e))
+      .then(() => setLocalReady(true));
+
+    await Promise.all([
+      localWork,
       restoreSessionAndNavigate(),
       fetchServerStatusState(),
     ]);
@@ -470,23 +486,20 @@ const App = () => {
   useClearAppIconBadgeOnMobile();
   useScrollbarStyle();
 
+  // The `isOffline` arm: an offline user with a session token would otherwise
+  // be stuck behind the native splash screen with no feedback, since `loadApp`
+  // retries `/check-session-token` until the network returns.
   useEffect(() => {
     (async () => {
-      if (!isLoading || serverStatus !== "ok") {
+      if (!localReady) {
+        return;
+      }
+
+      if (!isLoading || serverStatus !== "ok" || isOffline) {
         await ExpoSplashScreen.hideAsync();
       }
     })();
-  }, [isLoading, serverStatus]);
-
-  // Without this, an offline user with a session token is stuck behind the
-  // native splash screen: `loadApp` retries `/check-session-token` until the
-  // network returns, so the JS tree (and the "You're offline" banner) would
-  // never become visible.
-  useEffect(() => listen<boolean>(EV_NETWORK_IS_ONLINE, (isOnline) => {
-    if (isOnline === false) {
-      ExpoSplashScreen.hideAsync();
-    }
-  }, true), []);
+  }, [localReady, isLoading, serverStatus, isOffline]);
 
   if (serverStatus !== "ok") {
     return <UtilityScreen serverStatus={serverStatus} />

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -2,100 +2,51 @@ import {
   Platform,
 } from 'react-native';
 import {
-  useCallback,
-  useEffect,
   useMemo,
-  useRef,
-  useState,
 } from 'react';
 import {
   DefaultTheme,
-  InitialState,
   NavigationContainer,
-  NavigationState,
   ParamListBase,
-  PartialState,
   createNavigationContainerRef,
-  getPathFromState as rnGetPathFromState,
 } from '@react-navigation/native';
-import * as Font from 'expo-font';
-import * as ScreenOrientation from 'expo-screen-orientation';
-import * as ExpoSplashScreen from 'expo-splash-screen';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { HomeTabs } from './components/home-tabs';
 import { SplashScreen } from './components/splash-screen';
 import { ConnectionStatusBanner } from './components/connection-status-banner';
-import { EV_NETWORK_IS_ONLINE } from './network/network';
 import { ConversationScreen } from './components/conversation-screen/conversation-screen';
-import { ServerStatus, UtilityScreen } from './components/utility-screen';
+import { UtilityScreen } from './components/utility-screen';
 import { ProspectProfileScreen } from './components/prospect-profile-screen/prospect-profile-screen';
 import { GalleryScreen } from './components/gallery-screen';
 import { GlobalBackButton } from './components/global-back-button';
 import { InviteScreen, WelcomeScreen } from './components/welcome-screen';
-import { sessionToken, sessionPersonUuid } from './kv-storage/session-token';
-import { lastPath } from './kv-storage/last-path';
-import { clearAllKvExceptSessionToken } from './kv-storage/kv-storage';
-import { japi, CLIENT_VERSION } from './api/api';
-import { login, logout } from './chat/application-layer';
 import { useInboxStats } from './chat/application-layer/hooks/inbox-stats';
-import { STATUS_URL } from './env/env';
-import { delay } from './util/util';
 import { ColorPickerModal } from './components/modal/color-picker-modal/color-picker-modal';
 import { GifPickerModal } from './components/modal/gif-picker-modal';
 import { EmojiPickerModal } from './components/modal/emoji-picker-modal';
 import { ReportModal } from './components/modal/report-modal';
 import { ImageCropper } from './components/image-cropper';
-import {
-  useClearAppIconBadgeOnMobile,
-  useNotificationObserverOnMobile,
-  getLastNotificationResponseOnMobile,
-} from './notifications/mobile';
+import { useClearAppIconBadgeOnMobile } from './notifications/mobile';
 import { usePushTokenListenerOnMobile } from './notifications/notifications';
-import { useWebPushMessageListenerOnWeb } from './notifications/web-push';
 import { verificationWatcher } from './verification/verification';
-import { ClubItem } from './club/club';
 import { Toast } from './components/toast';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { createLinking, isBannerRoute, focusedProspectHandle, focusedConversationHandle, focusedRouteIsUnrestorable, getTopRouteName } from './navigation/linking';
+import { createLinking } from './navigation/linking';
 import { useScrollbarStyle } from './components/navigation/scroll-bar-hooks';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { ErrorBoundary } from './components/error-boundary';
 import { TooltipListener } from './components/tooltip';
 import { VerificationCameraModal } from './components/verification-camera';
-import { notify, useDerivedEvent } from './events/events';
-import { setActiveConversation } from './chat/conversation-priority';
 import { PointOfSaleModal } from './components/modal/point-of-sale-modal';
 import { DateOfBirthConfirmationModal } from './components/modal/date-of-birth-confirmation-modal';
-import { SignUpModal, showSignUp } from './components/modal/sign-up-modal';
+import { SignUpModal } from './components/modal/sign-up-modal';
 import { SignUpBanner } from './components/sign-up-banner';
-import { hasPendingAppleWebSignIn } from './api/social-auth';
-import { setSignedInUser, useSignedInUser, getSignedInUser, isWebLoggedOut } from './events/signed-in-user';
 import { useAppThemeLoader, useAppTheme } from './app-theme/app-theme';
-import { computeStartupNavigationState } from './navigation/startup';
-import { resetUserScopedClientState } from './navigation/reset-client-state';
+import { useAppStartup } from './app-startup/app-startup';
+import { useAppNavigation } from './navigation/app-navigation';
 
 verificationWatcher();
-
-ExpoSplashScreen.preventAutoHideAsync();
-
-type StatusResponse = {
-  supported_client_versions: number[];
-  statuses: string[];
-  status_index: number;
-};
-
-type CheckSessionTokenResponse = {
-  onboarded?: boolean;
-  clubs?: ClubItem[];
-  person_id?: number;
-  person_uuid?: string;
-  pending_club?: ClubItem | null;
-  units?: string;
-  estimated_end_date?: string;
-  name?: string | null;
-  has_gold?: boolean;
-};
 
 const Stack = createNativeStackNavigator();
 
@@ -105,360 +56,29 @@ const isImagePickerOpen = { value: false };
 const navigationContainerRef = createNavigationContainerRef<ParamListBase>();
 
 const App = () => {
-  const [initialState, setInitialState] = useState<InitialState | undefined>(undefined);
-  const [isLoading, setIsLoading] = useState(true);
-  const [localReady, setLocalReady] = useState(false);
-  const [serverStatus, setServerStatus] = useState<ServerStatus>("ok");
-  const [signedInUser] = useSignedInUser();
-  const [bannerVisible, setBannerVisible] = useState(false);
-  const [bannerProspectHandle, setBannerProspectHandle] = useState<string | undefined>(undefined);
-  const pendingPostLoginStateRef = useRef<PartialState<NavigationState> | null>(null);
-  const isOffline = useDerivedEvent<boolean, boolean>(
-    EV_NETWORK_IS_ONLINE,
-    (isOnline) => isOnline === false,
-    [],
-  );
   useAppThemeLoader();
   const { appTheme } = useAppTheme();
 
   const linking = useMemo(() => createLinking(), []);
 
-  const loadFonts = useCallback(async () => {
-    await Font.loadAsync({
-      Trueno: require('./assets/fonts/TruenoRound.otf'),
-      TruenoBold: require('./assets/fonts/TruenoRoundBd.otf'),
+  const {
+    pendingPostLoginStateRef,
+    bannerVisible,
+    bannerProspectHandle,
+    onNavigationReady,
+    onNavigationStateChange,
+  } = useAppNavigation(linking, navigationContainerRef);
 
-      MontserratBlack: require('./assets/fonts/montserrat/static/Montserrat-Black.ttf'),
-      MontserratBold: require('./assets/fonts/montserrat/static/Montserrat-Bold.ttf'),
-      MontserratExtraBold: require('./assets/fonts/montserrat/static/Montserrat-ExtraBold.ttf'),
-      MontserratExtraLight: require('./assets/fonts/montserrat/static/Montserrat-ExtraLight.ttf'),
-      MontserratLight: require('./assets/fonts/montserrat/static/Montserrat-Light.ttf'),
-      MontserratMedium: require('./assets/fonts/montserrat/static/Montserrat-Medium.ttf'),
-      MontserratRegular: require('./assets/fonts/montserrat/static/Montserrat-Regular.ttf'),
-      MontserratSemiBold: require('./assets/fonts/montserrat/static/Montserrat-SemiBold.ttf'),
-      MontserratThin: require('./assets/fonts/montserrat/static/Montserrat-Thin.ttf'),
-    });
-  }, []);
+  const {
+    initialState,
+    isLoading,
+    serverStatus,
+    onError,
+  } = useAppStartup(linking, pendingPostLoginStateRef);
 
-  const lockScreenOrientation = useCallback(async () => {
-    try {
-      if (Platform.OS === 'ios' || Platform.OS === 'android') {
-        await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT);
-      }
-    } catch (e) {
-      console.warn(e);
-    }
-  }, []);
-
-  const restoreSessionAndNavigate = useCallback(async () => {
-    const existingPersonUuid = await sessionPersonUuid();
-    const existingSessionToken = await sessionToken();
-    const notification = await getLastNotificationResponseOnMobile();
-
-    // `computeStartupNavigationState` owns every routing decision at startup:
-    // URL deep-links, public-vs-protected screens, push notifications, the
-    // pending-club flow, and persisted last-path restoration. The only thing
-    // we still do here is the auth side-effects (token check, logout, set
-    // signed-in user) and pass the resulting auth state in.
-    const applyStartupNav = async (
-      isAuthenticated: boolean,
-      pendingClub: ClubItem | null = null,
-    ) => {
-      const result = await computeStartupNavigationState({
-        linking,
-        isAuthenticated,
-        notification,
-        pendingClub,
-      });
-      if (result.postLoginRedirectState) {
-        pendingPostLoginStateRef.current = result.postLoginRedirectState;
-      }
-      // Report the focused conversation as soon as the startup route is known -
-      // before the navigation container mounts - so the chat layer can order an
-      // open conversation's history ahead of the inbox without waiting on
-      // `onReady`, and doesn't stall the inbox query when no conversation is
-      // open. See `frontend/chat/conversation-priority`.
-      setActiveConversation(focusedConversationHandle(result.initialState) ?? null);
-      setInitialState(result.initialState);
-    };
-
-    if (!existingPersonUuid || !existingSessionToken) {
-      await sessionPersonUuid(null);
-      await sessionToken(null);
-      await lastPath(null);
-      resetUserScopedClientState();
-      setSignedInUser(undefined);
-      logout();
-      await applyStartupNav(false);
-      return;
-    }
-
-    if (typeof existingSessionToken !== 'string') {
-      return;
-    }
-
-    // Log into XMPP
-    login(existingPersonUuid, existingSessionToken);
-
-    const response = await japi<CheckSessionTokenResponse>(
-      'post',
-      '/check-session-token',
-      undefined,
-      { retryOnTransientError: true }
-    );
-
-    const json = response.json;
-
-    if (
-      response.clientError ||
-      !json ||
-      json.onboarded === false ||
-      json.person_id === undefined ||
-      json.person_uuid === undefined
-    ) {
-      await sessionPersonUuid(null);
-      await sessionToken(null);
-      await lastPath(null);
-      resetUserScopedClientState();
-      setSignedInUser(undefined);
-      logout();
-      await applyStartupNav(false);
-      return;
-    }
-
-    const clubs = json.clubs;
-    const pendingClub = json.pending_club ?? null;
-
-    setSignedInUser({
-      personId: json.person_id,
-      personUuid: json.person_uuid,
-      units: json.units === 'Imperial' ? 'Imperial' : 'Metric',
-      sessionToken: existingSessionToken,
-      pendingClub: pendingClub,
-      estimatedEndDate: new Date(json.estimated_end_date ?? NaN),
-      name: json.name ?? null,
-      hasGold: json.has_gold ?? false,
-    });
-
-    notify<ClubItem[] | undefined>('updated-clubs', clubs);
-
-    await applyStartupNav(true, pendingClub);
-  }, [linking]);
-
-  // Centralised post-sign-in redirect. Runs both when `signedInUser` changes
-  // (the post-OTP-flow case) and when the NavigationContainer reports ready
-  // (the cold-start-with-existing-session case, where `signedInUser` may
-  // have been populated *before* the container mounted, so the effect's
-  // ref-lookup would have early-returned).
-  //
-  // Two responsibilities:
-  //   1. If a protected URL was deep-linked while logged-out, restore it
-  //      after the user signs in (`pendingPostLoginStateRef`).
-  //   2. Otherwise, if the user is parked on the logged-out Welcome stack
-  //      (just completed OTP, or typed `/sign-in`/`/welcome` while already
-  //      signed in), forward them to the canonical landing tab so they
-  //      aren't stranded on the sign-in form.
-  const applyPostSignInRedirect = useCallback(() => {
-    if (!getSignedInUser()) return;
-
-    const navigationContainer = navigationContainerRef.current;
-    if (!navigationContainer) return;
-
-    const pending = pendingPostLoginStateRef.current;
-    pendingPostLoginStateRef.current = null;
-
-    if (pending) {
-      navigationContainer.reset(pending);
-      return;
-    }
-
-    if (getTopRouteName(navigationContainer.getRootState?.()) === 'Welcome') {
-      navigationContainer.reset({
-        routes: [
-          { name: 'Home', state: { routes: [{ name: 'Q&A' }] } },
-        ],
-      });
-    }
-  }, []);
-
-  const recomputeBannerVisible = useCallback((state?: NavigationState) => {
-    const rootState = state ?? navigationContainerRef.current?.getRootState?.();
-    setBannerVisible(isWebLoggedOut() && isBannerRoute(rootState));
-    setBannerProspectHandle(focusedProspectHandle(rootState));
-  }, []);
-
-  // Tell the chat layer which conversation (if any) is on screen, so on connect
-  // it can load an open conversation's history before the inbox snapshot. See
-  // `frontend/chat/conversation-priority`.
-  const publishActiveConversation = useCallback((state?: NavigationState) => {
-    const rootState = state ?? navigationContainerRef.current?.getRootState?.();
-    setActiveConversation(focusedConversationHandle(rootState) ?? null);
-  }, []);
-
-  const onNavigationReady = useCallback(() => {
-    applyPostSignInRedirect();
-    recomputeBannerVisible();
-    publishActiveConversation();
-  }, [applyPostSignInRedirect, recomputeBannerVisible, publishActiveConversation]);
-
-  useEffect(() => {
-    // On sign-out drop any remaining pending state so a stale entry from
-    // this session can't latch onto a subsequent sign-in as a different
-    // user on the same browser.
-    if (!signedInUser) {
-      pendingPostLoginStateRef.current = null;
-    } else {
-      applyPostSignInRedirect();
-    }
-    recomputeBannerVisible();
-  }, [signedInUser?.personUuid, applyPostSignInRedirect, recomputeBannerVisible]);
-
-  const fetchServerStatusState = useCallback(async () => {
-    let response: Response | null = null
-    try {
-      response = await fetch(STATUS_URL, { cache: 'no-store' });
-    } catch (_) {};
-
-    if (response === null || !response.ok) {
-      // If even the status server is down, things are *very* not-okay. But odds
-      // are it can't be contacted because the user has a crappy internet
-      // connection. The "You're offline" notice should still provide some
-      // feedback.
-      setServerStatus("ok");
-      return;
-    }
-
-    const j: StatusResponse = await response.json();
-    const supportedClientVersions = j.supported_client_versions;
-    const reportedStatus = j.statuses[j.status_index];
-
-    const latestServerStatus: ServerStatus = (() => {
-      if (reportedStatus === "down for maintenance") {
-        return reportedStatus;
-      } else if (
-        !supportedClientVersions.includes(CLIENT_VERSION)
-      ) {
-        return "please update";
-      } else if (reportedStatus === "ok") {
-        return reportedStatus;
-      } else {
-        return "down for maintenance";
-      }
-    })();
-
-    if (serverStatus !== latestServerStatus) {
-      setServerStatus(latestServerStatus);
-    }
-  }, [serverStatus]);
-
-  const loadApp = useCallback(async () => {
-    // The splash screen may hide once the work that doesn't need the network
-    // is done; the network-dependent work below can stall indefinitely
-    // offline, which is what the `isOffline` arm of the hide condition
-    // bypasses.
-    const localWork = Promise.all([
-      loadFonts(),
-      lockScreenOrientation(),
-    ])
-      .catch((e) => console.warn(e))
-      .then(() => setLocalReady(true));
-
-    await Promise.all([
-      localWork,
-      restoreSessionAndNavigate(),
-      fetchServerStatusState(),
-    ]);
-
-    setIsLoading(false);
-  }, []);
-
-  useEffect(() => {
-    loadApp();
-  }, []);
-
-  useEffect(() => {
-    if (isLoading) return;
-    if (getSignedInUser()) return;
-    if (hasPendingAppleWebSignIn()) {
-      showSignUp(true);
-    }
-  }, [isLoading]);
-
-  useEffect(() => {
-    // Without this flag, an infinite loop will start each time this effect
-    // starts, which would effectively be whenever the server's status changes.
-    // That would lead to multiple infinite loops running concurrently.
-    let doBreak = false;
-
-    (async () => {
-      while (true) {
-        await delay(5000);
-        await fetchServerStatusState();
-        if (doBreak) break;
-      }
-    })();
-
-    return () => { doBreak = true; };
-  }, [fetchServerStatusState]);
-
-  const onError = useCallback(async () => {
-    await clearAllKvExceptSessionToken();
-
-    loadApp();
-  }, []);
-
-  const onNavigationStateChange = useCallback(async (state: NavigationState) => {
-    if (!state) return;
-
-    recomputeBannerVisible(state);
-    publishActiveConversation(state);
-
-    // URL-bar sync is left entirely to React Navigation's linking integration.
-    // Doing a `window.history.replaceState` here in addition to RN's own
-    // pushState corrupts the browser history stack: our handler runs
-    // synchronously from the state-change emit, while RN's pushState is
-    // queued as a microtask, so our replace overwrites the URL of the
-    // *previous* browser entry before RN appends a new one - effectively
-    // collapsing two history entries into one and breaking the back button.
-
-    // Read auth synchronously rather than closing over `signedInUser`. During
-    // sign-out we clear the user before triggering the navigation reset, and
-    // a stale closure would persist the post-logout path under the previous
-    // identity (or vice versa).
-    if (!getSignedInUser()) return;
-
-    // Don't persist URLs that can't be restored: the OptionScreen-backed
-    // wizards would hydrate with no payload and immediately `popToTop`, and
-    // the gallery would come back as the only route, with no screen under it
-    // to close onto. See `UNRESTORABLE_ROUTE_NAMES`. Walking the focused route
-    // chain detects these regardless of how deeply nested they are.
-    if (focusedRouteIsUnrestorable(state)) return;
-
-    // Persist just the canonical path - not the full navigation tree - so we
-    // can restore the user's last place on next startup. We let React
-    // Navigation's `getPathFromState` do the serialization so this stays in
-    // lock-step with whatever URL structure the linking config exposes.
-    try {
-      // The `as any` is unfortunate but unavoidable: React Navigation's
-      // PathConfig types insist every `screens`-bearing entry also declare
-      // its own `path`, but our `Home` deliberately doesn't have one (its
-      // children inherit the empty root). The runtime invariant being relied
-      // on here is that `Home` is always the implicit root of the path tree,
-      // so any path produced by getPathFromState round-trips back to a
-      // valid state via getStateFromPath.
-      const path = rnGetPathFromState(state, linking.config);
-      if (typeof path === 'string') {
-        await lastPath(path.startsWith('/') ? path : `/${path}`);
-      }
-    } catch (e) {
-      // Some transient navigation states aren't representable as URLs (e.g.
-      // mid-transition or screens not in the linking config). Skip those
-      // and warn so misconfiguration doesn't silently break last-path
-      // restoration in production - but use `warn` rather than `error`
-      // because intermittent failures on transient states are expected.
-      console.warn('Failed to persist last navigation path', e);
-    }
-  }, [linking, recomputeBannerVisible, publishActiveConversation]);
+  usePushTokenListenerOnMobile();
+  useClearAppIconBadgeOnMobile();
+  useScrollbarStyle();
 
   // Only need live updates on web (for browser tab title)
   const stats = useInboxStats(Platform.OS === 'web');
@@ -466,40 +86,6 @@ const App = () => {
   const numUnread =
     (stats?.numUnreadChats ?? 0) +
     (stats?.numUnreadIntros ?? 0);
-
-  const navigateFromNotification = (
-    screen: string,
-    params: Record<string, unknown>,
-  ) => {
-    const navigationContainer = navigationContainerRef.current;
-
-    if (!navigationContainer) return;
-    if (!screen) return;
-
-    navigationContainer.navigate(screen, params);
-  };
-
-  useNotificationObserverOnMobile(navigateFromNotification);
-  useWebPushMessageListenerOnWeb(navigateFromNotification);
-
-  usePushTokenListenerOnMobile();
-  useClearAppIconBadgeOnMobile();
-  useScrollbarStyle();
-
-  // The `isOffline` arm: an offline user with a session token would otherwise
-  // be stuck behind the native splash screen with no feedback, since `loadApp`
-  // retries `/check-session-token` until the network returns.
-  useEffect(() => {
-    (async () => {
-      if (!localReady) {
-        return;
-      }
-
-      if (!isLoading || serverStatus !== "ok" || isOffline) {
-        await ExpoSplashScreen.hideAsync();
-      }
-    })();
-  }, [localReady, isLoading, serverStatus, isOffline]);
 
   if (serverStatus !== "ok") {
     return <UtilityScreen serverStatus={serverStatus} />

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -24,6 +24,8 @@ import * as ExpoSplashScreen from 'expo-splash-screen';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { HomeTabs } from './components/home-tabs';
 import { SplashScreen } from './components/splash-screen';
+import { ConnectionStatusBanner } from './components/connection-status-banner';
+import { EV_NETWORK_IS_ONLINE } from './network/network';
 import { ConversationScreen } from './components/conversation-screen/conversation-screen';
 import { ServerStatus, UtilityScreen } from './components/utility-screen';
 import { ProspectProfileScreen } from './components/prospect-profile-screen/prospect-profile-screen';
@@ -61,7 +63,7 @@ import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { ErrorBoundary } from './components/error-boundary';
 import { TooltipListener } from './components/tooltip';
 import { VerificationCameraModal } from './components/verification-camera';
-import { notify } from './events/events';
+import { listen, notify } from './events/events';
 import { setActiveConversation } from './chat/conversation-priority';
 import { PointOfSaleModal } from './components/modal/point-of-sale-modal';
 import { DateOfBirthConfirmationModal } from './components/modal/date-of-birth-confirmation-modal';
@@ -476,6 +478,16 @@ const App = () => {
     })();
   }, [isLoading, serverStatus]);
 
+  // Without this, an offline user with a session token is stuck behind the
+  // native splash screen: `loadApp` retries `/check-session-token` until the
+  // network returns, so the JS tree (and the "You're offline" banner) would
+  // never become visible.
+  useEffect(() => listen<boolean>(EV_NETWORK_IS_ONLINE, (isOnline) => {
+    if (isOnline === false) {
+      ExpoSplashScreen.hideAsync();
+    }
+  }, true), []);
+
   if (serverStatus !== "ok") {
     return <UtilityScreen serverStatus={serverStatus} />
   }
@@ -567,6 +579,7 @@ const App = () => {
           </GestureHandlerRootView>
         }
         <SplashScreen loading={isLoading} />
+        <ConnectionStatusBanner/>
       </SafeAreaProvider>
     </ErrorBoundary>
   );

--- a/frontend/api/api.tsx
+++ b/frontend/api/api.tsx
@@ -3,8 +3,9 @@ import {
 } from '../env/env';
 import * as _ from "lodash";
 import { sessionToken } from '../kv-storage/session-token';
-import { delay, makeBackoff } from '../util/util';
-import { notify } from '../events/events';
+import { makeBackoff } from '../util/util';
+import { nextEvent, notify } from '../events/events';
+import { EV_NETWORK_CAME_ONLINE } from '../network/network';
 import { ValidationErrorToast, SOMETHING_WENT_WRONG } from '../components/toast';
 
 const CLIENT_VERSION = 10;
@@ -107,7 +108,7 @@ const api = async <T = unknown>(
       // TODO: There should be a message in the UI saying "you're offline" or something
       console.log(`Waiting ${(jitteredDelayMs / 1000).toFixed(1)} seconds and trying again; Caught error while fetching ${url}`, error);
 
-      await delay(jitteredDelayMs);
+      await nextEvent(EV_NETWORK_CAME_ONLINE, jitteredDelayMs);
     } finally {
       // cancel the timeout whether there was an error or not
       clearTimeout(timeoutId);

--- a/frontend/app-startup/app-startup.tsx
+++ b/frontend/app-startup/app-startup.tsx
@@ -1,0 +1,306 @@
+import { Platform } from 'react-native';
+import {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+import {
+  InitialState,
+  NavigationState,
+  PartialState,
+} from '@react-navigation/native';
+import * as Font from 'expo-font';
+import * as ScreenOrientation from 'expo-screen-orientation';
+import * as ExpoSplashScreen from 'expo-splash-screen';
+import { sessionToken, sessionPersonUuid } from '../kv-storage/session-token';
+import { lastPath } from '../kv-storage/last-path';
+import { clearAllKvExceptSessionToken } from '../kv-storage/kv-storage';
+import { japi, CLIENT_VERSION } from '../api/api';
+import { login, logout } from '../chat/application-layer';
+import { STATUS_URL } from '../env/env';
+import { delay } from '../util/util';
+import { getLastNotificationResponseOnMobile } from '../notifications/mobile';
+import { ClubItem } from '../club/club';
+import { ServerStatus } from '../components/utility-screen';
+import { notify, useDerivedEvent } from '../events/events';
+import { EV_NETWORK_IS_ONLINE } from '../network/network';
+import { setActiveConversation } from '../chat/conversation-priority';
+import { setSignedInUser, getSignedInUser } from '../events/signed-in-user';
+import { computeStartupNavigationState } from '../navigation/startup';
+import { createLinking, focusedConversationHandle } from '../navigation/linking';
+import { resetUserScopedClientState } from '../navigation/reset-client-state';
+import { hasPendingAppleWebSignIn } from '../api/social-auth';
+import { showSignUp } from '../components/modal/sign-up-modal';
+
+ExpoSplashScreen.preventAutoHideAsync();
+
+type AppLinking = ReturnType<typeof createLinking>;
+
+type StatusResponse = {
+  supported_client_versions: number[];
+  statuses: string[];
+  status_index: number;
+};
+
+type CheckSessionTokenResponse = {
+  onboarded?: boolean;
+  clubs?: ClubItem[];
+  person_id?: number;
+  person_uuid?: string;
+  pending_club?: ClubItem | null;
+  units?: string;
+  estimated_end_date?: string;
+  name?: string | null;
+  has_gold?: boolean;
+};
+
+type AppStartup = {
+  initialState: InitialState | undefined
+  isLoading: boolean
+  serverStatus: ServerStatus
+  onError: () => void
+};
+
+const loadFonts = async () => {
+  await Font.loadAsync({
+    Trueno: require('../assets/fonts/TruenoRound.otf'),
+    TruenoBold: require('../assets/fonts/TruenoRoundBd.otf'),
+
+    MontserratBlack: require('../assets/fonts/montserrat/static/Montserrat-Black.ttf'),
+    MontserratBold: require('../assets/fonts/montserrat/static/Montserrat-Bold.ttf'),
+    MontserratExtraBold: require('../assets/fonts/montserrat/static/Montserrat-ExtraBold.ttf'),
+    MontserratExtraLight: require('../assets/fonts/montserrat/static/Montserrat-ExtraLight.ttf'),
+    MontserratLight: require('../assets/fonts/montserrat/static/Montserrat-Light.ttf'),
+    MontserratMedium: require('../assets/fonts/montserrat/static/Montserrat-Medium.ttf'),
+    MontserratRegular: require('../assets/fonts/montserrat/static/Montserrat-Regular.ttf'),
+    MontserratSemiBold: require('../assets/fonts/montserrat/static/Montserrat-SemiBold.ttf'),
+    MontserratThin: require('../assets/fonts/montserrat/static/Montserrat-Thin.ttf'),
+  });
+};
+
+const lockScreenOrientation = async () => {
+  try {
+    if (Platform.OS === 'ios' || Platform.OS === 'android') {
+      await ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT);
+    }
+  } catch (e) {
+    console.warn(e);
+  }
+};
+
+const fetchServerStatus = async (): Promise<ServerStatus> => {
+  let response: Response | null = null
+  try {
+    response = await fetch(STATUS_URL, { cache: 'no-store' });
+  } catch (_) {};
+
+  if (response === null || !response.ok) {
+    // If even the status server is down, things are *very* not-okay. But odds
+    // are it can't be contacted because the user has a crappy internet
+    // connection. The "You're offline" notice should still provide some
+    // feedback.
+    return "ok";
+  }
+
+  const j: StatusResponse = await response.json();
+  const supportedClientVersions = j.supported_client_versions;
+  const reportedStatus = j.statuses[j.status_index];
+
+  if (reportedStatus === "down for maintenance") {
+    return reportedStatus;
+  } else if (!supportedClientVersions.includes(CLIENT_VERSION)) {
+    return "please update";
+  } else if (reportedStatus === "ok") {
+    return reportedStatus;
+  } else {
+    return "down for maintenance";
+  }
+};
+
+const useAppStartup = (
+  linking: AppLinking,
+  pendingPostLoginStateRef: MutableRefObject<PartialState<NavigationState> | null>,
+): AppStartup => {
+  const [initialState, setInitialState] = useState<InitialState | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(true);
+  const [localReady, setLocalReady] = useState(false);
+  const [serverStatus, setServerStatus] = useState<ServerStatus>("ok");
+  const isOffline = useDerivedEvent<boolean, boolean>(
+    EV_NETWORK_IS_ONLINE,
+    (isOnline) => isOnline === false,
+    [],
+  );
+
+  const restoreSessionAndNavigate = useCallback(async () => {
+    const existingPersonUuid = await sessionPersonUuid();
+    const existingSessionToken = await sessionToken();
+    const notification = await getLastNotificationResponseOnMobile();
+
+    // `computeStartupNavigationState` owns every routing decision at startup:
+    // URL deep-links, public-vs-protected screens, push notifications, the
+    // pending-club flow, and persisted last-path restoration. The only thing
+    // we still do here is the auth side-effects (token check, logout, set
+    // signed-in user) and pass the resulting auth state in.
+    const applyStartupNav = async (
+      isAuthenticated: boolean,
+      pendingClub: ClubItem | null = null,
+    ) => {
+      const result = await computeStartupNavigationState({
+        linking,
+        isAuthenticated,
+        notification,
+        pendingClub,
+      });
+      if (result.postLoginRedirectState) {
+        pendingPostLoginStateRef.current = result.postLoginRedirectState;
+      }
+      // Report the focused conversation as soon as the startup route is known -
+      // before the navigation container mounts - so the chat layer can order an
+      // open conversation's history ahead of the inbox without waiting on
+      // `onReady`, and doesn't stall the inbox query when no conversation is
+      // open. See `frontend/chat/conversation-priority`.
+      setActiveConversation(focusedConversationHandle(result.initialState) ?? null);
+      setInitialState(result.initialState);
+    };
+
+    if (!existingPersonUuid || !existingSessionToken) {
+      await sessionPersonUuid(null);
+      await sessionToken(null);
+      await lastPath(null);
+      resetUserScopedClientState();
+      setSignedInUser(undefined);
+      logout();
+      await applyStartupNav(false);
+      return;
+    }
+
+    if (typeof existingSessionToken !== 'string') {
+      return;
+    }
+
+    // Log into XMPP
+    login(existingPersonUuid, existingSessionToken);
+
+    const response = await japi<CheckSessionTokenResponse>(
+      'post',
+      '/check-session-token',
+      undefined,
+      { retryOnTransientError: true }
+    );
+
+    const json = response.json;
+
+    if (
+      response.clientError ||
+      !json ||
+      json.onboarded === false ||
+      json.person_id === undefined ||
+      json.person_uuid === undefined
+    ) {
+      await sessionPersonUuid(null);
+      await sessionToken(null);
+      await lastPath(null);
+      resetUserScopedClientState();
+      setSignedInUser(undefined);
+      logout();
+      await applyStartupNav(false);
+      return;
+    }
+
+    const clubs = json.clubs;
+    const pendingClub = json.pending_club ?? null;
+
+    setSignedInUser({
+      personId: json.person_id,
+      personUuid: json.person_uuid,
+      units: json.units === 'Imperial' ? 'Imperial' : 'Metric',
+      sessionToken: existingSessionToken,
+      pendingClub: pendingClub,
+      estimatedEndDate: new Date(json.estimated_end_date ?? NaN),
+      name: json.name ?? null,
+      hasGold: json.has_gold ?? false,
+    });
+
+    notify<ClubItem[] | undefined>('updated-clubs', clubs);
+
+    await applyStartupNav(true, pendingClub);
+  }, [linking]);
+
+  const loadApp = useCallback(async () => {
+    // The splash screen may hide once the work that doesn't need the network
+    // is done; the network-dependent work below can stall indefinitely
+    // offline, which is what the `isOffline` arm of the hide condition
+    // bypasses.
+    const localWork = Promise.all([
+      loadFonts(),
+      lockScreenOrientation(),
+    ])
+      .catch((e) => console.warn(e))
+      .then(() => setLocalReady(true));
+
+    await Promise.all([
+      localWork,
+      restoreSessionAndNavigate(),
+      fetchServerStatus().then(setServerStatus),
+    ]);
+
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadApp();
+  }, []);
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (getSignedInUser()) return;
+    if (hasPendingAppleWebSignIn()) {
+      showSignUp(true);
+    }
+  }, [isLoading]);
+
+  // Poll the server status. The flag stops the loop when the effect is torn
+  // down, so remounts can't accumulate concurrent loops.
+  useEffect(() => {
+    let doBreak = false;
+
+    (async () => {
+      while (true) {
+        await delay(5000);
+        setServerStatus(await fetchServerStatus());
+        if (doBreak) break;
+      }
+    })();
+
+    return () => { doBreak = true; };
+  }, []);
+
+  const onError = useCallback(async () => {
+    await clearAllKvExceptSessionToken();
+
+    loadApp();
+  }, []);
+
+  // The `isOffline` arm: an offline user with a session token would otherwise
+  // be stuck behind the native splash screen with no feedback, since `loadApp`
+  // retries `/check-session-token` until the network returns.
+  useEffect(() => {
+    (async () => {
+      if (!localReady) {
+        return;
+      }
+
+      if (!isLoading || serverStatus !== "ok" || isOffline) {
+        await ExpoSplashScreen.hideAsync();
+      }
+    })();
+  }, [localReady, isLoading, serverStatus, isOffline]);
+
+  return { initialState, isLoading, serverStatus, onError };
+};
+
+export {
+  AppStartup,
+  useAppStartup,
+};

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -50,17 +50,17 @@ const closeChatWebSocket = (): void => {
 // up to 60 seconds before `onclose` fires; WebKit fails the socket
 // immediately. Dropping the reference right away lets a reconnect proceed
 // without waiting for the zombie to time out. The zombie's own callbacks are
-// inert thanks to the `ws !== socket` guards.
+// inert thanks to the `ws !== _ws` guards.
 const abandonChatWebSocket = (): void => {
-  const socket = ws;
+  const _ws = ws;
 
-  if (!socket) {
+  if (!_ws) {
     return;
   }
 
   ws = null;
   expectedClose = false;
-  socket.close();
+  _ws.close();
   notify(EV_CHAT_WS_CLOSE);
   setTimeout(connectChatWebSocket, reconnectBackoff.next());
 };
@@ -86,13 +86,13 @@ const connectChatWebSocket = (): void => {
     return;
   }
 
-  const socket = new WebSocket(CHAT_URL, ['json']);
-  ws = socket;
+  const _ws = new WebSocket(CHAT_URL, ['json']);
+  ws = _ws;
 
   let resetDelayTimeout: ReturnType<typeof setTimeout> | undefined;
 
-  socket.onopen = () => {
-    if (ws !== socket) {
+  _ws.onopen = () => {
+    if (ws !== _ws) {
       return;
     }
 
@@ -100,8 +100,8 @@ const connectChatWebSocket = (): void => {
     notify(EV_CHAT_WS_OPEN);
   };
 
-  socket.onmessage = (event: MessageEvent) => {
-    if (ws !== socket) {
+  _ws.onmessage = (event: MessageEvent) => {
+    if (ws !== _ws) {
       return;
     }
 
@@ -111,10 +111,10 @@ const connectChatWebSocket = (): void => {
   // This seems to get called after the app has been backgrounded for some time.
   // If not, the ping mechanism should still restart the connection, though more
   // slowly.
-  socket.onclose = (event: CloseEvent) => {
+  _ws.onclose = (event: CloseEvent) => {
     clearTimeout(resetDelayTimeout);
 
-    if (ws !== socket) {
+    if (ws !== _ws) {
       return;
     }
 
@@ -129,8 +129,8 @@ const connectChatWebSocket = (): void => {
     }
   };
 
-  socket.onerror = () => {
-    socket.close();
+  _ws.onerror = () => {
+    _ws.close();
   };
 };
 

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -1,12 +1,15 @@
 import { CHAT_URL } from '../env/env';
-import { listen, notify } from '../events/events';
+import { lastEvent, listen, notify } from '../events/events';
 import {
   delay,
   jsonParseSilently,
   makeBackoff,
 } from '../util/util';
 import { AppState, AppStateStatus, Platform } from 'react-native';
-import { EV_NETWORK_CAME_ONLINE } from '../network/network';
+import {
+  EV_NETWORK_CAME_ONLINE,
+  EV_NETWORK_IS_ONLINE,
+} from '../network/network';
 
 type Pong = {
   preferredInterval: number
@@ -47,12 +50,19 @@ listen(EV_CHAT_WS_SEND_CLOSE, closeChatWebSocket);
 const isBackgrounded = (state: AppStateStatus): boolean =>
   Platform.OS !== 'web' && ['background', 'inactive'].includes(state);
 
+const isOffline = (): boolean =>
+  lastEvent<boolean>(EV_NETWORK_IS_ONLINE) === false;
+
 const connectChatWebSocket = (): void => {
   if (ws) {
     return;
   }
 
   if (isBackgrounded(AppState.currentState)) {
+    return;
+  }
+
+  if (isOffline()) {
     return;
   }
 
@@ -278,6 +288,15 @@ const onChangeAppState = (state: AppStateStatus) => {
 // In effect, updates the inbox when resuming from an inactive state by
 // detecting if the app went offline
 AppState.addEventListener('change', onChangeAppState);
+
+// Desktop browsers don't close websockets when connectivity drops; the socket
+// object stays OPEN until a write times out. Close it ourselves so the
+// came-online reconnect below isn't blocked by a stale socket.
+listen<boolean>(EV_NETWORK_IS_ONLINE, (isOnline) => {
+  if (isOnline === false) {
+    closeChatWebSocket();
+  }
+});
 
 listen(EV_NETWORK_CAME_ONLINE, connectChatWebSocket);
 

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -45,6 +45,26 @@ const closeChatWebSocket = (): void => {
   ws.close();
 };
 
+// `close()` only starts the closing handshake. When the network is gone the
+// close frame can't be delivered, so Chromium parks the socket in CLOSING for
+// up to 60 seconds before `onclose` fires; WebKit fails the socket
+// immediately. Dropping the reference right away lets a reconnect proceed
+// without waiting for the zombie to time out. The zombie's own callbacks are
+// inert thanks to the `ws !== socket` guards.
+const abandonChatWebSocket = (): void => {
+  const socket = ws;
+
+  if (!socket) {
+    return;
+  }
+
+  ws = null;
+  expectedClose = false;
+  socket.close();
+  notify(EV_CHAT_WS_CLOSE);
+  setTimeout(connectChatWebSocket, reconnectBackoff.next());
+};
+
 listen(EV_CHAT_WS_SEND_CLOSE, closeChatWebSocket);
 
 const isBackgrounded = (state: AppStateStatus): boolean =>
@@ -66,24 +86,38 @@ const connectChatWebSocket = (): void => {
     return;
   }
 
-  ws = new WebSocket(CHAT_URL, ['json']);
+  const socket = new WebSocket(CHAT_URL, ['json']);
+  ws = socket;
 
   let resetDelayTimeout: ReturnType<typeof setTimeout> | undefined;
 
-  ws.onopen = () => {
+  socket.onopen = () => {
+    if (ws !== socket) {
+      return;
+    }
+
     resetDelayTimeout = setTimeout(reconnectBackoff.reset, stableConnectionMs);
     notify(EV_CHAT_WS_OPEN);
   };
 
-  ws.onmessage = (event: MessageEvent) => {
+  socket.onmessage = (event: MessageEvent) => {
+    if (ws !== socket) {
+      return;
+    }
+
     notify<any>(EV_CHAT_WS_RECEIVE, jsonParseSilently(event.data)); // eslint-disable-line @typescript-eslint/no-explicit-any
   };
 
   // This seems to get called after the app has been backgrounded for some time.
   // If not, the ping mechanism should still restart the connection, though more
   // slowly.
-  ws.onclose = (event: CloseEvent) => {
+  socket.onclose = (event: CloseEvent) => {
     clearTimeout(resetDelayTimeout);
+
+    if (ws !== socket) {
+      return;
+    }
+
     notify<CloseEvent>(EV_CHAT_WS_CLOSE, event);
     ws = null;
 
@@ -95,8 +129,8 @@ const connectChatWebSocket = (): void => {
     }
   };
 
-  ws.onerror = () => {
-    ws?.close();
+  socket.onerror = () => {
+    socket.close();
   };
 };
 
@@ -250,7 +284,8 @@ const pingServer = async () => {
   }
 
   if (response === 'timeout') {
-    ws?.close();
+    // An unresponsive connection would stall the closing handshake too.
+    abandonChatWebSocket();
   } else {
     Object.assign(pong, response);
   }
@@ -290,11 +325,12 @@ const onChangeAppState = (state: AppStateStatus) => {
 AppState.addEventListener('change', onChangeAppState);
 
 // Desktop browsers don't close websockets when connectivity drops; the socket
-// object stays OPEN until a write times out. Close it ourselves so the
-// came-online reconnect below isn't blocked by a stale socket.
+// object stays OPEN until a write times out. Abandon it (rather than just
+// closing: see `abandonChatWebSocket`) so the came-online reconnect below
+// isn't blocked by a socket stuck in CLOSING.
 listen<boolean>(EV_NETWORK_IS_ONLINE, (isOnline) => {
   if (isOnline === false) {
-    closeChatWebSocket();
+    abandonChatWebSocket();
   }
 });
 

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -6,6 +6,7 @@ import {
   makeBackoff,
 } from '../util/util';
 import { AppState, AppStateStatus, Platform } from 'react-native';
+import { EV_NETWORK_CAME_ONLINE } from '../network/network';
 
 type Pong = {
   preferredInterval: number
@@ -277,6 +278,8 @@ const onChangeAppState = (state: AppStateStatus) => {
 // In effect, updates the inbox when resuming from an inactive state by
 // detecting if the app went offline
 AppState.addEventListener('change', onChangeAppState);
+
+listen(EV_NETWORK_CAME_ONLINE, connectChatWebSocket);
 
 connectChatWebSocket();
 

--- a/frontend/components/connection-status-banner.tsx
+++ b/frontend/components/connection-status-banner.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from 'react';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome';
+import { faWifi } from '@fortawesome/free-solid-svg-icons/faWifi';
+import { listen } from '../events/events';
+import { EV_NETWORK_IS_ONLINE } from '../network/network';
+import { DefaultText } from './default-text';
+import { ToastContainer } from './toast';
+import { useAppTheme } from '../app-theme/app-theme';
+
+const HIDDEN_POSITION = -500;
+const SLIDE_DURATION = 300;
+const BACK_ONLINE_HOLD_MS = 3000;
+
+type Banner = 'offline' | 'back-online';
+
+const bannerText: Record<Banner, string> = {
+  'offline': "You're offline",
+  'back-online': "You're back online",
+};
+
+const ConnectionStatusBanner = () => {
+  const insets = useSafeAreaInsets();
+  const { appTheme } = useAppTheme();
+  const translateY = useSharedValue(HIDDEN_POSITION);
+  const [banner, setBanner] = useState<Banner | null>(null);
+  const lastBannerRef = useRef<Banner>('offline');
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  if (banner !== null) {
+    lastBannerRef.current = banner;
+  }
+
+  useEffect(() => listen<boolean>(EV_NETWORK_IS_ONLINE, (isOnline) => {
+    if (isOnline === undefined) {
+      return;
+    }
+
+    clearTimeout(hideTimeoutRef.current);
+
+    if (!isOnline) {
+      setBanner('offline');
+      return;
+    }
+
+    setBanner((prev) => prev === null ? null : 'back-online');
+
+    hideTimeoutRef.current = setTimeout(
+      () => setBanner(null),
+      BACK_ONLINE_HOLD_MS,
+    );
+  }, true), []);
+
+  useEffect(() => {
+    translateY.value = withTiming(
+      banner === null ? HIDDEN_POSITION : 0,
+      { duration: SLIDE_DURATION },
+    );
+  }, [banner]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[
+        {
+          position: 'absolute',
+          top: insets.top,
+          left: 0,
+          right: 0,
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 1000,
+          elevation: 9,
+        },
+        animatedStyle,
+      ]}
+    >
+      <ToastContainer>
+        <FontAwesomeIcon
+          icon={faWifi}
+          color={appTheme.secondaryColor}
+          size={20}
+        />
+        <DefaultText
+          style={{
+            color: appTheme.secondaryColor,
+            fontWeight: '700',
+          }}
+        >
+          {bannerText[banner ?? lastBannerRef.current]}
+        </DefaultText>
+      </ToastContainer>
+    </Animated.View>
+  );
+};
+
+export {
+  ConnectionStatusBanner,
+};

--- a/frontend/components/connection-status-banner.tsx
+++ b/frontend/components/connection-status-banner.tsx
@@ -10,8 +10,6 @@ import { faWifi } from '@fortawesome/free-solid-svg-icons/faWifi';
 import { listen } from '../events/events';
 import { EV_NETWORK_IS_ONLINE } from '../network/network';
 import { DefaultText } from './default-text';
-import { ToastContainer } from './toast';
-import { useAppTheme } from '../app-theme/app-theme';
 
 const HIDDEN_POSITION = -500;
 const SLIDE_DURATION = 300;
@@ -24,9 +22,13 @@ const bannerText: Record<Banner, string> = {
   'back-online': "You're back online",
 };
 
+const bannerColor: Record<Banner, string> = {
+  'offline': '#d10000',
+  'back-online': '#00a000',
+};
+
 const ConnectionStatusBanner = () => {
   const insets = useSafeAreaInsets();
-  const { appTheme } = useAppTheme();
   const translateY = useSharedValue(HIDDEN_POSITION);
   const [banner, setBanner] = useState<Banner | null>(null);
   const lastBannerRef = useRef<Banner>('offline');
@@ -35,6 +37,8 @@ const ConnectionStatusBanner = () => {
   if (banner !== null) {
     lastBannerRef.current = banner;
   }
+
+  const displayedBanner = banner ?? lastBannerRef.current;
 
   useEffect(() => listen<boolean>(EV_NETWORK_IS_ONLINE, (isOnline) => {
     if (isOnline === undefined) {
@@ -73,32 +77,35 @@ const ConnectionStatusBanner = () => {
       style={[
         {
           position: 'absolute',
-          top: insets.top,
+          top: 0,
           left: 0,
           right: 0,
+          paddingTop: insets.top + 8,
+          paddingBottom: 8,
+          flexDirection: 'row',
           alignItems: 'center',
           justifyContent: 'center',
+          gap: 8,
+          backgroundColor: bannerColor[displayedBanner],
           zIndex: 1000,
           elevation: 9,
         },
         animatedStyle,
       ]}
     >
-      <ToastContainer>
-        <FontAwesomeIcon
-          icon={faWifi}
-          color={appTheme.secondaryColor}
-          size={20}
-        />
-        <DefaultText
-          style={{
-            color: appTheme.secondaryColor,
-            fontWeight: '700',
-          }}
-        >
-          {bannerText[banner ?? lastBannerRef.current]}
-        </DefaultText>
-      </ToastContainer>
+      <FontAwesomeIcon
+        icon={faWifi}
+        color="white"
+        size={14}
+      />
+      <DefaultText
+        style={{
+          color: 'white',
+          fontWeight: '700',
+        }}
+      >
+        {bannerText[displayedBanner]}
+      </DefaultText>
     </Animated.View>
   );
 };

--- a/frontend/components/connection-status-banner.tsx
+++ b/frontend/components/connection-status-banner.tsx
@@ -18,8 +18,8 @@ const BACK_ONLINE_HOLD_MS = 3000;
 type Banner = 'offline' | 'back-online';
 
 const bannerText: Record<Banner, string> = {
-  'offline': "You're offline",
-  'back-online': "You're back online",
+  'offline': "You’re offline",
+  'back-online': "You’re back online",
 };
 
 const bannerColor: Record<Banner, string> = {
@@ -80,8 +80,8 @@ const ConnectionStatusBanner = () => {
           top: 0,
           left: 0,
           right: 0,
-          paddingTop: insets.top + 8,
-          paddingBottom: 8,
+          paddingTop: insets.top + 5,
+          paddingBottom: 5,
           flexDirection: 'row',
           alignItems: 'center',
           justifyContent: 'center',
@@ -96,7 +96,7 @@ const ConnectionStatusBanner = () => {
       <FontAwesomeIcon
         icon={faWifi}
         color="white"
-        size={14}
+        size={16}
       />
       <DefaultText
         style={{

--- a/frontend/navigation/app-navigation.tsx
+++ b/frontend/navigation/app-navigation.tsx
@@ -1,0 +1,202 @@
+import {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import {
+  NavigationContainerRefWithCurrent,
+  NavigationState,
+  ParamListBase,
+  PartialState,
+  getPathFromState as rnGetPathFromState,
+} from '@react-navigation/native';
+import { lastPath } from '../kv-storage/last-path';
+import {
+  createLinking,
+  focusedConversationHandle,
+  focusedProspectHandle,
+  focusedRouteIsUnrestorable,
+  getTopRouteName,
+  isBannerRoute,
+} from './linking';
+import { setActiveConversation } from '../chat/conversation-priority';
+import {
+  getSignedInUser,
+  isWebLoggedOut,
+  useSignedInUser,
+} from '../events/signed-in-user';
+import { useNotificationObserverOnMobile } from '../notifications/mobile';
+import { useWebPushMessageListenerOnWeb } from '../notifications/web-push';
+
+type AppLinking = ReturnType<typeof createLinking>;
+
+type AppNavigationContainerRef = NavigationContainerRefWithCurrent<ParamListBase>;
+
+type AppNavigation = {
+  pendingPostLoginStateRef: MutableRefObject<PartialState<NavigationState> | null>
+  bannerVisible: boolean
+  bannerProspectHandle: string | undefined
+  onNavigationReady: () => void
+  onNavigationStateChange: (state: NavigationState) => void
+};
+
+const useAppNavigation = (
+  linking: AppLinking,
+  navigationContainerRef: AppNavigationContainerRef,
+): AppNavigation => {
+  const [signedInUser] = useSignedInUser();
+  const [bannerVisible, setBannerVisible] = useState(false);
+  const [bannerProspectHandle, setBannerProspectHandle] = useState<string | undefined>(undefined);
+  const pendingPostLoginStateRef = useRef<PartialState<NavigationState> | null>(null);
+
+  // Centralised post-sign-in redirect. Runs both when `signedInUser` changes
+  // (the post-OTP-flow case) and when the NavigationContainer reports ready
+  // (the cold-start-with-existing-session case, where `signedInUser` may
+  // have been populated *before* the container mounted, so the effect's
+  // ref-lookup would have early-returned).
+  //
+  // Two responsibilities:
+  //   1. If a protected URL was deep-linked while logged-out, restore it
+  //      after the user signs in (`pendingPostLoginStateRef`).
+  //   2. Otherwise, if the user is parked on the logged-out Welcome stack
+  //      (just completed OTP, or typed `/sign-in`/`/welcome` while already
+  //      signed in), forward them to the canonical landing tab so they
+  //      aren't stranded on the sign-in form.
+  const applyPostSignInRedirect = useCallback(() => {
+    if (!getSignedInUser()) return;
+
+    const navigationContainer = navigationContainerRef.current;
+    if (!navigationContainer) return;
+
+    const pending = pendingPostLoginStateRef.current;
+    pendingPostLoginStateRef.current = null;
+
+    if (pending) {
+      navigationContainer.reset(pending);
+      return;
+    }
+
+    if (getTopRouteName(navigationContainer.getRootState?.()) === 'Welcome') {
+      navigationContainer.reset({
+        routes: [
+          { name: 'Home', state: { routes: [{ name: 'Q&A' }] } },
+        ],
+      });
+    }
+  }, []);
+
+  const recomputeBannerVisible = useCallback((state?: NavigationState) => {
+    const rootState = state ?? navigationContainerRef.current?.getRootState?.();
+    setBannerVisible(isWebLoggedOut() && isBannerRoute(rootState));
+    setBannerProspectHandle(focusedProspectHandle(rootState));
+  }, []);
+
+  // Tell the chat layer which conversation (if any) is on screen, so on connect
+  // it can load an open conversation's history before the inbox snapshot. See
+  // `frontend/chat/conversation-priority`.
+  const publishActiveConversation = useCallback((state?: NavigationState) => {
+    const rootState = state ?? navigationContainerRef.current?.getRootState?.();
+    setActiveConversation(focusedConversationHandle(rootState) ?? null);
+  }, []);
+
+  const onNavigationReady = useCallback(() => {
+    applyPostSignInRedirect();
+    recomputeBannerVisible();
+    publishActiveConversation();
+  }, [applyPostSignInRedirect, recomputeBannerVisible, publishActiveConversation]);
+
+  useEffect(() => {
+    // On sign-out drop any remaining pending state so a stale entry from
+    // this session can't latch onto a subsequent sign-in as a different
+    // user on the same browser.
+    if (!signedInUser) {
+      pendingPostLoginStateRef.current = null;
+    } else {
+      applyPostSignInRedirect();
+    }
+    recomputeBannerVisible();
+  }, [signedInUser?.personUuid, applyPostSignInRedirect, recomputeBannerVisible]);
+
+  const onNavigationStateChange = useCallback(async (state: NavigationState) => {
+    if (!state) return;
+
+    recomputeBannerVisible(state);
+    publishActiveConversation(state);
+
+    // URL-bar sync is left entirely to React Navigation's linking integration.
+    // Doing a `window.history.replaceState` here in addition to RN's own
+    // pushState corrupts the browser history stack: our handler runs
+    // synchronously from the state-change emit, while RN's pushState is
+    // queued as a microtask, so our replace overwrites the URL of the
+    // *previous* browser entry before RN appends a new one - effectively
+    // collapsing two history entries into one and breaking the back button.
+
+    // Read auth synchronously rather than closing over `signedInUser`. During
+    // sign-out we clear the user before triggering the navigation reset, and
+    // a stale closure would persist the post-logout path under the previous
+    // identity (or vice versa).
+    if (!getSignedInUser()) return;
+
+    // Don't persist URLs that can't be restored: the OptionScreen-backed
+    // wizards would hydrate with no payload and immediately `popToTop`, and
+    // the gallery would come back as the only route, with no screen under it
+    // to close onto. See `UNRESTORABLE_ROUTE_NAMES`. Walking the focused route
+    // chain detects these regardless of how deeply nested they are.
+    if (focusedRouteIsUnrestorable(state)) return;
+
+    // Persist just the canonical path - not the full navigation tree - so we
+    // can restore the user's last place on next startup. We let React
+    // Navigation's `getPathFromState` do the serialization so this stays in
+    // lock-step with whatever URL structure the linking config exposes.
+    try {
+      // The `as any` is unfortunate but unavoidable: React Navigation's
+      // PathConfig types insist every `screens`-bearing entry also declare
+      // its own `path`, but our `Home` deliberately doesn't have one (its
+      // children inherit the empty root). The runtime invariant being relied
+      // on here is that `Home` is always the implicit root of the path tree,
+      // so any path produced by getPathFromState round-trips back to a
+      // valid state via getStateFromPath.
+      const path = rnGetPathFromState(state, linking.config);
+      if (typeof path === 'string') {
+        await lastPath(path.startsWith('/') ? path : `/${path}`);
+      }
+    } catch (e) {
+      // Some transient navigation states aren't representable as URLs (e.g.
+      // mid-transition or screens not in the linking config). Skip those
+      // and warn so misconfiguration doesn't silently break last-path
+      // restoration in production - but use `warn` rather than `error`
+      // because intermittent failures on transient states are expected.
+      console.warn('Failed to persist last navigation path', e);
+    }
+  }, [linking, recomputeBannerVisible, publishActiveConversation]);
+
+  const navigateFromNotification = (
+    screen: string,
+    params: Record<string, unknown>,
+  ) => {
+    const navigationContainer = navigationContainerRef.current;
+
+    if (!navigationContainer) return;
+    if (!screen) return;
+
+    navigationContainer.navigate(screen, params);
+  };
+
+  useNotificationObserverOnMobile(navigateFromNotification);
+  useWebPushMessageListenerOnWeb(navigateFromNotification);
+
+  return {
+    pendingPostLoginStateRef,
+    bannerVisible,
+    bannerProspectHandle,
+    onNavigationReady,
+    onNavigationStateChange,
+  };
+};
+
+export {
+  AppNavigation,
+  useAppNavigation,
+};

--- a/frontend/network/network.tsx
+++ b/frontend/network/network.tsx
@@ -1,0 +1,30 @@
+import {
+  NetworkStateEvent,
+  addNetworkStateListener,
+  getNetworkStateAsync,
+} from 'expo-network';
+import { notify } from '../events/events';
+
+const EV_NETWORK_CAME_ONLINE = 'network-came-online';
+
+let wasConnected = true;
+
+const onChangeIsConnected = (isConnected: boolean): void => {
+  if (isConnected && !wasConnected) {
+    notify(EV_NETWORK_CAME_ONLINE);
+  }
+
+  wasConnected = isConnected;
+};
+
+addNetworkStateListener(
+  (state: NetworkStateEvent) => onChangeIsConnected(state.isConnected === true)
+);
+
+getNetworkStateAsync().then(
+  (state) => { wasConnected = state?.isConnected === true; }
+);
+
+export {
+  EV_NETWORK_CAME_ONLINE,
+};

--- a/frontend/network/network.tsx
+++ b/frontend/network/network.tsx
@@ -6,15 +6,20 @@ import {
 import { notify } from '../events/events';
 
 const EV_NETWORK_CAME_ONLINE = 'network-came-online';
+const EV_NETWORK_IS_ONLINE = 'network-is-online';
 
 let wasConnected = true;
 
 const onChangeIsConnected = (isConnected: boolean): void => {
-  if (isConnected && !wasConnected) {
-    notify(EV_NETWORK_CAME_ONLINE);
-  }
+  const cameOnline = isConnected && !wasConnected;
 
   wasConnected = isConnected;
+
+  notify<boolean>(EV_NETWORK_IS_ONLINE, isConnected);
+
+  if (cameOnline) {
+    notify(EV_NETWORK_CAME_ONLINE);
+  }
 };
 
 addNetworkStateListener(
@@ -22,9 +27,14 @@ addNetworkStateListener(
 );
 
 getNetworkStateAsync().then(
-  (state) => { wasConnected = state?.isConnected === true; }
+  (state) => {
+    if (state) {
+      onChangeIsConnected(state.isConnected === true);
+    }
+  }
 );
 
 export {
   EV_NETWORK_CAME_ONLINE,
+  EV_NETWORK_IS_ONLINE,
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "expo-image-manipulator": "~55.0.18",
         "expo-image-picker": "~55.0.21",
         "expo-linear-gradient": "~55.0.15",
+        "expo-network": "~55.0.16",
         "expo-notifications": "~55.0.24",
         "expo-screen-orientation": "~55.0.17",
         "expo-secure-store": "~55.0.15",
@@ -7636,6 +7637,16 @@
         "react-native-worklets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-network": {
+      "version": "55.0.16",
+      "resolved": "https://registry.npmjs.org/expo-network/-/expo-network-55.0.16.tgz",
+      "integrity": "sha512-aqn9RvTjV51DkllBFLSh9etqnmmGi2KA3Pl3eeBEDxUqgtMVdZb0MW4WQhOF9fqHsxozq9rEKdfQr1bXvmohXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
       }
     },
     "node_modules/expo-notifications": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "expo-image-manipulator": "~55.0.18",
     "expo-image-picker": "~55.0.21",
     "expo-linear-gradient": "~55.0.15",
+    "expo-network": "~55.0.16",
     "expo-notifications": "~55.0.24",
     "expo-screen-orientation": "~55.0.17",
     "expo-secure-store": "~55.0.15",


### PR DESCRIPTION
## Summary

Follow-up to #1402. Makes the app react to connectivity changes instead of waiting out timeouts and backoff windows.

**1. Retry requests and reconnect chat as soon as the network returns** (`87297e60`)
- New `frontend/network/network.tsx` publishes connectivity events from `expo-network`'s state listener (browser `online`/`offline` events on web — one code path for all platforms).
- `api.tsx` retry sleeps become `nextEvent(EV_NETWORK_CAME_ONLINE, jitteredDelayMs)` — same jittered schedule, but network recovery cuts the wait short.
- The same event triggers `connectChatWebSocket()`.

**2. "You're offline" / "You're back online" banners** (`dc6c0a24`)
- Full-width bar pinned above everything including the splash screen (content padded below the top safe-area inset): red "You're offline" while offline, green "You're back online" for 3s on recovery.
- Fixes the stuck-at-splash confusion: an offline user with a session token used to sit behind the native splash indefinitely while `/check-session-token` retried. The native splash now hides as soon as the network is reported down, so the JS splash renders with the banner over it.

**3. Close the chat websocket when connectivity drops** (`a0f4395a`)
- Desktop browsers keep websockets in the OPEN state after the interface goes away, so the came-online reconnect was a no-op against the stale socket, and reconnection waited for ping timeout + backoff. iOS WebKit closes sockets itself, which is why behavior differed across browsers. The socket is now closed on the offline edge and connects are blocked while offline, mirroring the backgrounded handling. (`fa2cf049`)
- `close()` alone turned out to be insufficient on Chromium: with no network route the closing handshake stalls and the socket sits in CLOSING for up to 60s before `onclose` fires, blocking the reconnect behind the `if (ws)` guard (observed on a real wifi toggle). The offline edge and ping timeouts now *abandon* the socket — drop the reference and emit the close event immediately, with every socket callback identity-guarded so the zombie's eventual `onclose` can't clobber the replacement connection.

Spurious wakes stay harmless: an early retry that fails re-enters the same backoff schedule. Recoveries are per-client events, so this doesn't recreate the thundering herd the jitter work removed.

## Notes

- `expo-network` is a new native module: native apps need a fresh dev-client/EAS build; web picks it up immediately.
- `navigator.onLine === false` is reliable ("definitely offline"); `true` can be a lie, which is fine — a wrong "online" just means we fall back to the old timeout-based behavior.
- The native splash-hide path and the AppState interplay on real devices still deserve a device pass (Android + iOS).

## Test plan

- `npx tsc --noEmit`, `eslint` on changed files, `npx jest` (17 suites, 194 tests) pass.
- Verified in a real browser (Playwright + Chrome against a local Expo web build and a stub chat server, with `navigator.onLine` spoofed and API sockets dropped at the TCP level):
  - Zombie repro: against a stub that completes the websocket handshake but never answers the close frame (reproducing Chromium's stalled CLOSING state), the app reconnected **9ms** after the online event while the old socket was still stuck in CLOSING.
  - Desktop: on the offline event the chat socket closed in **8ms** (previously stayed OPEN until ping timeout) and the "You're offline" pill appeared; on the online event a new socket connected in **9ms** (previously waited out backoff).
  - "You're back online" shows for 3s on recovery, then slides away.
  - Startup while offline with a session token: app correctly shows the JS splash with the "You're offline" pill over it instead of an unexplained hang, and stays there until the network returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


