### PR TITLE
Include the number of visitors in cron visitor notifications

### DIFF
--- a/backend/NOTIFICATIONS.md
+++ b/backend/NOTIFICATIONS.md
@@ -31,6 +31,10 @@ of visit are skipped, because neither one appears in the visitors tab and a
 notification the user can't act on is worse than none: visits made while
 browsing invisibly, and visits by somebody deactivated or shadow banned.
 
+The periodic notification states how many people visited since the user was
+last online, capped at "99+". A single visitor is still "someone": the periodic
+check can count its window but can't name anyone in it.
+
 Visitors default to **weekly**, which is deliberately the quietest default of
 the three: a profile can be visited far more often than it's messaged.
 
@@ -43,8 +47,8 @@ instant somebody opens a profile would arrive while they're still reading it.
 
 Visits are never folded into a message notification. Somebody who was visited
 and then messaged gets **two** notifications: one headed "you have a new
-message", which opens the inbox, and one headed "someone visited your profile",
-which opens the visitors tab. Neither has to share a headline or a destination
+message", which opens the inbox, and one headed "someone visited your profile"
+(or how many people did), which opens the visitors tab. Neither has to share a headline or a destination
 with the other, and each is governed by its own frequency setting, so silencing
 one leaves the other alone.
 

--- a/backend/constants/__init__.py
+++ b/backend/constants/__init__.py
@@ -81,11 +81,14 @@ MIN_NOTABLE_TRAIT_SCORE = 10
 # cap only bites at the top of that quota.
 MAX_CLUBS_PER_PERSON_FOR_OVERLAP = 100
 
-# What a visitor notification says. The periodic check reads the newest visit
-# out of a whole window of them and so can only speak of "someone", while a push
-# sent as the visit happens knows exactly who it was.
+# What a visitor notification says. The periodic check can count the visitors
+# in its window but can't name one, so a lone visitor is "someone", while a
+# push sent as the visit happens knows exactly who it was.
 VISITOR_NOTIFICATION_TITLE = 'Someone visited your profile 👀'
 VISITOR_NOTIFICATION_BODY = 'Someone visited your profile!'
+
+VISITOR_NOTIFICATION_TITLE_PLURAL = '{count} people visited your profile 👀'
+VISITOR_NOTIFICATION_BODY_PLURAL = '{count} people visited your profile!'
 
 IMMEDIATE_VISITOR_NOTIFICATION_TITLE = '{name} visited your profile 👀'
 IMMEDIATE_VISITOR_NOTIFICATION_BODY = 'Open the app to see your visitors'

--- a/backend/service/cron/messagenotifications/__init__.py
+++ b/backend/service/cron/messagenotifications/__init__.py
@@ -71,6 +71,9 @@ def is_chat_sendable(row: PersonNotification) -> bool:
 def do_send_notification(row: PersonNotification) -> bool:
     return is_intro_sendable(row) or is_chat_sendable(row)
 
+def notification_subject(row: PersonNotification) -> str:
+    return MESSAGE_SUBJECT
+
 def notification_body(row: PersonNotification) -> str:
     # Every unread kind the query found, not only the ones whose frequency cap
     # has elapsed: one notification covers the whole inbox, so an intro still
@@ -101,7 +104,7 @@ MESSAGE_NOTIFICATIONS = NotificationKind(
     query=Q_UNREAD_INBOX,
     row_type=PersonNotification,
     poll_seconds=EMAIL_POLL_SECONDS,
-    subject=MESSAGE_SUBJECT,
+    subject=notification_subject,
     screen={'screen': 'Home', 'params': {'screen': 'Inbox'}},
     is_sendable=do_send_notification,
     push_body=notification_body,

--- a/backend/service/cron/notificationdispatch/__init__.py
+++ b/backend/service/cron/notificationdispatch/__init__.py
@@ -28,7 +28,7 @@ class NotificationKind(Generic[N]):
     query: str
     row_type: type[N]
     poll_seconds: int
-    subject: str
+    subject: Callable[[N], str]
     screen: Json
     is_sendable: Callable[[N], bool]
     push_body: Callable[[N], str]
@@ -45,7 +45,7 @@ async def send_email_notification(kind: NotificationKind[N], row: N) -> None:
         print('Email notification failed because it ends with @example.com')
         return
 
-    subject = kind.subject
+    subject = kind.subject(row)
     body = kind.email_body(row)
     to_addr = row.email
 
@@ -68,7 +68,7 @@ def send_mobile_notification(
     else:
         notify.enqueue_mobile_notification(
             token=row.token,
-            title=kind.subject,
+            title=kind.subject(row),
             body=kind.push_body(row),
             data=kind.screen,
             badge=badge,

--- a/backend/service/cron/visitornotifications/__init__.py
+++ b/backend/service/cron/visitornotifications/__init__.py
@@ -11,8 +11,8 @@ from service.cron.visitornotifications.sql import (
     Q_PENDING_VISITOR_NOTIFICATIONS,
 )
 from service.cron.visitornotifications.template import (
-    VISITOR_BIG_PART,
-    VISITOR_SUBJECT,
+    big_part,
+    title_part,
     visitor_emailtemplate,
 )
 import os
@@ -32,6 +32,7 @@ class VisitorNotification:
     name: str
     email: str
     visitors_drift_seconds: int
+    visitor_count: int
     token: str | None
 
 def do_send_notification(row: VisitorNotification) -> bool:
@@ -41,11 +42,15 @@ def do_send_notification(row: VisitorNotification) -> bool:
             row.last_visitor_seconds
     )
 
+def push_title(row: VisitorNotification) -> str:
+    return title_part(row.visitor_count)
+
 def push_body(row: VisitorNotification) -> str:
-    return VISITOR_BIG_PART
+    return big_part(row.visitor_count)
 
 def email_body(row: VisitorNotification) -> str:
-    return visitor_emailtemplate(email=row.email)
+    return visitor_emailtemplate(
+        email=row.email, visitor_count=row.visitor_count)
 
 async def update_last_notification_time(row: VisitorNotification) -> None:
     params = dict(username=row.person_uuid)
@@ -58,7 +63,7 @@ VISITOR_NOTIFICATIONS = NotificationKind(
     query=Q_PENDING_VISITOR_NOTIFICATIONS,
     row_type=VisitorNotification,
     poll_seconds=VISITOR_POLL_SECONDS,
-    subject=VISITOR_SUBJECT,
+    subject=push_title,
     screen={'screen': 'Home', 'params': {'screen': 'Visitors'}},
     is_sendable=do_send_notification,
     push_body=push_body,

--- a/backend/service/cron/visitornotifications/sql/__init__.py
+++ b/backend/service/cron/visitornotifications/sql/__init__.py
@@ -82,6 +82,39 @@ WITH ten_minutes_ago AS (
         person.activated
 ), filtered AS (
     SELECT * FROM notifiable WHERE has_visitor
+), counted AS (
+    -- How many people visited since the person was last online, so the copy
+    -- can say how many. Capped at 100 (rendered as "99+"), so the scan stops
+    -- early for very popular profiles.
+    SELECT
+        filtered.*,
+        (
+            SELECT
+                COUNT(*)
+            FROM (
+                SELECT
+                    1
+                FROM
+                    visited
+                JOIN
+                    person AS visitor
+                ON
+                    visitor.id = visited.subject_person_id
+                WHERE
+                    visited.object_person_id = filtered.person_id
+                AND
+                    NOT visited.invisible
+                AND
+                    visited.updated_at > filtered.last_online_time
+                AND
+                    visitor.activated
+                AND
+                    visitor.shadow_banned_at IS NULL
+                LIMIT 100
+            ) AS visitor
+        )::int AS visitor_count
+    FROM
+        filtered
 ), session_summary AS (
     -- Per person, summarise their logged-in sessions. A signed-in `duo_session`
     -- with a NULL `push_token` is a push-less (web) client: only the mobile app
@@ -110,21 +143,22 @@ WITH ten_minutes_ago AS (
         duo_session.person_id
 )
 SELECT
-    filtered.person_uuid,
-    filtered.last_visitor_seconds,
-    filtered.last_visitor_notification_seconds,
+    counted.person_uuid,
+    counted.last_visitor_seconds,
+    counted.last_visitor_notification_seconds,
     -- One row per notification to send (see the LATERAL join below): a
     -- non-NULL token produces a push, a NULL token produces an email.
     notification_target.token,
-    filtered.name,
-    filtered.email,
-    filtered.visitors_drift_seconds
+    counted.name,
+    counted.email,
+    counted.visitors_drift_seconds,
+    counted.visitor_count
 FROM
-    filtered
+    counted
 LEFT JOIN
     session_summary
 ON
-    session_summary.person_id = filtered.person_id
+    session_summary.person_id = counted.person_id
 -- Fan a single person out into one row per notification that must be sent:
 -- one push per distinct logged-in mobile push token, plus a single email (NULL
 -- token) when any of: no logged-in device can receive push; the user was last
@@ -145,7 +179,7 @@ CROSS JOIN LATERAL (
     WHERE
         session_summary.push_tokens IS NULL
     OR
-        extract(epoch from filtered.last_online_time)
+        extract(epoch from counted.last_online_time)
             <= EXTRACT(EPOCH FROM NOW() - INTERVAL '8 days')
     OR
         COALESCE(

--- a/backend/service/cron/visitornotifications/sql/__init__.py
+++ b/backend/service/cron/visitornotifications/sql/__init__.py
@@ -85,34 +85,47 @@ WITH ten_minutes_ago AS (
 ), counted AS (
     -- How many people visited since the person was last online, so the copy
     -- can say how many. Capped at 100 (rendered as "99+"), so the scan stops
-    -- early for very popular profiles.
+    -- early for very popular profiles. Thousands of people can sit in
+    -- `filtered` waiting out their drift period while only a handful are due
+    -- to be sent each poll, so the count is only computed where the drift
+    -- gate (mirroring `do_send_notification`) passes; everyone else gets a 0
+    -- that `is_sendable` discards anyway.
     SELECT
         filtered.*,
-        (
-            SELECT
-                COUNT(*)
-            FROM (
+        (CASE
+            WHEN
+                filtered.visitors_drift_seconds >= 0
+            AND
+                filtered.last_visitor_notification_seconds +
+                    filtered.visitors_drift_seconds <
+                        filtered.last_visitor_seconds
+            THEN (
                 SELECT
-                    1
-                FROM
-                    visited
-                JOIN
-                    person AS visitor
-                ON
-                    visitor.id = visited.subject_person_id
-                WHERE
-                    visited.object_person_id = filtered.person_id
-                AND
-                    NOT visited.invisible
-                AND
-                    visited.updated_at > filtered.last_online_time
-                AND
-                    visitor.activated
-                AND
-                    visitor.shadow_banned_at IS NULL
-                LIMIT 100
-            ) AS visitor
-        )::int AS visitor_count
+                    COUNT(*)
+                FROM (
+                    SELECT
+                        1
+                    FROM
+                        visited
+                    JOIN
+                        person AS visitor
+                    ON
+                        visitor.id = visited.subject_person_id
+                    WHERE
+                        visited.object_person_id = filtered.person_id
+                    AND
+                        NOT visited.invisible
+                    AND
+                        visited.updated_at > filtered.last_online_time
+                    AND
+                        visitor.activated
+                    AND
+                        visitor.shadow_banned_at IS NULL
+                    LIMIT 100
+                ) AS visitor
+            )
+            ELSE 0
+        END)::int AS visitor_count
     FROM
         filtered
 ), session_summary AS (

--- a/backend/service/cron/visitornotifications/template/__init__.py
+++ b/backend/service/cron/visitornotifications/template/__init__.py
@@ -1,22 +1,37 @@
 from constants import (
     VISITOR_NOTIFICATION_BODY,
+    VISITOR_NOTIFICATION_BODY_PLURAL,
     VISITOR_NOTIFICATION_TITLE,
+    VISITOR_NOTIFICATION_TITLE_PLURAL,
 )
 from service.cron.emailtemplate import notification_emailtemplate
-
-VISITOR_SUBJECT = VISITOR_NOTIFICATION_TITLE
-
-VISITOR_BIG_PART = VISITOR_NOTIFICATION_BODY
 
 VISITOR_LITTLE_PART = 'Open the app to see who'
 
 VISITOR_URL = 'https://get.duolicious.app/visitors'
 
-def visitor_emailtemplate(email: str) -> str:
+def count_part(visitor_count: int) -> str:
+    if visitor_count > 99:
+        return '99+'
+    return str(visitor_count)
+
+def title_part(visitor_count: int) -> str:
+    if visitor_count > 1:
+        return VISITOR_NOTIFICATION_TITLE_PLURAL.format(
+            count=count_part(visitor_count))
+    return VISITOR_NOTIFICATION_TITLE
+
+def big_part(visitor_count: int) -> str:
+    if visitor_count > 1:
+        return VISITOR_NOTIFICATION_BODY_PLURAL.format(
+            count=count_part(visitor_count))
+    return VISITOR_NOTIFICATION_BODY
+
+def visitor_emailtemplate(email: str, visitor_count: int) -> str:
     return notification_emailtemplate(
         email=email,
-        subject=VISITOR_SUBJECT,
-        big=VISITOR_BIG_PART,
+        subject=title_part(visitor_count),
+        big=big_part(visitor_count),
         little=VISITOR_LITTLE_PART,
         url=VISITOR_URL,
     )

--- a/backend/service/cron/visitornotifications/template/test_init.py
+++ b/backend/service/cron/visitornotifications/template/test_init.py
@@ -6,15 +6,26 @@ from service.cron.visitornotifications.template import (
 class TestVisitorEmailTemplate(unittest.TestCase):
 
     def test_visitors_get_their_own_email(self) -> None:
-        visitor = visitor_emailtemplate('mail@example.com')
+        visitor = visitor_emailtemplate('mail@example.com', visitor_count=1)
 
         self.assertIn('Someone visited your profile', visitor)
         self.assertIn('get.duolicious.app/visitors', visitor)
         self.assertNotIn('get.duolicious.app/inbox', visitor)
         self.assertNotIn('message', visitor)
 
+    def test_multiple_visitors_are_counted(self) -> None:
+        visitor = visitor_emailtemplate('mail@example.com', visitor_count=3)
+
+        self.assertIn('3 people visited your profile!', visitor)
+        self.assertNotIn('Someone visited', visitor)
+
+    def test_visitor_counts_are_capped(self) -> None:
+        visitor = visitor_emailtemplate('mail@example.com', visitor_count=100)
+
+        self.assertIn('99+ people visited your profile!', visitor)
+
     def test_every_notification_type_can_be_capped(self) -> None:
-        email = visitor_emailtemplate('mail@example.com')
+        email = visitor_emailtemplate('mail@example.com', visitor_count=1)
 
         for notification_type in ['Chats', 'Intros', 'Visitors']:
             for frequency in ['Immediately', 'Daily', 'Every+3+days',

--- a/backend/service/cron/visitornotifications/test_init.py
+++ b/backend/service/cron/visitornotifications/test_init.py
@@ -25,6 +25,7 @@ def make_visitor_notification(**overrides: str | int | bool | None) -> VisitorNo
         name='jk',
         email='user.1@gmail.com',
         visitors_drift_seconds=604800,
+        visitor_count=1,
         token='asdf',
     )
     for key, value in overrides.items():
@@ -78,6 +79,42 @@ class TestSendMobileNotification(unittest.TestCase):
         self.assertEqual(
                 kwargs['data'],
                 {'screen': 'Home', 'params': {'screen': 'Visitors'}})
+
+    @patch('service.cron.notificationdispatch.disable_mobile_notifications')
+    @patch('service.cron.notificationdispatch.notify.enqueue_mobile_notification')
+    def test_multiple_visitors_are_counted(
+        self,
+        mock_enqueue: MagicMock,
+        mock_disable: MagicMock,
+    ) -> None:
+        mock_disable.return_value = False
+
+        send_mobile_notification(
+                VISITOR_NOTIFICATIONS,
+                make_visitor_notification(visitor_count=3),
+                badge=1)
+
+        [kwargs] = [call.kwargs for call in mock_enqueue.call_args_list]
+        self.assertEqual(kwargs['title'], '3 people visited your profile 👀')
+        self.assertEqual(kwargs['body'], '3 people visited your profile!')
+
+    @patch('service.cron.notificationdispatch.disable_mobile_notifications')
+    @patch('service.cron.notificationdispatch.notify.enqueue_mobile_notification')
+    def test_visitor_counts_are_capped(
+        self,
+        mock_enqueue: MagicMock,
+        mock_disable: MagicMock,
+    ) -> None:
+        mock_disable.return_value = False
+
+        send_mobile_notification(
+                VISITOR_NOTIFICATIONS,
+                make_visitor_notification(visitor_count=100),
+                badge=1)
+
+        [kwargs] = [call.kwargs for call in mock_enqueue.call_args_list]
+        self.assertEqual(kwargs['title'], '99+ people visited your profile 👀')
+        self.assertEqual(kwargs['body'], '99+ people visited your profile!')
 
 
 class TestUpdateLastNotificationTime(unittest.TestCase):

--- a/backend/test/functionality1/cron-notifications.sh
+++ b/backend/test/functionality1/cron-notifications.sh
@@ -807,6 +807,24 @@ test_happy_path_visitors () {
   [[ "$(count_pushes_to 'token_visitors')" = 1 ]]
 }
 
+# When more than one person visited since the user was last online, the
+# notification says how many.
+test_happy_path_multiple_visitors () {
+  setup
+
+  echo 0 > ../../test/input/disable-mobile-notifications
+  clear_pushes
+
+  give_user1_a_phone 'token_multi'
+
+  insert_visit "$user2id" "$user1id" '11 minutes'
+  insert_visit "$user3id" "$user1id" '12 minutes'
+
+  sleep 4
+
+  [[ "$(pushes_to 'token_multi')" = '[{"title":"2 people visited your profile 👀","body":"2 people visited your profile!","screen":"Visitors"}]' ]]
+}
+
 # A message and a visit arriving in the same window are announced separately:
 # two notifications, each with its own headline and destination, and each
 # counting towards the app-icon badge.
@@ -962,6 +980,7 @@ test_happy_path_chat_not_deferred_by_intro
 test_chat_notification_also_covers_a_capped_intro
 
 test_happy_path_visitors
+test_happy_path_multiple_visitors
 test_happy_path_visitor_and_intro_are_separate
 test_sad_invisible_visit
 test_sad_shadow_banned_visitor


### PR DESCRIPTION
Closes #1411

The periodic visitor notification now says how many people visited — in the push title and body, and the email subject and headline — instead of always "Someone visited your profile".

- The pending-notifications query gains a `counted` CTE that counts distinct visitors whose visit postdates the recipient's `last_online_time`, using the same filters as the notification trigger. The trigger already requires the newest visit to postdate last-online, so the count is always ≥ 1. The scan is capped at 100 rows per person.
- 100 or more visitors renders as "99+ people visited your profile 👀".
- A single visitor keeps the existing "Someone visited your profile" copy, since the periodic check can count its window but can't name anyone in it.
- `NotificationKind.subject` becomes a callable so the count can reach the push title and email subject; message notifications wrap their constant subject unchanged.

Unit tests cover the plural and capped copy for push and email, and `cron-notifications.sh` gains a two-visitor happy path. Existing single-visitor assertions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)