### PR TITLE
Build and publish a postgres image in CI

### DIFF
--- a/.github/workflows/backend-publish.yml
+++ b/.github/workflows/backend-publish.yml
@@ -95,3 +95,32 @@ jobs:
         run: |
           gcloud auth configure-docker us-east1-docker.pkg.dev
           docker push $IMAGE_NAME:$GITHUB_SHA
+
+  build-postgres:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - id: get_branch
+        run: echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+
+      - id: set_image_name
+        run: echo "IMAGE_NAME=us-east1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/postgres/${BRANCH}" >> $GITHUB_ENV
+
+      - name: Build Docker Image
+        run: docker build -t $IMAGE_NAME:$GITHUB_SHA -f postgres.Dockerfile .
+
+      - name: Push Docker Image to Google Artifact Registry
+        run: |
+          gcloud auth configure-docker us-east1-docker.pkg.dev
+          docker push $IMAGE_NAME:$GITHUB_SHA

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -18,9 +18,6 @@ services:
       postgres
       -c shared_preload_libraries=pg_stat_statements
       -c pg_stat_statements.track=all
-      -c wal_level=logical
-      -c shared_buffers=1GB
-      -c random_page_cost=1.1
     ports:
       - "5432:5432"
     environment:
@@ -28,7 +25,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres
     volumes:
-      - ${POSTGRES_VOLUME:-postgres_test}:/var/lib/postgresql/data
+      - ${POSTGRES_VOLUME:-postgres_test}:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 1s

--- a/backend/postgres.Dockerfile
+++ b/backend/postgres.Dockerfile
@@ -12,6 +12,6 @@ RUN : \
 CMD [ \
   "postgres", \
   "-c", "wal_level=logical", \
-  "-c", "shared_buffers=1GB", \
+  "-c", "shared_buffers=2GB", \
   "-c", "random_page_cost=1.1" \
 ]

--- a/backend/postgres.Dockerfile
+++ b/backend/postgres.Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.0
+FROM postgres:18-trixie
 
 RUN : \
   && pgversion=$(psql --version | awk '{print $3}' | cut -d'.' -f1) \
@@ -8,3 +8,10 @@ RUN : \
     postgresql-${pgversion}-pgvector \
     postgresql-contrib \
     postgresql-plpython3-${pgversion}
+
+CMD [ \
+  "postgres", \
+  "-c", "wal_level=logical", \
+  "-c", "shared_buffers=1GB", \
+  "-c", "random_page_cost=1.1" \
+]


### PR DESCRIPTION
## Summary
- Add a `build-postgres` job to the backend-publish workflow, mirroring the `api`/`cron`/`firehol` jobs, pushing `backend/postgres.Dockerfile` to `us-east1-docker.pkg.dev/<project>/postgres/<branch>`.
- Bump the postgres base image from `postgres:16.0` to `postgres:18-trixie`.
- Bake `wal_level=logical`, `shared_buffers=2GB` and `random_page_cost=1.1` into the image via `CMD`; the `pg_stat_statements` flags stay in `backend/docker-compose.yml` only.
- Move the dev compose volume mount from `/var/lib/postgresql/data` to `/var/lib/postgresql`, matching the postgres:18 image's new data mountpoint (`PGDATA` is now `/var/lib/postgresql/18/docker`; mounting the old path would leave data in an anonymous volume).

## Notes
- Compose `command:` replaces the image `CMD`, so dev containers now run with default `wal_level`/`shared_buffers`/`random_page_cost`. Nothing in the repo depends on those settings locally, but shout if dev should keep them — they'd need to be restated in the compose command.
- The artifact registry needs a `postgres` repository to exist before the push step succeeds.
- The 16→18 bump means existing local data volumes won't carry over; local postgres re-initialises fresh.
- I couldn't build the image locally (no docker access); the CI job on this branch is the build verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
