### PR TITLE
Reject rate-limited /chat handshakes with 429 instead of 403

### DIFF
--- a/backend/service/api/chat/__init__.py
+++ b/backend/service/api/chat/__init__.py
@@ -115,6 +115,7 @@ from service.api.chat.audiomessage import (
 )
 import redis.asyncio as redis
 from fastapi import WebSocket, WebSocketDisconnect
+from starlette.responses import PlainTextResponse
 from starlette.websockets import WebSocketState
 from service.api.ratelimit import (
     RateLimitExceeded,
@@ -722,7 +723,11 @@ async def process_websocket_messages(websocket: WebSocket) -> None:
         await check_chat_connect_limit(websocket)
     except RateLimitExceeded:
         logger.info(f'Chat connection rejected: rate limited; ip={ip}')
-        await websocket.close(code=1013)
+        if 'websocket.http.response' in websocket.scope.get('extensions', {}):
+            await websocket.send_denial_response(
+                PlainTextResponse('Too Many Requests', status_code=429))
+        else:
+            await websocket.close(code=1013)
         return
 
     await websocket.accept(subprotocol='json')


### PR DESCRIPTION
When the per-IP `/chat` connect limit was hit, the handler closed the unaccepted websocket (`close(code=1013)`), which uvicorn renders as an HTTP 403 handshake rejection:

```
INFO:     2600:...:0 - "WebSocket /chat" 403
INFO:     connection rejected (403 Forbidden)
```

That made rate limiting indistinguishable from an auth/forbidden failure in the logs and to clients. Every HTTP endpoint already returns 429 via the `RateLimitExceeded` exception handler in `service/api/asgi.py`; the websocket handshake was the only rate-limited path producing something else.

Now the handler rejects the handshake with a proper `429 Too Many Requests` denial response via the ASGI WebSocket Denial Response extension, which uvicorn's `websockets` implementation (what `api.main.sh` runs) has supported since uvicorn 0.26. If the extension is ever absent, it falls back to the previous close-with-1013 behaviour rather than erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)