### PR TITLE
Hash the Q&A search filter and drop the personality HNSW index

### DIFF
--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -11,6 +11,7 @@ from database._row import (
     require_row,
     row_bool,
     row_int,
+    row_int_list,
     row_int_list_or_none,
     row_int_or_none,
     row_str,

--- a/backend/database/_row.py
+++ b/backend/database/_row.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from typing import TypeVar
 from util.coerce import (
     boolean,
+    int_list,
     integer,
     optional_int,
     optional_int_list,
@@ -46,6 +47,10 @@ def row_str_or_none(row: Mapping[str, object], key: str) -> str | None:
 
 def row_str_list(row: Mapping[str, object], key: str) -> list[str]:
     return string_list(row_value(row, key), key)
+
+
+def row_int_list(row: Mapping[str, object], key: str) -> list[int]:
+    return int_list(row_value(row, key), key)
 
 
 def row_int_list_or_none(row: Mapping[str, object], key: str) -> list[int] | None:

--- a/backend/init-api.sql
+++ b/backend/init-api.sql
@@ -1036,11 +1036,6 @@ CREATE INDEX IF NOT EXISTS idx__search_preference_distance__person_id__distance
 CREATE INDEX IF NOT EXISTS idx__search_preference_height_cm__person_id__bounds
     ON search_preference_height_cm(person_id) INCLUDE (min_height_cm, max_height_cm);
 
-CREATE INDEX IF NOT EXISTS
-    idx__person__personality
-    ON person
-    USING hnsw (personality vector_ip_ops);
-
 
 --------------------------------------------------------------------------------
 -- DATA

--- a/backend/migrations.sql
+++ b/backend/migrations.sql
@@ -17,3 +17,9 @@ CREATE INDEX IF NOT EXISTS idx__search_preference_distance__person_id__distance
 
 CREATE INDEX IF NOT EXISTS idx__search_preference_height_cm__person_id__bounds
     ON search_preference_height_cm(person_id) INCLUDE (min_height_cm, max_height_cm);
+
+-- The HNSW graph degenerates when many people share byte-identical
+-- personality vectors (every unanswered profile holds the default), silently
+-- omitting matching prospects from /search; the search now orders by exact
+-- distance instead, and nothing else queries by personality proximity.
+DROP INDEX IF EXISTS idx__person__personality;

--- a/backend/search/__init__.py
+++ b/backend/search/__init__.py
@@ -63,7 +63,6 @@ async def _uncached_search_results(
 
     try:
         await tx.execute('SET LOCAL jit = off')
-        await tx.execute("SET LOCAL hnsw.iterative_scan = strict_order")
 
         await tx.execute(Q_DELETE_SEARCH_CACHE, params)
         await tx.execute(uncached_search, params)

--- a/backend/search/sql/test_search.py
+++ b/backend/search/sql/test_search.py
@@ -50,7 +50,7 @@ def maximal_prefs() -> Row:
         show_messaged=False,
         show_skipped=False,
         has_answer_prefs=True,
-        has_required_answer_prefs=True,
+        required_answer_question_ids=[1, 2],
         searcher_person_id=1,
         searcher_coordinates='POINT(0 0)',
         searcher_personality='[0]',

--- a/backend/search/sql/test_search.py
+++ b/backend/search/sql/test_search.py
@@ -50,6 +50,7 @@ def maximal_prefs() -> Row:
         show_messaged=False,
         show_skipped=False,
         has_answer_prefs=True,
+        has_required_answer_prefs=True,
         searcher_person_id=1,
         searcher_coordinates='POINT(0 0)',
         searcher_personality='[0]',

--- a/backend/searchfilters/__init__.py
+++ b/backend/searchfilters/__init__.py
@@ -8,6 +8,7 @@ from database import (
     Row,
     row_bool,
     row_int,
+    row_int_list,
     row_int_list_or_none,
     row_int_or_none,
     row_str,
@@ -158,35 +159,24 @@ _ANSWER_NOT_CONTRARY = sql_fragment("""
 """)
 
 
-# The prospect answered every Q&A filter whose accept_unanswered is FALSE.
-# Emitted only when the searcher has such a filter: with zero required
-# questions the IN set is empty and would exclude everyone.
-_ANSWER_REQUIRED_ANSWERED = sql_fragment("""
-    prospect.id IN (
-        SELECT
-            ans.person_id
-        FROM
-            answer AS ans
-        JOIN
-            search_preference_answer AS pref
-        ON
-            pref.question_id = ans.question_id
-        WHERE
-            pref.person_id = %(searcher_person_id)s AND
-            pref.accept_unanswered = FALSE AND
-            ans.answer IS NOT NULL
-        GROUP BY
-            ans.person_id
-        HAVING
-            count(*) = (
-                SELECT count(*)
-                FROM search_preference_answer
-                WHERE
-                    person_id = %(searcher_person_id)s AND
-                    accept_unanswered = FALSE
-            )
-    )
-""")
+# The prospect answered this Q&A filter whose accept_unanswered is FALSE. One
+# clause per required question rather than a single aggregated set: a GROUP
+# BY/HAVING subquery gets un-nested into a semi-join against an unindexed
+# aggregate, which the planner nested-loops under row misestimates (>60s on
+# prod data), whereas plain membership in `answer` keeps its indexes usable by
+# every join strategy.
+def _answer_required_clause(param: str) -> str:
+    return sql_fragment(f"""
+        prospect.id IN (
+            SELECT
+                person_id
+            FROM
+                answer
+            WHERE
+                question_id = %({param})s AND
+                answer IS NOT NULL
+        )
+    """)
 
 
 _PARAM_ENUM_SELECTS = ',\n'.join(
@@ -301,12 +291,13 @@ SELECT
         FROM search_preference_answer
         WHERE person_id = person.id
     ) AS has_answer_prefs,
-    EXISTS (
-        SELECT 1
+    ARRAY(
+        SELECT question_id
         FROM search_preference_answer
         WHERE person_id = person.id
         AND accept_unanswered = FALSE
-    ) AS has_required_answer_prefs,
+        ORDER BY question_id
+    ) AS required_answer_question_ids,
     person.coordinates::TEXT AS searcher_coordinates,
     person.personality::TEXT AS searcher_personality,
     EXTRACT(YEAR FROM AGE(person.date_of_birth))::INT AS searcher_age,
@@ -377,9 +368,11 @@ def prospect_filters(prefs: Row) -> ProspectFilters:
         params['searcher_person_id'] = row_int(prefs, 'searcher_person_id')
         clauses.append(_ANSWER_NOT_CONTRARY)
 
-    if row_bool(prefs, 'has_required_answer_prefs'):
-        params['searcher_person_id'] = row_int(prefs, 'searcher_person_id')
-        clauses.append(_ANSWER_REQUIRED_ANSWERED)
+    for i, question_id in enumerate(
+            row_int_list(prefs, 'required_answer_question_ids')):
+        param = f'required_answer_question_id_{i}'
+        params[param] = question_id
+        clauses.append(_answer_required_clause(param))
 
     return ProspectFilters(clauses=clauses, params=params)
 

--- a/backend/searchfilters/__init__.py
+++ b/backend/searchfilters/__init__.py
@@ -134,27 +134,57 @@ _SHOWS_ONLINE_STATUS = sql_fragment("""
 """)
 
 
-_ANSWER_NOT_EXISTS = sql_fragment("""
-    NOT EXISTS (
-        SELECT 1
-        FROM (
-            SELECT *
-            FROM search_preference_answer
-            WHERE person_id = %(searcher_person_id)s
-        ) AS pref
-        LEFT JOIN
-            answer ans
+# The prospect answered none of the searcher's Q&A filters contrarily. The
+# subquery is deliberately uncorrelated: the planner builds the exclusion set
+# once per statement and hashes every prospect against it, where a correlated
+# form re-probes `answer` per prospect and made broad searches time out. In
+# per-prospect consumers (inbox) the hashed subplan is likewise built once per
+# statement and reused across rows.
+_ANSWER_NOT_CONTRARY = sql_fragment("""
+    prospect.id NOT IN (
+        SELECT
+            ans.person_id
+        FROM
+            search_preference_answer AS pref
+        JOIN
+            answer AS ans
         ON
-            ans.person_id = prospect.id AND
             ans.question_id = pref.question_id
         WHERE
-            -- Contrary because the answer exists and is wrong
+            pref.person_id = %(searcher_person_id)s AND
             ans.answer IS NOT NULL AND
             ans.answer != pref.answer
-        OR
-            -- Contrary because the answer doesn't exist but should
-            ans.answer IS NULL AND
-            pref.accept_unanswered = FALSE
+    )
+""")
+
+
+# The prospect answered every Q&A filter whose accept_unanswered is FALSE.
+# Emitted only when the searcher has such a filter: with zero required
+# questions the IN set is empty and would exclude everyone.
+_ANSWER_REQUIRED_ANSWERED = sql_fragment("""
+    prospect.id IN (
+        SELECT
+            ans.person_id
+        FROM
+            answer AS ans
+        JOIN
+            search_preference_answer AS pref
+        ON
+            pref.question_id = ans.question_id
+        WHERE
+            pref.person_id = %(searcher_person_id)s AND
+            pref.accept_unanswered = FALSE AND
+            ans.answer IS NOT NULL
+        GROUP BY
+            ans.person_id
+        HAVING
+            count(*) = (
+                SELECT count(*)
+                FROM search_preference_answer
+                WHERE
+                    person_id = %(searcher_person_id)s AND
+                    accept_unanswered = FALSE
+            )
     )
 """)
 
@@ -271,6 +301,12 @@ SELECT
         FROM search_preference_answer
         WHERE person_id = person.id
     ) AS has_answer_prefs,
+    EXISTS (
+        SELECT 1
+        FROM search_preference_answer
+        WHERE person_id = person.id
+        AND accept_unanswered = FALSE
+    ) AS has_required_answer_prefs,
     person.coordinates::TEXT AS searcher_coordinates,
     person.personality::TEXT AS searcher_personality,
     EXTRACT(YEAR FROM AGE(person.date_of_birth))::INT AS searcher_age,
@@ -339,7 +375,11 @@ def prospect_filters(prefs: Row) -> ProspectFilters:
 
     if row_bool(prefs, 'has_answer_prefs'):
         params['searcher_person_id'] = row_int(prefs, 'searcher_person_id')
-        clauses.append(_ANSWER_NOT_EXISTS)
+        clauses.append(_ANSWER_NOT_CONTRARY)
+
+    if row_bool(prefs, 'has_required_answer_prefs'):
+        params['searcher_person_id'] = row_int(prefs, 'searcher_person_id')
+        clauses.append(_ANSWER_REQUIRED_ANSWERED)
 
     return ProspectFilters(clauses=clauses, params=params)
 

--- a/backend/util/coerce.py
+++ b/backend/util/coerce.py
@@ -56,6 +56,12 @@ def string_list(value: object, field_name: str | None = None) -> list[str]:
     return cast(list[str], value)
 
 
+def int_list(value: object, field_name: str | None = None) -> list[int]:
+    if not isinstance(value, list) or not all(isinstance(x, int) for x in value):
+        raise RuntimeError(_message('a list of integers', field_name))
+    return cast(list[int], value)
+
+
 def optional_int_list(
     value: object,
     field_name: str | None = None,


### PR DESCRIPTION
## Problem

Two distinct defects made searches slow or wrong (#1449):

1. **The Q&A answer filter ran per prospect.** `_ANSWER_NOT_EXISTS` was a correlated subquery, so a full-table candidate scan re-probed `answer` (41M rows) once per prospect per preference. With broad scalar filters (e.g. "last online: all time") the scan covers ~196k people and the query blows through the 10s `statement_timeout` — the exact shape of the #1449 report (7 answer filters + weak scalar filters).

2. **The personality HNSW index silently drops matches.** Every profile with no quiz answers carries the byte-identical default vector (16k+ people on prod data, plus other duplicate clusters), which degenerates the HNSW graph. For some searchers an index-ordered scan emits a handful of rows and exhausts: measured on a prod-scale copy, one searcher's ordered `LIMIT 750` query returned 29 rows via the index when 83,594 people actually matched. For another, a cursor-streamed variant of the same query returned 0 rows when 87 people matched.

## Approach

- The answer filter becomes **uncorrelated, hashable** set-membership clauses, built once per statement instead of probed per row:
  - `_ANSWER_NOT_CONTRARY`: `prospect.id NOT IN (…answers contrary to a preference…)`
  - One `prospect.id IN (SELECT person_id FROM answer WHERE question_id = … AND answer IS NOT NULL)` clause **per required question** (`accept_unanswered = FALSE`), driven by a new `required_answer_question_ids` search parameter. An earlier draft aggregated these into a single `IN (… GROUP BY … HAVING …)` clause, but the planner un-nests that into a semi-join against an unindexed aggregate and nested-loops it under row misestimates — a real searcher regressed from 0.5s to a >60s timeout. With plain per-question membership the semi-join's inner side is the indexed `answer` table, so hash semi-join and per-row index probes are both cheap and there is no catastrophic plan.
- `idx__person__personality` is dropped (removed from `init-api.sql`, idempotent `DROP INDEX IF EXISTS` in `migrations.sql`). The uncached search's `ORDER BY personality <#> … LIMIT 750` then plans as a filter-driven scan + top-N heapsort (~1.3MB of sort memory): exact results, stable plan. Nothing else in the backend does an index-eligible `ORDER BY … <#>` (every other use is column-to-column), so the index had no other ordering consumer — just 97MB and per-write graph maintenance.
- The now-meaningless `hnsw.iterative_scan` session setting is removed.

These two changes are interdependent: the HNSW index was load-bearing *for the old clause* (it bounded how many candidates got the expensive per-row probe — no index + old clause is ~107s on the #1449 shape). Neither half should ship or be reverted without the other.

## Behaviour (benchmarked on a prod-scale copy)

- Rewritten answer clauses return **identical match sets** to the old clause, verified element-for-element for **all 226 searchers with required (`accept_unanswered = FALSE`) preferences**, plus representative answer-preference searchers (up to 83,594 matches) — zero mismatches.
- Reproduction of the #1449 shape (87,835-person scalar pool + the report's five Q&A filters, candidate `SELECT` only): **9.0s → 1.1s**. Old clause on the full pool: 118s.
- Adversarial worst case for the required-question clauses (the 20 *most-answered* questions all marked required over the same broad pool): **~6s**.
- End-to-end uncached search (full `INSERT … SELECT` including cache write, no index) for the pathological searchers found during review: all **≤2.3s**.
- Exact-distance ordering worst case (no filters at all, 196k candidates): **2.1–2.6s**, well inside the 10s timeout. A 30-user sweep of real saved preferences maxed at 2.7s, median ~0.06s.
- The inbox's `matches_search_filters` (same clause builders) builds each hashed set once per snapshot statement and reuses it across conversations; per-prospect probes stay fast.

Alternative to #1450 / #1451: with the two root causes fixed, uncached search fits its budget as a single plain statement, so no cursor streaming, deadline bookkeeping, or plan introspection is needed. (#1450's `cursor_tuple_fraction` delegation is also unsound: it flips the DECLARE'd plan to the degenerate HNSW crawl invisibly to EXPLAIN — that's the 0-of-87-rows measurement above.) Fixes #1449.

---

* Closes https://github.com/duolicious/duolicious/issues/1453
* Closes https://github.com/duolicious/duolicious/issues/1449

🤖 Generated with [Claude Code](https://claude.com/claude-code)
