### PR TITLE
Fix the inbox failing to load when two filters bind the same parameter

### DIFF
--- a/backend/service/api/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/api/chat/messagestorage/inbox/__init__.py
@@ -542,15 +542,42 @@ def _conversation_from_row(row: Row) -> InboxConversation:
     )
 
 
+def build_inbox_snapshot_query(
+    username: str,
+    prefs: Row,
+    prospect_username: str | None,
+) -> tuple[str, dict[str, SearchParam]]:
+    filters = prospect_filters(prefs)
+    reverse = two_way_filters(prefs)
+
+    params: dict[str, SearchParam] = dict(
+        username=username,
+        recently_online_seconds=LAST_ONLINE_DEFAULT_SECONDS,
+    )
+    params.update(filters.params)
+    params.update(reverse.params)
+
+    if prospect_username is not None:
+        params['remote_bare_jid'] = f'{prospect_username}@{LSERVER}'
+
+    query = _q_inbox_snapshot(
+        entry_predicate=(
+            _ENTRY_PREDICATE_SNAPSHOT if prospect_username is None
+            else _ENTRY_PREDICATE_ENTRY
+        ),
+        matches_search_filters=and_clauses([
+            *filters.clauses,
+            *reverse.clauses,
+        ]),
+    )
+
+    return query, params
+
+
 async def _fetch_inbox_conversations(
     username: str,
     prospect_username: str | None = None,
 ) -> list[InboxConversation]:
-    entry_predicate = (
-        _ENTRY_PREDICATE_SNAPSHOT if prospect_username is None
-        else _ENTRY_PREDICATE_ENTRY
-    )
-
     async with api_tx('read committed') as tx:
         # The whole-inbox query's estimated cost crosses the default jit
         # thresholds for users with large inboxes, so JIT spends ~1s compiling
@@ -563,24 +590,10 @@ async def _fetch_inbox_conversations(
             dict(username=username),
         )
 
-        filters = prospect_filters(prefs)
-        reverse = two_way_filters(prefs)
-
-        params: dict[str, SearchParam] = dict(
+        query, params = build_inbox_snapshot_query(
             username=username,
-            recently_online_seconds=LAST_ONLINE_DEFAULT_SECONDS,
-            **filters.params,
-            **reverse.params,
-        )
-        if prospect_username is not None:
-            params['remote_bare_jid'] = f'{prospect_username}@{LSERVER}'
-
-        query = _q_inbox_snapshot(
-            entry_predicate=entry_predicate,
-            matches_search_filters=and_clauses([
-                *filters.clauses,
-                *reverse.clauses,
-            ]),
+            prefs=prefs,
+            prospect_username=prospect_username,
         )
 
         await tx.execute(query, params)

--- a/backend/service/api/chat/messagestorage/inbox/test_inbox.py
+++ b/backend/service/api/chat/messagestorage/inbox/test_inbox.py
@@ -1,0 +1,51 @@
+import unittest
+
+from search.sql.test_search import maximal_prefs
+from service.api.chat.messagestorage.inbox import build_inbox_snapshot_query
+
+
+class TestBuildInboxSnapshotQuery(unittest.TestCase):
+    def test_every_filter_parameter_is_bound(self) -> None:
+        prefs = maximal_prefs()
+
+        query, params = build_inbox_snapshot_query(
+            username='11111111-1111-1111-1111-111111111111',
+            prefs=prefs,
+            prospect_username=None,
+        )
+
+        for param in params:
+            self.assertIn(f'%({param})s', query)
+
+    def test_two_way_distance_alongside_own_distance_filter(self) -> None:
+        prefs = maximal_prefs()
+        self.assertIsNotNone(prefs['distance_meters'])
+        self.assertTrue(prefs['two_way_furthest_distance'])
+
+        _, params = build_inbox_snapshot_query(
+            username='11111111-1111-1111-1111-111111111111',
+            prefs=prefs,
+            prospect_username=None,
+        )
+
+        self.assertEqual(
+            params['searcher_coordinates'],
+            prefs['searcher_coordinates'],
+        )
+
+    def test_entry_predicate_binds_the_prospect(self) -> None:
+        query, params = build_inbox_snapshot_query(
+            username='11111111-1111-1111-1111-111111111111',
+            prefs=maximal_prefs(),
+            prospect_username='22222222-2222-2222-2222-222222222222',
+        )
+
+        self.assertIn('remote_bare_jid = %(remote_bare_jid)s', query)
+        self.assertEqual(
+            params['remote_bare_jid'],
+            '22222222-2222-2222-2222-222222222222@duolicious.app',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## The bug

Some users' inboxes never load: the client sends `duo_query_inbox` and the server never responds with `duo_inbox`.

`prospect_filters` binds `searcher_coordinates` when the viewer has a distance preference, and `two_way_filters` binds the *same* parameter when the viewer has the two-way distance filter on. `_fetch_inbox_conversations` merged the two sets by splatting them into one `dict(...)` call:

```python
params: dict[str, SearchParam] = dict(
    username=username,
    recently_online_seconds=LAST_ONLINE_DEFAULT_SECONDS,
    **filters.params,
    **reverse.params,
)
```

With both filters set that raises `TypeError: dict() got multiple values for keyword argument 'searcher_coordinates'`, before the query is ever sent to the database.

`get_inbox_snapshot` and `get_inbox_entry` catch the exception, print the traceback and return no stanzas, so the failure is silent on the wire: affected viewers wait out the `duo_query_inbox` timeout with an inbox that never loads, and they never receive `duo_inbox_entry` pushes for incoming messages either.

The equivalent merge in `search.sql.search.build_uncached_search` uses `params.update(...)`, so search was never affected — only the inbox.

## The fix

Extract `build_inbox_snapshot_query`, so the query and its parameters are built together in one place, and merge the two parameter sets with `update` there. Both sources bind `searcher_coordinates` to the same value, read from the same `prefs` row, so the merge is lossless.

## Testing

- New unit tests build the query from `search.sql.test_search.maximal_prefs`, which already sets both a distance preference and every two-way filter — the exact combination that used to raise. The tests also assert that every bound parameter appears in the generated SQL, and that the single-entry predicate binds the prospect.
- Verified against a copy of the production database: every affected viewer failed with the `TypeError` beforehand and returns their conversations afterwards, while a control group of unaffected viewers is unchanged.
- `./mypy.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)