### PR TITLE
Close the chat websocket synchronously when the app is backgrounded

### DIFF
--- a/frontend/chat/websocket-layer.test.tsx
+++ b/frontend/chat/websocket-layer.test.tsx
@@ -1,0 +1,119 @@
+import { jest } from '@jest/globals';
+import { AppState, AppStateStatus, Platform } from 'react-native';
+
+// React Native stops dispatching JS timers while the app is backgrounded, so
+// the connection has to be closed synchronously from the app-state handler.
+// These tests pin that down: they never advance timers before asserting that
+// the socket was closed, which is exactly what a deferred close would need.
+
+type ChangeHandler = (state: AppStateStatus) => void;
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static readonly OPEN = 1;
+
+  readyState = 0;
+  closeCalls = 0;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor() {
+    FakeWebSocket.instances.push(this);
+  }
+
+  close(): void {
+    this.closeCalls++;
+    this.readyState = 2;
+  }
+
+  send(): void {}
+}
+
+const defineProperty = (target: object, key: string, value: unknown): void => {
+  Object.defineProperty(target, key, { configurable: true, value });
+};
+
+describe('chat websocket app-state handling', () => {
+  let changeHandlers: ChangeHandler[] = [];
+
+  const setAppState = (state: AppStateStatus): void => {
+    defineProperty(AppState, 'currentState', state);
+    changeHandlers.forEach((handler) => handler(state));
+  };
+
+  const currentSocket = (): FakeWebSocket => {
+    const socket = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+    if (!socket) {
+      throw new Error('No websocket was created');
+    }
+    return socket;
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers();
+
+    FakeWebSocket.instances = [];
+    changeHandlers = [];
+
+    Object.assign(globalThis, { WebSocket: FakeWebSocket });
+
+    defineProperty(Platform, 'OS', 'android');
+    defineProperty(AppState, 'currentState', 'active');
+
+    jest.spyOn(AppState, 'addEventListener').mockImplementation(
+      (type, handler) => {
+        if (type === 'change') {
+          changeHandlers.push(handler);
+        }
+        return { remove: () => {} };
+      }
+    );
+
+    // The module connects and registers its app-state listener on import, so
+    // it has to be required after the mocks above are in place. `require` is
+    // deliberate: `jest.resetModules()` operates on the CommonJS cache, which
+    // a hoisted `import` would bypass.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('./websocket-layer');
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('closes the connection as soon as the app is backgrounded', () => {
+    const socket = currentSocket();
+
+    setAppState('background');
+
+    expect(socket.closeCalls).toBe(1);
+  });
+
+  test('keeps the connection through a transient inactive state', () => {
+    const socket = currentSocket();
+
+    setAppState('inactive');
+    jest.advanceTimersByTime(6000);
+
+    expect(socket.closeCalls).toBe(0);
+  });
+
+  test('does not reconnect while the app stays backgrounded', () => {
+    setAppState('background');
+    jest.advanceTimersByTime(6000);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  test('reconnects when the app becomes active again', () => {
+    setAppState('background');
+    setAppState('active');
+
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+});

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -22,9 +22,7 @@ const EV_CHAT_WS_RECEIVE = 'chat-ws-receive';
 const EV_CHAT_WS_SEND_CLOSE = 'chat-ws-send-close';
 
 const stableConnectionMs = 10000;
-const backgroundedCloseGraceMs = 5000;
 const reconnectBackoff = makeBackoff();
-let backgroundedCloseTimeout: ReturnType<typeof setTimeout> | undefined;
 
 const pong: Pong = {
   preferredInterval: 10000,
@@ -51,7 +49,7 @@ const closeChatWebSocket = (): void => {
 // immediately. Dropping the reference right away lets a reconnect proceed
 // without waiting for the zombie to time out. The zombie's own callbacks are
 // inert thanks to the `ws !== _ws` guards.
-const abandonChatWebSocket = (): void => {
+const dropChatWebSocket = (): void => {
   const _ws = ws;
 
   if (!_ws) {
@@ -62,6 +60,14 @@ const abandonChatWebSocket = (): void => {
   expectedClose = false;
   _ws.close();
   notify(EV_CHAT_WS_CLOSE);
+};
+
+const abandonChatWebSocket = (): void => {
+  if (!ws) {
+    return;
+  }
+
+  dropChatWebSocket();
   setTimeout(connectChatWebSocket, reconnectBackoff.next());
 };
 
@@ -69,6 +75,12 @@ listen(EV_CHAT_WS_SEND_CLOSE, closeChatWebSocket);
 
 const isBackgrounded = (state: AppStateStatus): boolean =>
   Platform.OS !== 'web' && ['background', 'inactive'].includes(state);
+
+// Only 'background' means the app actually went away. iOS also reports
+// 'inactive' for transient interruptions - the app switcher, the notification
+// shade, a permission dialog - where cycling the connection would be churn.
+const didEnterBackground = (state: AppStateStatus): boolean =>
+  Platform.OS !== 'web' && state === 'background';
 
 const isOffline = (): boolean =>
   lastEvent<boolean>(EV_NETWORK_IS_ONLINE) === false;
@@ -298,25 +310,20 @@ const pingServerForever = async () => {
   };
 };
 
-const closeIfStillBackgrounded = (): void => {
-  if (isBackgrounded(AppState.currentState)) {
-    closeChatWebSocket();
-  }
-};
-
 const onChangeAppState = (state: AppStateStatus) => {
   if (state === 'active') {
     lastEnteredActiveState = new Date();
-    clearTimeout(backgroundedCloseTimeout);
     connectChatWebSocket();
   }
 
-  if (isBackgrounded(state)) {
-    clearTimeout(backgroundedCloseTimeout);
-    backgroundedCloseTimeout = setTimeout(
-      closeIfStillBackgrounded,
-      backgroundedCloseGraceMs,
-    );
+  // The close has to happen synchronously here. React Native stops
+  // dispatching JS timers once the app is backgrounded
+  // (`JavaTimerManager.onHostPause` clears the timer frame callback on
+  // Android; iOS suspends the JS thread), so a deferred close would only run
+  // after the app came back - leaving the connection, and the user's 'online'
+  // status, alive for the whole time the app was away.
+  if (didEnterBackground(state)) {
+    dropChatWebSocket();
   }
 };
 

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -73,15 +73,13 @@ const dropChatWebSocketAndReconnect = (): void => {
 
 listen(EV_CHAT_WS_SEND_CLOSE, closeChatWebSocket);
 
-const isNative = Platform.OS !== 'web';
-
 // 'inactive' and 'background' both mean the app isn't in the foreground. Only
 // 'background' means it actually went away, though: iOS reports 'inactive' for
 // transient interruptions like the app switcher, the notification shade or a
 // permission dialog, so the two states are treated differently below - we stop
 // connecting during either, but only disconnect on the latter.
 const isNotForeground = (state: AppStateStatus): boolean =>
-  isNative && ['background', 'inactive'].includes(state);
+  Platform.OS !== 'web' && ['background', 'inactive'].includes(state);
 
 const isOffline = (): boolean =>
   lastEvent<boolean>(EV_NETWORK_IS_ONLINE) === false;
@@ -323,7 +321,7 @@ const onChangeAppState = (state: AppStateStatus) => {
   // Android; iOS suspends the JS thread), so a deferred close would only run
   // after the app came back - leaving the connection, and the user's 'online'
   // status, alive for the whole time the app was away.
-  if (isNative && state === 'background') {
+  if (Platform.OS !== 'web' && state === 'background') {
     dropChatWebSocket();
   }
 };

--- a/frontend/chat/websocket-layer.tsx
+++ b/frontend/chat/websocket-layer.tsx
@@ -62,7 +62,7 @@ const dropChatWebSocket = (): void => {
   notify(EV_CHAT_WS_CLOSE);
 };
 
-const abandonChatWebSocket = (): void => {
+const dropChatWebSocketAndReconnect = (): void => {
   if (!ws) {
     return;
   }
@@ -73,14 +73,15 @@ const abandonChatWebSocket = (): void => {
 
 listen(EV_CHAT_WS_SEND_CLOSE, closeChatWebSocket);
 
-const isBackgrounded = (state: AppStateStatus): boolean =>
-  Platform.OS !== 'web' && ['background', 'inactive'].includes(state);
+const isNative = Platform.OS !== 'web';
 
-// Only 'background' means the app actually went away. iOS also reports
-// 'inactive' for transient interruptions - the app switcher, the notification
-// shade, a permission dialog - where cycling the connection would be churn.
-const didEnterBackground = (state: AppStateStatus): boolean =>
-  Platform.OS !== 'web' && state === 'background';
+// 'inactive' and 'background' both mean the app isn't in the foreground. Only
+// 'background' means it actually went away, though: iOS reports 'inactive' for
+// transient interruptions like the app switcher, the notification shade or a
+// permission dialog, so the two states are treated differently below - we stop
+// connecting during either, but only disconnect on the latter.
+const isNotForeground = (state: AppStateStatus): boolean =>
+  isNative && ['background', 'inactive'].includes(state);
 
 const isOffline = (): boolean =>
   lastEvent<boolean>(EV_NETWORK_IS_ONLINE) === false;
@@ -90,7 +91,7 @@ const connectChatWebSocket = (): void => {
     return;
   }
 
-  if (isBackgrounded(AppState.currentState)) {
+  if (isNotForeground(AppState.currentState)) {
     return;
   }
 
@@ -297,7 +298,7 @@ const pingServer = async () => {
 
   if (response === 'timeout') {
     // An unresponsive connection would stall the closing handshake too.
-    abandonChatWebSocket();
+    dropChatWebSocketAndReconnect();
   } else {
     Object.assign(pong, response);
   }
@@ -322,7 +323,7 @@ const onChangeAppState = (state: AppStateStatus) => {
   // Android; iOS suspends the JS thread), so a deferred close would only run
   // after the app came back - leaving the connection, and the user's 'online'
   // status, alive for the whole time the app was away.
-  if (didEnterBackground(state)) {
+  if (isNative && state === 'background') {
     dropChatWebSocket();
   }
 };
@@ -332,12 +333,12 @@ const onChangeAppState = (state: AppStateStatus) => {
 AppState.addEventListener('change', onChangeAppState);
 
 // Desktop browsers don't close websockets when connectivity drops; the socket
-// object stays OPEN until a write times out. Abandon it (rather than just
-// closing: see `abandonChatWebSocket`) so the came-online reconnect below
-// isn't blocked by a socket stuck in CLOSING.
+// object stays OPEN until a write times out. Drop it rather than closing it,
+// so the came-online reconnect below isn't blocked by a socket stuck in
+// CLOSING.
 listen<boolean>(EV_NETWORK_IS_ONLINE, (isOnline) => {
   if (isOnline === false) {
-    abandonChatWebSocket();
+    dropChatWebSocketAndReconnect();
   }
 });
 


### PR DESCRIPTION
## The regression

Backgrounding the app stopped disconnecting the chat websocket in #1402 (`9d3c4542`, shipped as v32.9.2). Before that, `onChangeAppState` closed the socket immediately; #1402 deferred it behind a five-second grace period to absorb transient background/active blips.

That timer never fires. React Native stops dispatching JS timers as soon as the app is backgrounded — on Android `JavaTimerManager.onHostPause()` sets `isPaused` and calls `clearFrameCallback()`, removing the `TIMERS_EVENTS` choreographer callback that drives `setTimeout`; on iOS the JS thread is suspended outright. So the deferred close only becomes eligible to run once the app is foregrounded again, at which point:

- `onChangeAppState('active')` has usually already called `clearTimeout` on it, and
- even if it does run, `closeIfStillBackgrounded` reads `AppState.currentState` as `'active'` and skips the close.

Either way the connection survives for as long as the app is backgrounded.

**User-visible effects:** the user keeps reporting as online to everyone else (`redis_has_subscribers` stays true, so `last_online_time` keeps advancing); their app-icon badge count is suppressed, since `_send_mobile_push` only increments the badge when the recipient has no connected clients; and the server holds an open websocket per backgrounded client, which is what #1396 set out to avoid.

## The fix

Close synchronously from the app-state handler, which is the only place the work is guaranteed to run.

The grace period existed to absorb the background/active pairs that system dialogs produce, so this keeps that protection where it can be had without a timer: only `'background'` closes the connection, not the `'inactive'` state iOS reports for the app switcher, notification shade, or a permission dialog. On Android, where a permission dialog does report `'background'`, the loop that motivated the grace period is fixed at its source (the notification prompt now runs at most once per session) and the reconnect backoff caps any residual churn at one cycle per blip rather than ~1/second.

The socket reference is dropped rather than waiting on the close handshake (reusing the machinery added in #1404, split into `dropChatWebSocket` + `abandonChatWebSocket`), so a handshake stalled by the OS suspending the process can't block the reconnect on resume.

## Test plan

`frontend/chat/websocket-layer.test.tsx` is new and pins the behaviour that no static check could catch:

- the socket is closed on `'background'` **without advancing any timers** — this fails against the code being replaced here, which is the regression test proper
- `'inactive'` does not close the connection
- no reconnect while the app stays backgrounded
- reconnect on return to `'active'`

Verified by CI (jest, tsc, eslint, playwright). Not verifiable in a browser: `isBackgrounded` is native-only, so a device pass — background the app, confirm the socket drops immediately and the user goes offline, then foreground and confirm a prompt reconnect — is still worth doing before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)