### PR TITLE
Only show gallery blurhashes when the photo is slow to load

### DIFF
--- a/frontend/components/fill-image.tsx
+++ b/frontend/components/fill-image.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { StyleSheet } from 'react-native';
 import { Image as ExpoImage } from 'expo-image';
 
@@ -12,19 +13,37 @@ const FillImage = ({
   uri: string
   blurhash?: string | null
   onLoad?: () => void
-}) => (
-  <ExpoImage
-    source={{ uri }}
-    style={StyleSheet.absoluteFill}
-    contentFit="fill"
-    placeholder={blurhash ? { blurhash } : undefined}
-    placeholderContentFit="fill"
-    transition={0}
-    cachePolicy="memory-disk"
-    draggable={false}
-    onLoad={onLoad}
-  />
-);
+}) => {
+  const isLoaded = useRef(false);
+  const [showBlurhash, setShowBlurhash] = useState(false);
+
+  useEffect(() => {
+    if (!blurhash) return;
+    const timeout = setTimeout(() => {
+      if (!isLoaded.current) setShowBlurhash(true);
+    }, 200);
+    return () => clearTimeout(timeout);
+  }, [blurhash]);
+
+  const internalOnLoad = useCallback(() => {
+    isLoaded.current = true;
+    onLoad?.();
+  }, [onLoad]);
+
+  return (
+    <ExpoImage
+      source={{ uri }}
+      style={StyleSheet.absoluteFill}
+      contentFit="fill"
+      placeholder={showBlurhash && blurhash ? { blurhash } : undefined}
+      placeholderContentFit="fill"
+      transition={0}
+      cachePolicy="memory-disk"
+      draggable={false}
+      onLoad={internalOnLoad}
+    />
+  );
+};
 
 export {
   FillImage,

--- a/frontend/components/pinchy.tsx
+++ b/frontend/components/pinchy.tsx
@@ -215,7 +215,7 @@ const FitWithinScreenImage = ({
           the original, so there's a photo to show while the original
           downloads. The original covers them when it arrives.
         */}
-        {geometry && cropUri &&
+        {geometry && cropUri && !originalLoaded &&
           <View
             style={[styles.crop, cropRectWithin(geometry, imageWidth)]}
           >


### PR DESCRIPTION
Since 8af3a503 (#1377), pressing an `EnlargeablePhoto` flickered on Android at the start and end of the expansion animation.

The blurhash placeholders added in #1377 sit on the `FillImage`s at the gallery's two hand-off points, and on Android `expo-image` paints the placeholder first and swaps in the source asynchronously, a frame or two later, even on a memory-cache hit. So the opaque blurhash briefly covered a sharp photo that was already on screen: the still-visible preview when `ExpandingPhoto` mounts, and the still-mounted `ExpandingPhoto` when `Pinchy` mounts at the end of the morph. It was less likely on the second open because the source only wins the race against the placeholder when it's already in the memory cache.

`FillImage` now waits out a 200ms grace period before attaching the placeholder, and skips it if the image has loaded by then - the same idiom the gallery spinner already uses. Cache hits paint inside the window, so the hand-offs never show the blurhash; on slow connections it still appears after 200ms. Once shown it stays latched on, so the placeholder prop doesn't churn mid-display.

Trade-off: on slow connections, a page swiped to in the gallery shows black for 200ms before its blurhash, rather than the blurhash immediately.

Verified on an Android device: the flicker is gone at both ends of the animation, including on the first open of a photo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)