### PR TITLE
Keep conversations read when inbox snapshots lag displayed markers

### DIFF
--- a/backend/service/api/chat/__init__.py
+++ b/backend/service/api/chat/__init__.py
@@ -349,6 +349,8 @@ async def _handle_reaction(
 
     deliver_to_partner = not await fetch_is_shadow_banned(from_id)
 
+    reacted_at_microseconds = now_microseconds()
+
     stored = await store_reaction(
         reactor_username=from_username,
         partner_username=partner_username,
@@ -358,13 +360,14 @@ async def _handle_reaction(
         emoji=parsed.emoji,
         previous_reaction=target.previous_reaction,
         target_body=target.target_body,
+        timestamp_microseconds=reacted_at_microseconds,
         deliver_to_recipient=deliver_to_partner,
     )
 
     if stored is None:
         return await reject()
 
-    stamp = format_timestamp(now_microseconds())
+    stamp = format_timestamp(reacted_at_microseconds)
 
     partner_has_subscribers = await redis_has_subscribers(
         REDIS_WORKER_CLIENT, partner_username)

--- a/backend/service/api/chat/messagestorage/__init__.py
+++ b/backend/service/api/chat/messagestorage/__init__.py
@@ -64,6 +64,7 @@ def store_message(
             to_username=to_username,
             msg_id=msg_id,
             body=message.body,
+            timestamp=timestamp_microseconds,
             deliver_to_recipient=deliver_to_recipient,
         ),
         messaged_job=SetMessagedJob(
@@ -93,6 +94,7 @@ async def store_reaction(
     emoji: str,
     previous_reaction: str | None,
     target_body: str,
+    timestamp_microseconds: int,
     deliver_to_recipient: bool,
 ) -> StoredReaction | None:
     """
@@ -127,6 +129,7 @@ async def store_reaction(
                 reaction_target_mam_id=reactor_copy_id,
                 emoji=emoji,
                 target_body=target_body,
+                timestamp=timestamp_microseconds,
                 deliver_to_recipient=deliver_to_recipient,
             )
             await process_set_messaged_batch(tx, [

--- a/backend/service/api/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/api/chat/messagestorage/inbox/__init__.py
@@ -289,7 +289,7 @@ WITH upsert_sender AS (
         -- The sender's own copy: remote_bare_jid is the recipient (the To), so
         -- the message is outgoing.
         'O'::mam_direction,
-        EXTRACT(EPOCH FROM NOW()) * 1e6,
+        %(timestamp)s,
         0
     )
     ON CONFLICT (luser, remote_bare_jid)
@@ -327,7 +327,7 @@ WITH upsert_sender AS (
         -- The recipient's copy: remote_bare_jid is the sender (the From), so
         -- the message is incoming.
         'I'::mam_direction,
-        EXTRACT(EPOCH FROM NOW()) * 1e6,
+        %(timestamp)s,
         1
     WHERE
         %(deliver_to_recipient)s::BOOLEAN
@@ -353,7 +353,7 @@ WITH update_reactor AS (
         reaction_target_mam_id = %(reaction_target_mam_id)s,
         reaction_body = %(reaction_body)s,
         box = 'chats',
-        timestamp = EXTRACT(EPOCH FROM NOW()) * 1e6,
+        timestamp = %(timestamp)s,
         unread_count = 0
     WHERE
         luser = %(reactor_username)s
@@ -365,7 +365,7 @@ UPDATE inbox SET
     reaction_target_mam_id = %(reaction_target_mam_id)s,
     reaction_body = %(reaction_body)s,
     box = 'chats',
-    timestamp = EXTRACT(EPOCH FROM NOW()) * 1e6,
+    timestamp = %(timestamp)s,
     unread_count = CASE
         WHEN reaction_target_mam_id = %(reaction_target_mam_id)s
         THEN GREATEST(COALESCE(unread_count, 0), 1)
@@ -421,13 +421,14 @@ Q_MARK_DISPLAYED = """
 UPDATE
     inbox
 SET
-    displayed_at = NOW(),
+    displayed_at = target.displayed_at,
     unread_count = 0
 FROM
     unnest(
         %(lusers)s::text[],
-        %(remote_bare_jids)s::text[]
-    ) AS target(luser, remote_bare_jid)
+        %(remote_bare_jids)s::text[],
+        %(displayed_ats)s::timestamp[]
+    ) AS target(luser, remote_bare_jid, displayed_at)
 WHERE
     inbox.luser = target.luser
 AND
@@ -447,6 +448,7 @@ class UpsertConversationJob:
     to_username: str
     msg_id: str
     body: str
+    timestamp: int
     deliver_to_recipient: bool = True
 
 
@@ -455,6 +457,7 @@ class MarkDisplayedJob:
     from_username: str
     to_username: str
     publish_receipt: bool
+    displayed_at: datetime
 
 
 def reaction_inbox_body(emoji: str, target_body: str) -> str:
@@ -632,6 +635,7 @@ async def set_inbox_reaction(
     reaction_target_mam_id: int,
     emoji: str,
     target_body: str,
+    timestamp: int,
     deliver_to_recipient: bool,
 ) -> None:
     await tx.execute(
@@ -644,6 +648,7 @@ async def set_inbox_reaction(
             reaction_target_mam_id=reaction_target_mam_id,
             reaction=emoji,
             reaction_body=target_body,
+            timestamp=timestamp,
             deliver_to_recipient=deliver_to_recipient,
         ),
     )
@@ -694,6 +699,7 @@ async def process_upsert_conversation_batch(tx: Tx, batch: list[UpsertConversati
             recipient_jid=f"{job.to_username}@{LSERVER}",
             msg_id=job.msg_id,
             body=job.body,
+            timestamp=job.timestamp,
             deliver_to_recipient=job.deliver_to_recipient,
         )
         for job in batch
@@ -712,12 +718,13 @@ def mark_displayed(
             from_username=from_username,
             to_username=to_username,
             publish_receipt=publish_receipt,
+            displayed_at=datetime.utcnow(),
         )
     )
 
 
 async def _write_mark_displayed(
-    conversations: list[tuple[str, str]],
+    conversations: list[tuple[str, str, datetime]],
 ) -> dict[tuple[str, str], datetime]:
     """
     Marks each (reader, sender) conversation as read, returning the recorded read
@@ -725,9 +732,9 @@ async def _write_mark_displayed(
     conversation is absent from the result.
     """
     targets = list({
-        (reader, f'{sender}@{LSERVER}')
-        for reader, sender in conversations
-    })
+        (reader, f'{sender}@{LSERVER}'): displayed_at
+        for reader, sender, displayed_at in conversations
+    }.items())
 
     if not targets:
         return {}
@@ -735,8 +742,9 @@ async def _write_mark_displayed(
     try:
         async with api_tx('read committed') as tx:
             await tx.execute(Q_MARK_DISPLAYED, dict(
-                lusers=[luser for luser, _ in targets],
-                remote_bare_jids=[jid for _, jid in targets],
+                lusers=[luser for (luser, _), _ in targets],
+                remote_bare_jids=[jid for (_, jid), _ in targets],
+                displayed_ats=[displayed_at for _, displayed_at in targets],
             ))
             rows = await tx.fetchall()
     except Exception:
@@ -755,7 +763,15 @@ async def _process_mark_displayed_batch(batch: list[MarkDisplayedJob]) -> None:
         for job in batch
     }
 
-    advanced = await _write_mark_displayed(list(publish_receipt))
+    displayed_ats = {
+        (job.from_username, job.to_username): job.displayed_at
+        for job in batch
+    }
+
+    advanced = await _write_mark_displayed([
+        (reader, sender, at)
+        for (reader, sender), at in displayed_ats.items()
+    ])
 
     for (reader, sender), displayed_at in advanced.items():
         if not publish_receipt.get((reader, sender)):

--- a/backend/test/functionality6/read-receipts.sh
+++ b/backend/test/functionality6/read-receipts.sh
@@ -186,6 +186,23 @@ gold_receipts=$(count_read_receipts "$user2uuid" "$user1uuid" <<< "$gold_convers
 [[ "$gold_receipts" == "1" ]] \
   || { echo "Expected 1 read receipt for the gold user, got ${gold_receipts}"; exit 1; }
 
+message_stamp=$(jq -s -r '
+  [.[] | .message.result.forwarded.delay["@stamp"]? | select(. != null)] | max
+' <<< "$gold_conversation")
+
+receipt_stamp=$(jq -s -r '
+  [ .[]
+    | select(.message["@type"] == "read-receipt")
+    | .message.displayed["@stamp"]
+    | select(. != null)
+  ][0]
+' <<< "$gold_conversation")
+
+[[ -n "$message_stamp" && "$message_stamp" != "null" ]] \
+  || { echo "Missing message stamp"; exit 1; }
+[[ "$receipt_stamp" == "$message_stamp" || "$receipt_stamp" > "$message_stamp" ]] \
+  || { echo "Receipt stamp '${receipt_stamp}' predates message stamp '${message_stamp}'"; exit 1; }
+
 
 echo "Re-reading the same last message does not advance the read receipt"
 

--- a/backend/test/functionality6/xmpp-inbox-snapshot.sh
+++ b/backend/test/functionality6/xmpp-inbox-snapshot.sh
@@ -368,3 +368,29 @@ actual_snapshot=$(query_inbox_snapshot user1 | snapshot_conversations)
 diff -u --color \
   <(echo "$actual_snapshot") \
   <(jq -S '[.[0] | .location = "chats"]' <<< "$expected_snapshot")
+
+
+echo "The delivered stamp matches the inbox timestamp everywhere it appears"
+
+curl -sX GET "http://localhost:3001/pop?id=user2" > /dev/null
+
+send_message user2 "$user2uuid" "$user1uuid" "stamped message"
+
+delivered_stamp=$(curl -sX GET "http://localhost:3001/pop?id=user2" \
+  | jq -s -r '[.[] | .duo_message_delivered | select(. != null)][0]["@stamp"]')
+
+entry_timestamp=$(curl -sX GET "http://localhost:3001/pop?id=user1" \
+  | jq -s -r '[.[] | .duo_inbox_entry | select(. != null)][0].last_message_timestamp')
+
+snapshot_timestamp=$(query_inbox_snapshot user1 \
+  | jq -s -r '
+      [.[] | .duo_inbox | select(. != null)][0]
+      | .conversations[0].last_message_timestamp
+    ')
+
+[[ -n "$delivered_stamp" && "$delivered_stamp" != "null" ]] \
+  || { echo "Missing delivered stamp"; exit 1; }
+[[ "$entry_timestamp" == "$delivered_stamp" ]] \
+  || { echo "Entry timestamp '$entry_timestamp' != stamp '$delivered_stamp'"; exit 1; }
+[[ "$snapshot_timestamp" == "$delivered_stamp" ]] \
+  || { echo "Snapshot timestamp '$snapshot_timestamp' != stamp '$delivered_stamp'"; exit 1; }

--- a/frontend/chat/application-layer/displayed-up-to.tsx
+++ b/frontend/chat/application-layer/displayed-up-to.tsx
@@ -1,0 +1,36 @@
+import { lastEvent, notify } from '../../events/events';
+
+const displayedUpToKey = (personUuid: string) =>
+  `inbox-displayed-up-to-${personUuid}`;
+
+const touchedPersonUuids = new Set<string>();
+
+const getDisplayedUpTo = (personUuid: string): Date | null =>
+  lastEvent<Date>(displayedUpToKey(personUuid)) ?? null;
+
+const advanceDisplayedUpTo = (personUuid: string, displayedUpTo: Date): void => {
+  if (Number.isNaN(displayedUpTo.getTime())) {
+    return;
+  }
+
+  const prev = getDisplayedUpTo(personUuid);
+
+  if (prev && displayedUpTo <= prev) {
+    return;
+  }
+
+  touchedPersonUuids.add(personUuid);
+  notify<Date>(displayedUpToKey(personUuid), displayedUpTo);
+};
+
+const clearDisplayedUpTo = (): void => {
+  touchedPersonUuids.forEach((personUuid) =>
+    notify<Date>(displayedUpToKey(personUuid)));
+  touchedPersonUuids.clear();
+};
+
+export {
+  advanceDisplayedUpTo,
+  clearDisplayedUpTo,
+  getDisplayedUpTo,
+};

--- a/frontend/chat/application-layer/inbox-displayed.test.tsx
+++ b/frontend/chat/application-layer/inbox-displayed.test.tsx
@@ -1,0 +1,162 @@
+import { jest } from '@jest/globals';
+
+type SendRequest = {
+  responseDetector?: (doc: unknown) => unknown
+};
+
+const mockSend = jest.fn<(request: SendRequest) => Promise<unknown>>();
+
+jest.mock('../websocket-layer', () => ({
+  EV_CHAT_WS_CLOSE: 'chat-ws-close',
+  EV_CHAT_WS_OPEN: 'chat-ws-open',
+  EV_CHAT_WS_RECEIVE: 'chat-ws-receive',
+  EV_CHAT_WS_SEND_CLOSE: 'chat-ws-send-close',
+  send: mockSend,
+}));
+
+jest.mock('../../notifications/notifications', () => ({
+  getAndRegisterPushToken: jest.fn(),
+}));
+
+const PERSON = '00000000-0000-4000-8000-000000000000';
+const T1 = '2026-07-14T10:30:00.000Z';
+const T2 = '2026-07-14T11:00:00.000Z';
+
+const wireConversation = (
+  lastMessageTimestamp: string,
+  lastMessageRead: boolean,
+) => ({
+  person_uuid: PERSON,
+  name: 'Test Person',
+  match_percentage: 90,
+  last_message: 'hi',
+  last_message_read: lastMessageRead,
+  last_message_timestamp: lastMessageTimestamp,
+  is_available: true,
+  is_verified: false,
+  location: 'intros',
+  matches_search_filters: true,
+});
+
+describe('inbox read state vs. server snapshots', () => {
+  let events: typeof import('../../events/events');
+  let chat: typeof import('./index');
+
+  beforeEach(async () => {
+    jest.resetModules();
+    mockSend.mockReset();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    events = require('../../events/events');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    chat = require('./index');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const priority: typeof import('../conversation-priority') =
+      require('../conversation-priority');
+
+    mockSend.mockResolvedValue('timeout');
+    await chat.login('me', 'password');
+    priority.setActiveConversation(null);
+  });
+
+  const deliverInboxSnapshot = async (conversations: unknown[]) => {
+    mockSend.mockImplementation(async (request) => {
+      if (!request.responseDetector) {
+        return 'timeout';
+      }
+
+      return request.responseDetector({ duo_inbox: { conversations } }) ?? 'timeout';
+    });
+
+    await chat.refreshInbox();
+
+    mockSend.mockResolvedValue('timeout');
+  };
+
+  const lastMessageRead = (): boolean | null => {
+    const conversation = chat.getInbox()?.intros.conversationsMap[PERSON];
+    return conversation ? conversation.lastMessageRead : null;
+  };
+
+  test('a mark sent while the inbox is loading survives the snapshot', async () => {
+    await chat.markDisplayed(PERSON, 'm1', new Date(T1));
+
+    expect(chat.getInbox()).toBeNull();
+
+    await deliverInboxSnapshot([wireConversation(T1, false)]);
+
+    expect(lastMessageRead()).toBe(true);
+  });
+
+  test('a stale unread snapshot does not clobber a local mark', async () => {
+    await deliverInboxSnapshot([wireConversation(T1, false)]);
+
+    expect(lastMessageRead()).toBe(false);
+
+    await chat.markDisplayed(PERSON, 'm1', new Date(T1));
+
+    expect(lastMessageRead()).toBe(true);
+
+    await deliverInboxSnapshot([wireConversation(T1, false)]);
+
+    expect(lastMessageRead()).toBe(true);
+  });
+
+  test('a message newer than the mark stays unread', async () => {
+    await chat.markDisplayed(PERSON, 'm1', new Date(T1));
+    await deliverInboxSnapshot([wireConversation(T1, false)]);
+
+    expect(lastMessageRead()).toBe(true);
+
+    events.notify('chat-ws-receive', { duo_inbox_entry: wireConversation(T2, false) });
+
+    expect(lastMessageRead()).toBe(false);
+  });
+
+  test('a mark without a timestamp is backed by the inbox entry', async () => {
+    await deliverInboxSnapshot([wireConversation(T1, false)]);
+
+    await chat.markDisplayed(PERSON, 'm1', null);
+    await deliverInboxSnapshot([wireConversation(T1, false)]);
+
+    expect(lastMessageRead()).toBe(true);
+  });
+
+  test('logging out clears the marks', async () => {
+    await chat.markDisplayed(PERSON, 'm1', new Date(T1));
+    await chat.logout();
+
+    await deliverInboxSnapshot([wireConversation(T1, false)]);
+
+    expect(lastMessageRead()).toBe(false);
+  });
+});
+
+describe('displayed-up-to overlay', () => {
+  let overlay: typeof import('./displayed-up-to');
+
+  beforeEach(() => {
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    overlay = require('./displayed-up-to');
+  });
+
+  test('an older mark does not regress a newer one', () => {
+    overlay.advanceDisplayedUpTo(PERSON, new Date(T2));
+    overlay.advanceDisplayedUpTo(PERSON, new Date(T1));
+
+    expect(overlay.getDisplayedUpTo(PERSON)).toEqual(new Date(T2));
+  });
+
+  test('an invalid date is ignored', () => {
+    overlay.advanceDisplayedUpTo(PERSON, new Date('not a date'));
+
+    expect(overlay.getDisplayedUpTo(PERSON)).toBeNull();
+  });
+
+  test('clearing resets the overlay', () => {
+    overlay.advanceDisplayedUpTo(PERSON, new Date(T1));
+    overlay.clearDisplayedUpTo();
+
+    expect(overlay.getDisplayedUpTo(PERSON)).toBeNull();
+  });
+});

--- a/frontend/chat/application-layer/index.tsx
+++ b/frontend/chat/application-layer/index.tsx
@@ -23,6 +23,11 @@ import {
   awaitFocusedConversationFetch,
   markConversationFetchDispatched,
 } from '../conversation-priority';
+import {
+  advanceDisplayedUpTo,
+  clearDisplayedUpTo,
+  getDisplayedUpTo,
+} from './displayed-up-to';
 
 const AUDIO_MESSAGE = 'Audio message';
 
@@ -179,6 +184,39 @@ const getInbox = (): Inbox | null => {
   return lastEvent<Inbox | null>('inbox') ?? null;
 }
 
+// Only unread entries have trustworthy timestamps here: they can only have
+// been built by `conversationFromWire`, so their timestamps are the server's.
+// Read entries may carry a client-clock timestamp from `setInboxSent`.
+const unreadConversationTimestamp = (personUuid: string): Date | null => {
+  const inbox = getInbox();
+
+  if (!inbox) {
+    return null;
+  }
+
+  const conversation = [
+    ...inbox.chats.conversations,
+    ...inbox.intros.conversations,
+    ...inbox.archive.conversations,
+  ].find((c) => c.personUuid === personUuid);
+
+  if (!conversation) {
+    return null;
+  }
+
+  if (conversation.lastMessageRead) {
+    return null;
+  }
+
+  return conversation.lastMessageTimestamp;
+};
+
+const latestOf = (a: Date | null, b: Date | null): Date | null => {
+  if (!a) return b;
+  if (!b) return a;
+  return a > b ? a : b;
+};
+
 const inboxStats = (inbox: Inbox): {
   numChats: number
   numUnreadChats: number
@@ -239,6 +277,29 @@ const conversationListToMap = (
   );
 };
 
+// Server snapshots can lag the client's own `displayed` markers: the inbox
+// query races the mark-displayed batcher on the server, and on cold start the
+// marker for the open conversation is sent after the snapshot query. So a
+// snapshot saying "unread" is only authoritative for messages newer than the
+// last one this session marked displayed.
+const withDisplayedUpTo = (conversation: Conversation): Conversation => {
+  if (conversation.lastMessageRead) {
+    return conversation;
+  }
+
+  const displayedUpTo = getDisplayedUpTo(conversation.personUuid);
+
+  if (!displayedUpTo) {
+    return conversation;
+  }
+
+  if (conversation.lastMessageTimestamp > displayedUpTo) {
+    return conversation;
+  }
+
+  return { ...conversation, lastMessageRead: true };
+};
+
 // Builds a `Conversation` from the complete, snake-cased conversation objects
 // the server sends in `duo_inbox` snapshots and `duo_inbox_entry` pushes.
 const conversationFromWire = (
@@ -250,7 +311,7 @@ const conversationFromWire = (
 
   const locations = ['chats', 'intros', 'archive', 'nowhere'];
 
-  return {
+  const conversation: Conversation = {
     personUuid: c.person_uuid,
     urlSlug: c.url_slug ?? null,
     name: c.name ?? 'Unavailable Person',
@@ -265,6 +326,8 @@ const conversationFromWire = (
     location: locations.includes(c.location) ? c.location : 'archive',
     matchesSearchFilters: !!(c.matches_search_filters ?? true),
   };
+
+  return withDisplayedUpTo(conversation);
 };
 
 const jidToBareJid = (jid: string): string =>
@@ -405,6 +468,7 @@ const logout = async () => {
   await registerWebPushSubscription(null);
   notify(EV_CHAT_WS_SEND_CLOSE);
   notify<Inbox | null>('inbox', null);
+  clearDisplayedUpTo();
 };
 
 const authenticate = async () => {
@@ -439,10 +503,26 @@ const authenticate = async () => {
 };
 
 // The server marks the whole conversation displayed; `messageId` is inert.
-const markDisplayed = async (otherPersonUuid: string, messageId: string) => {
+// Only server-sourced timestamps may be passed as `lastMessageTimestamp` -
+// recording a client-clock time could force-read a message that arrives just
+// after the mark.
+const markDisplayed = async (
+  otherPersonUuid: string,
+  messageId: string,
+  lastMessageTimestamp: Date | null,
+) => {
   if (!credentials) return;
 
   if (!isValidUuid(otherPersonUuid)) return;
+
+  const displayedUpTo = latestOf(
+    unreadConversationTimestamp(otherPersonUuid),
+    lastMessageTimestamp,
+  );
+
+  if (displayedUpTo) {
+    advanceDisplayedUpTo(otherPersonUuid, displayedUpTo);
+  }
 
   const data = {
     message: {
@@ -812,7 +892,13 @@ const onReceiveMessage = (
     if (!doMarkDisplayed) return;
     if (jidToBareJid(reaction['@from'] ?? '') !== otherPersonUuid) return;
 
-    await markDisplayed(otherPersonUuid, reaction['@mam_id'] ?? '');
+    const stamp = reaction['@stamp'];
+
+    await markDisplayed(
+      otherPersonUuid,
+      reaction['@mam_id'] ?? '',
+      stamp ? new Date(stamp) : null,
+    );
   };
 
   const _onReceiveMessage = async (doc: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -859,7 +945,7 @@ const onReceiveMessage = (
     }
 
     if (otherPersonUuid !== undefined && doMarkDisplayed && !message.fromCurrentUser) {
-      await markDisplayed(otherPersonUuid, message.id);
+      await markDisplayed(otherPersonUuid, message.id, null);
     }
 
     if (callback !== undefined) {
@@ -1001,7 +1087,7 @@ const fetchConversation = async (
 
   if (response !== 'timeout' && response.length > 0) {
     const lastMessage = response[response.length - 1];
-    await markDisplayed(withPersonUuid, lastMessage.id);
+    await markDisplayed(withPersonUuid, lastMessage.id, lastMessage.timestamp);
   }
 
   return response;

--- a/frontend/components/conversation-screen/conversation-screen.tsx
+++ b/frontend/components/conversation-screen/conversation-screen.tsx
@@ -679,7 +679,7 @@ const ConversationScreen = ({navigation, route}: NativeStackScreenProps<RootPara
       return;
     }
 
-    await markDisplayed(personUuid, lastMessage.message.id);
+    await markDisplayed(personUuid, lastMessage.message.id, null);
   }, [_.last(messageIds)]);
 
   useSkipped(personUuid, () => navigation.popToTop());


### PR DESCRIPTION
Fixes #1412

## The bug

Opening a conversation from a push notification, then backing out to the inbox tab, showed the conversation as unread. Reloading the app showed it read, and navigating from an inbox row worked fine. Both mechanisms hypothesised in the issue turned out to be real:

- **Cold start (dropped mark):** the inbox lives on the event bus and starts `null`. From a notification, `refreshInbox`'s snapshot query is released as soon as the conversation's history query is *dispatched*, so the server computes the snapshot before the `displayed` marker is even sent. When `markDisplayed` finally runs (after the MAM `fin`), `setInboxDisplayed` silently returns because the inbox is still `null`, and the snapshot then lands with `last_message_read: false`.
- **Warm foreground (clobbered mark):** mobile drops the websocket on background and reconnects on foreground, and `refreshInbox` wholesale-replaces the inbox with no merge of local read state. The snapshot races the server's mark-displayed batcher (`flush_interval=0.1`), so a stale unread snapshot clobbers the locally-set read flag. `duo_inbox_entry` pushes could clobber the same way.

## The fix

A session-local "displayed up to" overlay on the events bus (mirroring the `advanceReadAt` monotonic-max pattern in `hooks/read-receipt.tsx`):

- `markDisplayed` records, before sending the marker, that the conversation was read up to a given **server-side** message timestamp (the MAM stamp from `fetchConversation`, the reaction's `@stamp`, or the unread inbox entry's timestamp).
- `conversationFromWire` - the single choke point where both `duo_inbox` snapshots and `duo_inbox_entry` pushes become `Conversation`s - forces `lastMessageRead: true` when an unread wire conversation's last message is no newer than the local mark.

Only server-sourced timestamps ever enter the overlay, so a fast client clock can never force-read a genuinely new message: MAM stamps and inbox `last_message_timestamp` are renderings of the same DB column, and an *unread* inbox entry's timestamp is necessarily server-built (`setInboxSent`/`setInboxDisplayed` both mark conversations read, so a client-fabricated timestamp can only sit on a read entry, which the helper ignores). A message newer than the mark keeps its unread state. The overlay is deliberately not persisted - a reload refetches the snapshot, which is correct by then - and is cleared on logout.

## Tests

`frontend/chat/application-layer/inbox-displayed.test.tsx` drives the real `refreshInbox`/`duo_inbox_entry` parse paths against a mocked websocket `send` and pins:

- a mark sent while the inbox is still loading survives the snapshot (the cold-start bug)
- a stale unread snapshot doesn't clobber a local mark (the warm-foreground bug)
- a message newer than the mark stays unread
- a mark without an explicit timestamp is backed by the unread inbox entry's timestamp
- logout clears the marks
- overlay unit behaviour: monotonic max, invalid dates rejected, clearing resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)