### PR TITLE
Keep the visitor badge cleared after checking the Visitors tab

### DIFF
--- a/frontend/chat/application-layer/hooks/visitors.test.tsx
+++ b/frontend/chat/application-layer/hooks/visitors.test.tsx
@@ -1,0 +1,113 @@
+import { jest } from '@jest/globals';
+import type { DataItem } from './visitors';
+
+jest.mock('../../websocket-layer', () => ({
+  send: jest.fn(),
+  EV_CHAT_WS_RECEIVE: 'chat-ws-receive',
+}));
+
+jest.mock('../../conversation-priority', () => ({
+  awaitFocusedConversationFetch: jest.fn(async () => undefined),
+}));
+
+const t1 = '2026-08-01T00:00:00+00:00';
+const t2 = '2026-08-01T01:00:00+00:00';
+
+const makeItem = (overrides: Partial<DataItem>): DataItem => ({
+  person_uuid: 'person-1',
+  url_slug: null,
+  photo_uuid: null,
+  photo_blurhash: null,
+  time: t1,
+  name: 'Alice',
+  age: 25,
+  gender: 'Woman',
+  location: null,
+  is_verified: false,
+  match_percentage: 50,
+  verification_required_to_view: null,
+  is_new: false,
+  was_invisible: false,
+  ...overrides,
+});
+
+describe('visitor badge count', () => {
+  let markVisitorsChecked: (time: string) => void;
+  let notify: (key: string, data?: unknown) => void;
+  let lastEvent: <T>(key: string) => T | undefined;
+
+  beforeEach(() => {
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const visitors = require('./visitors');
+    markVisitorsChecked = visitors.markVisitorsChecked;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const events = require('../../../events/events');
+    notify = events.notify;
+    lastEvent = events.lastEvent;
+  });
+
+  const receiveSnapshot = (data: {
+    visited_you: DataItem[],
+    you_visited: DataItem[],
+    last_visited_at: string | null,
+  }) =>
+    notify('chat-ws-receive', { duo_visitors: JSON.stringify(data) });
+
+  const receiveDelta = (
+    section: 'visited_you' | 'you_visited',
+    item: DataItem,
+  ) =>
+    notify('chat-ws-receive', {
+      duo_visitor: {
+        '@section': section,
+        '@last_visited_at': item.time,
+        '#text': JSON.stringify(item),
+      },
+    });
+
+  test('the badge stays cleared when I visit someone after checking my visitors', () => {
+    receiveSnapshot({
+      visited_you: [makeItem({ person_uuid: 'visitor-1', is_new: true })],
+      you_visited: [],
+      last_visited_at: t1,
+    });
+    expect(lastEvent('num-visitors')).toBe(1);
+
+    markVisitorsChecked(t1);
+    expect(lastEvent('num-visitors')).toBe(0);
+
+    receiveDelta('you_visited', makeItem({ person_uuid: 'prospect-1', time: t2 }));
+    expect(lastEvent('num-visitors')).toBe(0);
+  });
+
+  test('checking my visitors keeps each row’s `is_new` dot until tapped', () => {
+    receiveSnapshot({
+      visited_you: [makeItem({ person_uuid: 'visitor-1', is_new: true })],
+      you_visited: [],
+      last_visited_at: t1,
+    });
+
+    markVisitorsChecked(t1);
+    expect(lastEvent<DataItem>('visited_you-visitor-1')?.is_new).toBe(true);
+
+    receiveDelta('you_visited', makeItem({ person_uuid: 'prospect-1', time: t2 }));
+    expect(lastEvent<DataItem>('visited_you-visitor-1')?.is_new).toBe(true);
+  });
+
+  test('a visit newer than the checked time still lights the badge', () => {
+    receiveSnapshot({
+      visited_you: [makeItem({ person_uuid: 'visitor-1', is_new: true })],
+      you_visited: [],
+      last_visited_at: t1,
+    });
+
+    markVisitorsChecked(t1);
+
+    receiveDelta(
+      'visited_you',
+      makeItem({ person_uuid: 'visitor-2', time: t2, is_new: true }),
+    );
+    expect(lastEvent('num-visitors')).toBe(1);
+  });
+});

--- a/frontend/chat/application-layer/hooks/visitors.tsx
+++ b/frontend/chat/application-layer/hooks/visitors.tsx
@@ -194,6 +194,17 @@ const emptyData = (): Data => ({
 
 let currentData: Data = emptyData();
 
+// The client-side mirror of the server's `last_visitor_check_time`. The badge
+// only counts visits since then, while each row's `is_new` dot survives until
+// that row is tapped.
+let lastCheckedAt: string | null = null;
+
+const countNewVisitors = (items: DataItem[]): number =>
+  items.filter(
+    // ISO 8601 UTC timestamps sort lexicographically.
+    (d) => d.is_new && (!lastCheckedAt || d.time > lastCheckedAt)
+  ).length;
+
 const setData = (data: Data) => {
   currentData = data;
 
@@ -211,7 +222,7 @@ const setData = (data: Data) => {
 
   setLastVisitedAt(data.last_visited_at);
 
-  setNumVisitors(data.visited_you.filter(d => d.is_new).length);
+  setNumVisitors(countNewVisitors(data.visited_you));
 };
 
 const maxTimestamp = (
@@ -279,11 +290,6 @@ const applyVisitorDelta = (
   });
 };
 
-const markVisitorsChecked = (time: string) => {
-  send({ data: { duo_mark_visitors_checked: { '@when': time } } });
-  setNumVisitors(0);
-};
-
 const markVisitorChecked = (personUuid: string) => {
   const key = `visited_you-${personUuid}`;
 
@@ -304,6 +310,12 @@ const markVisitorChecked = (personUuid: string) => {
   };
 
   setVisitorDataItem(key, updated, false);
+};
+
+const markVisitorsChecked = (time: string) => {
+  send({ data: { duo_mark_visitors_checked: { '@when': time } } });
+  lastCheckedAt = maxTimestamp(lastCheckedAt, time);
+  setNumVisitors(countNewVisitors(currentData.visited_you));
 };
 
 const requestVisitorsSnapshot = async () => {
@@ -358,6 +370,7 @@ listen(
   (user) => {
     if (!user) {
       youVisitedReorderSuppressions.clear();
+      lastCheckedAt = null;
       setData(emptyData());
     }
   },


### PR DESCRIPTION
Fixes #1430.

## Diagnosis

Visiting anyone's profile makes the server push a `duo_visitor` delta for the `you_visited` section back to the visitor themselves (`backend/visitorspush/__init__.py`). On the client, `applyVisitorDelta` merges that delta and calls `setData`, which recomputes the badge as `visited_you.filter(d => d.is_new).length`.

The problem: `markVisitorsChecked` (called when the Visitors tab gains focus) zeroed the badge and told the server, but left the cached `is_new: true` flags in `currentData.visited_you` untouched. So the very next delta — such as the one produced by you visiting someone else — resurrected the badge count from the stale flags.

## Fix

The badge is now computed against a client-side checked-at watermark (`lastCheckedAt`, mirroring the server's `last_visitor_check_time`): only visits strictly newer than the watermark count. `markVisitorsChecked` advances the watermark instead of zeroing the count, so a later delta can't re-light the badge, while a visit that lands *after* the check still does.

The per-row `is_new` flags are deliberately left untouched, so each row's "new" dot keeps its existing behavior: it survives until that row is tapped (`markVisitorChecked`) rather than vanishing the moment the tab gains focus.

Includes jest regression tests for all three behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
