### PR TITLE
Show the read-receipt upsell before the delivery time

### DIFF
--- a/frontend/components/conversation-screen/chat-message.tsx
+++ b/frontend/components/conversation-screen/chat-message.tsx
@@ -63,8 +63,7 @@ import { notify } from '../../events/events';
 import {
   ShowEmojiPickerEvent,
 } from '../modal/emoji-picker-modal';
-import { MessageReceipt } from './message-receipt';
-import { deliveredText } from './message-receipt-logic';
+import { MessageReceipt, ReceiptText } from './message-receipt';
 
 const currentUserBackgroundColor = '#70f';
 
@@ -777,7 +776,12 @@ const ChatMessage = ({
             color: appTheme.hintColor,
           }}
         >
-          {deliveredText(message.message.timestamp)}
+          <ReceiptText
+            content={{
+              kind: 'delivered',
+              timestamp: message.message.timestamp,
+            }}
+          />
         </DefaultText>
       }
       <MessageStatusComponent

--- a/frontend/components/conversation-screen/message-receipt-logic.test.tsx
+++ b/frontend/components/conversation-screen/message-receipt-logic.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, jest, test } from '@jest/globals';
+import { describe, expect, test } from '@jest/globals';
 import {
   Content,
   ReceiptState,
@@ -6,7 +6,6 @@ import {
   contentKey,
   contentText,
   newsKey,
-  readStatusDelayMs,
   receiptContent,
   useReceiptSide,
 } from './message-receipt-logic';
@@ -207,16 +206,6 @@ describe('useReceiptSide', () => {
     };
   };
 
-  const wait = (ms: number) => act(() => { jest.advanceTimersByTime(ms) });
-
-  beforeEach(() => {
-    jest.useFakeTimers();
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
   describe('settling on its own', () => {
     test('the slot starts on the delivery time', () => {
       render();
@@ -224,36 +213,12 @@ describe('useReceiptSide', () => {
       expect(latest).toEqual('delivered');
     });
 
-    test('the status takes the slot once the wait is up', () => {
-      render();
-
-      wait(readStatusDelayMs);
-
-      expect(latest).toEqual('status');
-    });
-
-    test('the status does not take the slot early', () => {
-      render();
-
-      wait(readStatusDelayMs - 1);
-
-      expect(latest).toEqual('delivered');
-    });
-
-    test('an arriving receipt takes the slot without waiting', () => {
+    test('an arriving receipt takes the slot', () => {
       const { set } = render();
 
       set({ readAt: READ_AT });
 
       expect(latest).toEqual('status');
-    });
-
-    test('an undelivered message never starts the wait', () => {
-      render({ deliveredAt: null });
-
-      wait(readStatusDelayMs * 10);
-
-      expect(latest).toEqual('delivered');
     });
   });
 
@@ -273,35 +238,6 @@ describe('useReceiptSide', () => {
       press();
 
       expect(latest).toEqual('delivered');
-    });
-
-    test('a pinned slot does not lose the wait to the status', () => {
-      const { press } = render();
-
-      press();
-      press();
-      wait(readStatusDelayMs * 10);
-
-      expect(latest).toEqual('delivered');
-    });
-
-    test('a press after the wait is up pins the delivery time', () => {
-      const { press } = render();
-
-      wait(readStatusDelayMs);
-      press();
-
-      expect(latest).toEqual('delivered');
-    });
-
-    test('a press before delivery does not stop the wait', () => {
-      const { set, press } = render({ deliveredAt: null });
-
-      press();
-      set({ deliveredAt: DELIVERED_AT });
-      wait(readStatusDelayMs);
-
-      expect(latest).toEqual('status');
     });
   });
 

--- a/frontend/components/conversation-screen/message-receipt-logic.test.tsx
+++ b/frontend/components/conversation-screen/message-receipt-logic.test.tsx
@@ -161,8 +161,12 @@ describe('contentParts', () => {
 
   test('the other kinds carry no label', () => {
     expect(contentParts({ kind: 'blank' }).label).toEqual('');
-    expect(contentParts({ kind: 'unread' }).label).toEqual('');
     expect(contentParts({ kind: 'upsell' }).label).toEqual('');
+  });
+
+  test('the unseen status is all label', () => {
+    expect(contentParts({ kind: 'unread' }))
+      .toEqual({ label: 'Not seen yet', detail: '' });
   });
 
   test('the label and detail together read as the full text', () => {

--- a/frontend/components/conversation-screen/message-receipt-logic.test.tsx
+++ b/frontend/components/conversation-screen/message-receipt-logic.test.tsx
@@ -169,11 +169,12 @@ describe('useReceiptSide', () => {
   type Props = {
     deliveredAt: Date | null
     readAt: Date | null
+    hasGold: boolean
     pressToggle: boolean
   };
 
-  const Probe = ({ deliveredAt, readAt, pressToggle }: Props) => {
-    latest = useReceiptSide(deliveredAt, readAt, pressToggle);
+  const Probe = ({ deliveredAt, readAt, hasGold, pressToggle }: Props) => {
+    latest = useReceiptSide(deliveredAt, readAt, hasGold, pressToggle);
     return null;
   };
 
@@ -181,6 +182,7 @@ describe('useReceiptSide', () => {
     let props: Props = {
       deliveredAt: DELIVERED_AT,
       readAt: null,
+      hasGold: true,
       pressToggle: false,
       ...initial,
     };
@@ -207,14 +209,28 @@ describe('useReceiptSide', () => {
   };
 
   describe('settling on its own', () => {
-    test('the slot starts on the delivery time', () => {
+    test('a gold user\'s slot starts on the delivery time', () => {
       render();
 
       expect(latest).toEqual('delivered');
     });
 
+    test('a non-gold user\'s slot starts on the status side', () => {
+      render({ hasGold: false });
+
+      expect(latest).toEqual('status');
+    });
+
     test('an arriving receipt takes the slot', () => {
       const { set } = render();
+
+      set({ readAt: READ_AT });
+
+      expect(latest).toEqual('status');
+    });
+
+    test('a receipt keeps a non-gold user\'s slot on the status side', () => {
+      const { set } = render({ hasGold: false });
 
       set({ readAt: READ_AT });
 
@@ -239,6 +255,14 @@ describe('useReceiptSide', () => {
 
       expect(latest).toEqual('delivered');
     });
+
+    test('a press shows a non-gold user the delivery time', () => {
+      const { press } = render({ hasGold: false });
+
+      press();
+
+      expect(latest).toEqual('delivered');
+    });
   });
 
   describe('news unpinning the slot', () => {
@@ -249,6 +273,15 @@ describe('useReceiptSide', () => {
       set({ deliveredAt: DELIVERED_AT });
 
       expect(latest).toEqual('delivered');
+    });
+
+    test('delivery settles a non-gold user\'s slot on the status side', () => {
+      const { set, press } = render({ deliveredAt: null, hasGold: false });
+
+      press();
+      set({ deliveredAt: DELIVERED_AT });
+
+      expect(latest).toEqual('status');
     });
 
     test('an arriving receipt takes the slot off what was pinned', () => {

--- a/frontend/components/conversation-screen/message-receipt-logic.test.tsx
+++ b/frontend/components/conversation-screen/message-receipt-logic.test.tsx
@@ -4,6 +4,7 @@ import {
   ReceiptState,
   Side,
   contentKey,
+  contentParts,
   contentText,
   newsKey,
   receiptContent,
@@ -144,6 +145,31 @@ describe('contentText', () => {
 
   test('the upsell keeps the name of the feature it sells', () => {
     expect(contentText({ kind: 'upsell' })).toEqual('Get read receipts');
+  });
+});
+
+describe('contentParts', () => {
+  test('the delivered label stands apart from the time', () => {
+    expect(contentParts({ kind: 'delivered', timestamp: DELIVERED_AT }).label)
+      .toEqual('Delivered');
+  });
+
+  test('the seen label stands apart from the time', () => {
+    expect(contentParts({ kind: 'read', timestamp: READ_AT }).label)
+      .toEqual('Seen');
+  });
+
+  test('the other kinds carry no label', () => {
+    expect(contentParts({ kind: 'blank' }).label).toEqual('');
+    expect(contentParts({ kind: 'unread' }).label).toEqual('');
+    expect(contentParts({ kind: 'upsell' }).label).toEqual('');
+  });
+
+  test('the label and detail together read as the full text', () => {
+    const content: Content = { kind: 'read', timestamp: READ_AT };
+    const { label, detail } = contentParts(content);
+
+    expect(label + detail).toEqual(contentText(content));
   });
 });
 

--- a/frontend/components/conversation-screen/message-receipt-logic.tsx
+++ b/frontend/components/conversation-screen/message-receipt-logic.tsx
@@ -25,17 +25,33 @@ const contentKey = (content: Content): string =>
     ? `${content.kind}-${content.timestamp.getTime()}`
     : content.kind;
 
-const deliveredText = (timestamp: Date): string =>
-  `Delivered ${longFriendlyTimestamp(timestamp)}`;
+type ContentParts = { label: string, detail: string };
+
+const contentParts = (content: Content): ContentParts => {
+  switch (content.kind) {
+    case 'blank':
+      return { label: '', detail: '\xa0' };
+    case 'delivered':
+      return {
+        label: 'Delivered',
+        detail: ` ${longFriendlyTimestamp(content.timestamp)}`,
+      };
+    case 'read':
+      return {
+        label: 'Seen',
+        detail: ` ${longFriendlyTimestamp(content.timestamp)}`,
+      };
+    case 'unread':
+      return { label: '', detail: 'Not seen yet' };
+    case 'upsell':
+      return { label: '', detail: 'Get read receipts' };
+  }
+};
 
 const contentText = (content: Content): string => {
-  switch (content.kind) {
-    case 'blank': return '\xa0';
-    case 'delivered': return deliveredText(content.timestamp);
-    case 'read': return `Seen ${longFriendlyTimestamp(content.timestamp)}`;
-    case 'unread': return 'Not seen yet';
-    case 'upsell': return 'Get read receipts';
-  }
+  const { label, detail } = contentParts(content);
+
+  return label + detail;
 };
 
 const receiptContent = ({
@@ -101,8 +117,8 @@ export {
   ReceiptState,
   Side,
   contentKey,
+  contentParts,
   contentText,
-  deliveredText,
   newsKey,
   receiptContent,
   useReceiptSide,

--- a/frontend/components/conversation-screen/message-receipt-logic.tsx
+++ b/frontend/components/conversation-screen/message-receipt-logic.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { longFriendlyTimestamp } from '../../util/util';
-
-const readStatusDelayMs = 3000;
 
 const newsKey = (deliveredAt: Date | null, readAt: Date | null): string =>
   `${deliveredAt?.getTime() ?? 0}-${readAt?.getTime() ?? 0}`;
@@ -61,28 +59,6 @@ const receiptContent = ({
   );
 };
 
-// The status only takes the slot a few seconds after delivery, so the delivery
-// time is seen before it's replaced. Pinning the slot by hand stops the wait,
-// so the status can't land on top of what the user chose to see.
-const useIsDelayElapsed = (
-  deliveredAt: Date | null,
-  isPinned: boolean,
-): boolean => {
-  const [isDelayElapsed, setIsDelayElapsed] = useState(false);
-
-  useEffect(() => {
-    if (!deliveredAt || isPinned) {
-      return;
-    }
-
-    const timeout = setTimeout(() => setIsDelayElapsed(true), readStatusDelayMs);
-
-    return () => clearTimeout(timeout);
-  }, [deliveredAt?.getTime(), isPinned]);
-
-  return isDelayElapsed;
-};
-
 // The slot settles on a side by itself, and each press pins it to the other
 // one. Delivery or an arriving receipt is news, which unpins the slot: it
 // settles afresh rather than staying on what the user last pressed to see.
@@ -99,9 +75,7 @@ const useReceiptSide = (
     pressToggle: boolean
   }>({ side: null, news, pressToggle });
 
-  const isDelayElapsed = useIsDelayElapsed(deliveredAt, pin.side !== null);
-
-  const settled: Side = readAt || isDelayElapsed ? 'status' : 'delivered';
+  const settled: Side = readAt ? 'status' : 'delivered';
 
   if (pin.news !== news) {
     setPin({ side: null, news, pressToggle });
@@ -129,7 +103,6 @@ export {
   contentText,
   deliveredText,
   newsKey,
-  readStatusDelayMs,
   receiptContent,
   useReceiptSide,
 };

--- a/frontend/components/conversation-screen/message-receipt-logic.tsx
+++ b/frontend/components/conversation-screen/message-receipt-logic.tsx
@@ -42,7 +42,7 @@ const contentParts = (content: Content): ContentParts => {
         detail: ` ${longFriendlyTimestamp(content.timestamp)}`,
       };
     case 'unread':
-      return { label: '', detail: 'Not seen yet' };
+      return { label: 'Not seen yet', detail: '' };
     case 'upsell':
       return { label: '', detail: 'Get read receipts' };
   }

--- a/frontend/components/conversation-screen/message-receipt-logic.tsx
+++ b/frontend/components/conversation-screen/message-receipt-logic.tsx
@@ -65,6 +65,7 @@ const receiptContent = ({
 const useReceiptSide = (
   deliveredAt: Date | null,
   readAt: Date | null,
+  hasGold: boolean,
   pressToggle: boolean,
 ): Side => {
   const news = newsKey(deliveredAt, readAt);
@@ -75,7 +76,7 @@ const useReceiptSide = (
     pressToggle: boolean
   }>({ side: null, news, pressToggle });
 
-  const settled: Side = readAt ? 'status' : 'delivered';
+  const settled: Side = readAt || !hasGold ? 'status' : 'delivered';
 
   if (pin.news !== news) {
     setPin({ side: null, news, pressToggle });

--- a/frontend/components/conversation-screen/message-receipt.tsx
+++ b/frontend/components/conversation-screen/message-receipt.tsx
@@ -5,11 +5,27 @@ import { useAppTheme } from '../../app-theme/app-theme';
 import { CrossFadeText } from '../cross-fade';
 import { useReadReceipt } from '../../chat/application-layer/hooks/read-receipt';
 import {
+  Content,
   contentKey,
-  contentText,
+  contentParts,
   receiptContent,
   useReceiptSide,
 } from './message-receipt-logic';
+
+const ReceiptText = ({ content }: { content: Content }) => {
+  const { label, detail } = contentParts(content);
+
+  return (
+    <>
+      {label !== '' &&
+        <DefaultText disableTheme={true} style={styles.labelText}>
+          {label}
+        </DefaultText>
+      }
+      {detail}
+    </>
+  );
+};
 
 const MessageReceipt = ({
   personUuid,
@@ -46,7 +62,7 @@ const MessageReceipt = ({
               }
             }}
           >
-            {contentText(content)}
+            <ReceiptText content={content} />
           </DefaultText>
         </Pressable>
       :
@@ -60,7 +76,7 @@ const MessageReceipt = ({
             }
           }}
         >
-          {contentText(content)}
+          <ReceiptText content={content} />
         </DefaultText>
       }
     </CrossFadeText>
@@ -83,8 +99,12 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     cursor: 'pointer',
   },
+  labelText: {
+    fontWeight: '700',
+  },
 });
 
 export {
   MessageReceipt,
+  ReceiptText,
 };

--- a/frontend/components/conversation-screen/message-receipt.tsx
+++ b/frontend/components/conversation-screen/message-receipt.tsx
@@ -1,7 +1,4 @@
-import { useMemo } from 'react';
-import { StyleSheet, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { runOnJS } from 'react-native-reanimated';
+import { Pressable, StyleSheet } from 'react-native';
 import { DefaultText } from '../default-text';
 import { showPointOfSale } from '../modal/point-of-sale-modal';
 import { useAppTheme } from '../../app-theme/app-theme';
@@ -31,30 +28,27 @@ const MessageReceipt = ({
 
   const content = receiptContent({ deliveredAt, readAt, hasGold, side });
 
-  const upsellGesture = useMemo(
-    () => Gesture.Tap().onEnd(() => runOnJS(showPointOfSale)(true)),
-    []
-  );
-
   return (
     <CrossFadeText triggerKey={contentKey(content)} style={styles.container}>
       {content.kind === 'upsell' ?
-        <GestureDetector gesture={upsellGesture}>
-          <View style={styles.upsellTarget}>
-            <DefaultText
-              disableTheme={true}
-              style={{
-                ...styles.upsellText,
-                ...{
-                  color: appTheme.brandColor,
-                  fontSize: appTheme.timestampFontSize,
-                }
-              }}
-            >
-              {contentText(content)}
-            </DefaultText>
-          </View>
-        </GestureDetector>
+        <Pressable
+          onPress={() => showPointOfSale(true)}
+          hitSlop={{ top: 5, bottom: 10, left: 10, right: 10 }}
+          style={styles.upsellTarget}
+        >
+          <DefaultText
+            disableTheme={true}
+            style={{
+              ...styles.upsellText,
+              ...{
+                color: appTheme.brandColor,
+                fontSize: appTheme.timestampFontSize,
+              }
+            }}
+          >
+            {contentText(content)}
+          </DefaultText>
+        </Pressable>
       :
         <DefaultText
           disableTheme={true}

--- a/frontend/components/conversation-screen/message-receipt.tsx
+++ b/frontend/components/conversation-screen/message-receipt.tsx
@@ -27,7 +27,7 @@ const MessageReceipt = ({
 }) => {
   const { appTheme } = useAppTheme();
   const readAt = useReadReceipt(personUuid, deliveredAt);
-  const side = useReceiptSide(deliveredAt, readAt, pressToggle);
+  const side = useReceiptSide(deliveredAt, readAt, hasGold, pressToggle);
 
   const content = receiptContent({ deliveredAt, readAt, hasGold, side });
 

--- a/frontend/components/conversation-screen/message-receipt.tsx
+++ b/frontend/components/conversation-screen/message-receipt.tsx
@@ -70,7 +70,7 @@ const MessageReceipt = ({
 const styles = StyleSheet.create({
   container: {
     width: '100%',
-    marginTop: 3,
+    marginTop: 5,
   },
   text: {
     textAlign: 'right',


### PR DESCRIPTION
Since #1371 shipped, the "Get read receipts" upsell has only appeared after a 3-second delay, and new-user subscription sales have dropped. This PR reworks the receipt slot so the upsell leads, and hardens the press path. One commit per change:

1. **Remove the timed transition.** The slot no longer hands itself to the read status after 3 seconds; it moves only when the user presses the speech bubble (news — delivery or an arriving receipt — still settles it afresh).
2. **Show "Get read receipts" first.** A non-gold user's slot settles on the status side, so the upsell is the first thing they see after delivery; the delivery time is a press away. Gold users still see the delivery time first.
3. **Audit: press the upsell through a `Pressable`, not `Gesture.Tap()`.** Findings on why the old press could be flaky:
   - `Gesture.Tap()` defaults to `maxDurationMs: 500` and `maxDistance: 10` — a press held over half a second, or one that drifts ~10px, **fails silently**. No fallback, no feedback.
   - The `GestureDetector` sits inside `CrossFadeText`, which remounts its subtree (`key` change) on every content transition, tearing down and re-registering the native handler and dropping any tap in flight. With the old timer, that remount landed at t=3s — exactly when users went to press.
   - RNGH taps don't respond to keyboard/screen-reader activation on web, and the `runOnJS` worklet hop is an extra moving part. The rest of the app presses its way into the point of sale with a plain `Pressable` (`basic.tsx`), so the upsell now does too, plus a modest `hitSlop`.
4. **+2px between the slot and the bubble**, so a press aimed at the slot is less likely to land on the bubble and flip the slot away.
5. **Bold "Delivered"/"Seen"**, iMessage-style; the time stays regular. The plain timestamp under older messages shares the same rendering.

## Testing

`npm run typecheck`, `npm run lint` and the read-receipt unit tests (39) pass.

Verified end-to-end on mobile web (Playwright, iPhone-13 viewport) against the local backend with two test accounts:
- Non-gold sender: "Get read receipts" appears immediately on delivery (7ms after the send click, no 3s wait); bubble presses toggle to "**Delivered** \<time\>" and back; nothing changes on its own after 4s of waiting; pressing the upsell opens the GOLD point of sale.
- Gold sender: "**Delivered** \<time\>" shows first, bubble press toggles to "Not seen yet", and the slot flips to "**Seen** \<time\>" when the recipient opens the conversation.
- The bold labels render in MontserratBold with the timestamp regular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)