### PR TITLE
Carry web.duolicious.app sessions over to duolicious.app

### DIFF
--- a/.github/workflows/frontend-publish.yml
+++ b/.github/workflows/frontend-publish.yml
@@ -49,10 +49,20 @@ jobs:
             exit 1
           fi
 
+          # The session-bridge page must be frameable by duolicious.app --
+          # and only by duolicious.app -- so the apex origin can lift
+          # signed-in sessions out of web.duolicious.app's localStorage
+          # (see frontend/api/session-bridge.tsx). Everything else keeps
+          # X-Frame-Options: DENY. Cloudflare Pages serves the page at the
+          # extension-less URL and redirects the .html one to it, so only
+          # the extension-less path needs the carve-out.
           cat > dist/_headers <<EOF
             /*
               X-Frame-Options: DENY
               Access-Control-Allow-Origin: ${DUO_API_URL}
+            /assets/session-bridge
+              ! X-Frame-Options
+              Content-Security-Policy: frame-ancestors https://duolicious.app
           EOF
 
           # Cloudflare ignores directories containing the string 'node_modules'.

--- a/.github/workflows/frontend-publish.yml
+++ b/.github/workflows/frontend-publish.yml
@@ -52,7 +52,7 @@ jobs:
           # The session-bridge page must be frameable by duolicious.app --
           # and only by duolicious.app -- so the apex origin can lift
           # signed-in sessions out of web.duolicious.app's localStorage
-          # (see frontend/api/session-bridge.tsx). Everything else keeps
+          # (see frontend/kv-storage/session-bridge.tsx). Everything else keeps
           # X-Frame-Options: DENY. Cloudflare Pages serves the page at the
           # extension-less URL and redirects the .html one to it, so only
           # the extension-less path needs the carve-out.

--- a/frontend/api/session-bridge.tsx
+++ b/frontend/api/session-bridge.tsx
@@ -1,0 +1,81 @@
+import { Platform } from 'react-native';
+import { storeKv } from '../kv-storage/kv-storage';
+
+// Sessions live in origin-scoped localStorage, so users who signed in on
+// web.duolicious.app arrive at duolicious.app logged out. This fetches
+// their session from the old origin via a hidden iframe of the static
+// bridge page (public/assets/session-bridge.html), which posts the
+// stored credentials back. It works because the two domains are the same
+// site (registrable domain duolicious.app), so browsers don't partition
+// the iframe's storage. The handed-over token is treated as untrusted:
+// the caller runs it through the ordinary /check-session-token
+// validation, and a dead or bogus token just lands on the welcome
+// screen.
+//
+// A definitive answer (including "no session there") is recorded in
+// kv-storage so each browser only ever pays for the bridge once; a
+// timeout isn't recorded, so transient failures retry on the next load.
+
+const BRIDGE_ORIGIN = 'https://web.duolicious.app';
+const BRIDGE_URL = `${BRIDGE_ORIGIN}/assets/session-bridge`;
+const BRIDGE_TIMEOUT_MS = 2000;
+
+type BridgedSession = {
+  sessionToken: string
+  personUuid: string
+};
+
+const runBridge = (): Promise<BridgedSession | null> =>
+  new Promise((resolve) => {
+    const iframe = document.createElement('iframe');
+    iframe.style.display = 'none';
+
+    const finish = async (
+      result: BridgedSession | null,
+      isDefinitive: boolean,
+    ) => {
+      window.removeEventListener('message', onMessage);
+      clearTimeout(timer);
+      iframe.remove();
+      if (isDefinitive) {
+        await storeKv('web_session_bridge_answered', '1');
+      }
+      resolve(result);
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin !== BRIDGE_ORIGIN) return;
+      if (event.source !== iframe.contentWindow) return;
+      const data = event.data;
+      if (data?.type !== 'session-bridge') return;
+      if (typeof data.sessionToken !== 'string') {
+        finish(null, true);
+        return;
+      }
+      if (typeof data.personUuid !== 'string') {
+        finish(null, true);
+        return;
+      }
+      finish(
+        { sessionToken: data.sessionToken, personUuid: data.personUuid },
+        true,
+      );
+    };
+
+    const timer = setTimeout(() => finish(null, false), BRIDGE_TIMEOUT_MS);
+    window.addEventListener('message', onMessage);
+    iframe.src = BRIDGE_URL;
+    document.body.appendChild(iframe);
+  });
+
+const fetchWebSessionOnApex = async (): Promise<BridgedSession | null> => {
+  if (Platform.OS !== 'web') return null;
+  if (window.location.hostname !== 'duolicious.app') return null;
+  if (await storeKv('web_session_bridge_answered')) return null;
+
+  return await runBridge();
+};
+
+export {
+  fetchWebSessionOnApex,
+};

--- a/frontend/api/session-bridge.tsx
+++ b/frontend/api/session-bridge.tsx
@@ -1,16 +1,17 @@
 import { Platform } from 'react-native';
-import { storeKv } from '../kv-storage/kv-storage';
+import { KEYS, Key, storeKv } from '../kv-storage/kv-storage';
 
 // Sessions live in origin-scoped localStorage, so users who signed in on
 // web.duolicious.app arrive at duolicious.app logged out. This fetches
-// their session from the old origin via a hidden iframe of the static
-// bridge page (public/assets/session-bridge.html), which posts the
-// stored credentials back. It works because the two domains are the same
-// site (registrable domain duolicious.app), so browsers don't partition
-// the iframe's storage. The handed-over token is treated as untrusted:
-// the caller runs it through the ordinary /check-session-token
-// validation, and a dead or bogus token just lands on the welcome
-// screen.
+// their session -- and the rest of the app's stored state, like drafts,
+// theme and seen-hints -- from the old origin via a hidden iframe of the
+// static bridge page (public/assets/session-bridge.html), which posts
+// its entire localStorage back; only keys in the kv-storage allowlist
+// are adopted. It works because the two domains are the same site
+// (registrable domain duolicious.app), so browsers don't partition the
+// iframe's storage. The handed-over token is treated as untrusted: the
+// caller runs it through the ordinary /check-session-token validation,
+// and a dead or bogus token just lands on the welcome screen.
 //
 // A definitive answer (including "no session there") is recorded in
 // kv-storage so each browser only ever pays for the bridge once; a
@@ -20,9 +21,44 @@ const BRIDGE_ORIGIN = 'https://web.duolicious.app';
 const BRIDGE_URL = `${BRIDGE_ORIGIN}/assets/session-bridge`;
 const BRIDGE_TIMEOUT_MS = 2000;
 
+// The session keys gate the transfer and are adopted explicitly by
+// `adoptWebSession`; the bridge bookkeeping key must reflect this
+// origin's own state, never the other origin's.
+const UNTRANSFERABLE_KEYS: readonly Key[] = [
+  'session_token',
+  'person_uuid',
+  'web_session_bridge_answered',
+];
+
 type BridgedSession = {
   sessionToken: string
   personUuid: string
+  extras: Partial<Record<Key, string>>
+};
+
+const isRecord = (x: unknown): x is Record<string, unknown> =>
+  typeof x === 'object' && x !== null;
+
+const parseBridgedSession = (data: unknown): BridgedSession | null => {
+  if (!isRecord(data)) return null;
+  const values = data.storage;
+  if (!isRecord(values)) return null;
+
+  const sessionToken = values['session_token'];
+  const personUuid = values['person_uuid'];
+  if (typeof sessionToken !== 'string') return null;
+  if (typeof personUuid !== 'string') return null;
+
+  const extras: Partial<Record<Key, string>> = {};
+  for (const key of KEYS) {
+    if (UNTRANSFERABLE_KEYS.includes(key)) continue;
+    const value = values[key];
+    if (typeof value === 'string') {
+      extras[key] = value;
+    }
+  }
+
+  return { sessionToken, personUuid, extras };
 };
 
 const runBridge = (): Promise<BridgedSession | null> =>
@@ -46,20 +82,8 @@ const runBridge = (): Promise<BridgedSession | null> =>
     const onMessage = (event: MessageEvent) => {
       if (event.origin !== BRIDGE_ORIGIN) return;
       if (event.source !== iframe.contentWindow) return;
-      const data = event.data;
-      if (data?.type !== 'session-bridge') return;
-      if (typeof data.sessionToken !== 'string') {
-        finish(null, true);
-        return;
-      }
-      if (typeof data.personUuid !== 'string') {
-        finish(null, true);
-        return;
-      }
-      finish(
-        { sessionToken: data.sessionToken, personUuid: data.personUuid },
-        true,
-      );
+      if (event.data?.type !== 'session-bridge') return;
+      finish(parseBridgedSession(event.data), true);
     };
 
     const timer = setTimeout(() => finish(null, false), BRIDGE_TIMEOUT_MS);
@@ -76,6 +100,19 @@ const fetchWebSessionOnApex = async (): Promise<BridgedSession | null> => {
   return await runBridge();
 };
 
+const adoptWebSession = async (bridged: BridgedSession): Promise<void> => {
+  await storeKv('session_token', bridged.sessionToken);
+  await storeKv('person_uuid', bridged.personUuid);
+  for (const key of KEYS) {
+    const value = bridged.extras[key];
+    if (value !== undefined) {
+      await storeKv(key, value);
+    }
+  }
+};
+
 export {
+  BridgedSession,
+  adoptWebSession,
   fetchWebSessionOnApex,
 };

--- a/frontend/app-startup/app-startup.tsx
+++ b/frontend/app-startup/app-startup.tsx
@@ -31,10 +31,7 @@ import { computeStartupNavigationState } from '../navigation/startup';
 import { createLinking, focusedConversationHandle } from '../navigation/linking';
 import { resetUserScopedClientState } from '../navigation/reset-client-state';
 import { hasPendingAppleWebSignIn } from '../api/social-auth';
-import {
-  adoptWebSession,
-  fetchWebSessionOnApex,
-} from '../kv-storage/session-bridge';
+import { adoptWebSessionOnApex } from '../kv-storage/session-bridge';
 import { showSignUp } from '../components/modal/sign-up-modal';
 
 ExpoSplashScreen.preventAutoHideAsync();
@@ -138,18 +135,11 @@ const useAppStartup = (
   );
 
   const restoreSessionAndNavigate = useCallback(async () => {
-    let existingPersonUuid = await sessionPersonUuid();
-    let existingSessionToken = await sessionToken();
-    const notification = await getLastNotificationResponseOnMobile();
+    await adoptWebSessionOnApex();
 
-    if (!existingPersonUuid || !existingSessionToken) {
-      const bridged = await fetchWebSessionOnApex();
-      if (bridged) {
-        await adoptWebSession(bridged);
-        existingSessionToken = bridged.sessionToken;
-        existingPersonUuid = bridged.personUuid;
-      }
-    }
+    const existingPersonUuid = await sessionPersonUuid();
+    const existingSessionToken = await sessionToken();
+    const notification = await getLastNotificationResponseOnMobile();
 
     // `computeStartupNavigationState` owns every routing decision at startup:
     // URL deep-links, public-vs-protected screens, push notifications, the

--- a/frontend/app-startup/app-startup.tsx
+++ b/frontend/app-startup/app-startup.tsx
@@ -34,7 +34,7 @@ import { hasPendingAppleWebSignIn } from '../api/social-auth';
 import {
   adoptWebSession,
   fetchWebSessionOnApex,
-} from '../api/session-bridge';
+} from '../kv-storage/session-bridge';
 import { showSignUp } from '../components/modal/sign-up-modal';
 
 ExpoSplashScreen.preventAutoHideAsync();

--- a/frontend/app-startup/app-startup.tsx
+++ b/frontend/app-startup/app-startup.tsx
@@ -31,7 +31,10 @@ import { computeStartupNavigationState } from '../navigation/startup';
 import { createLinking, focusedConversationHandle } from '../navigation/linking';
 import { resetUserScopedClientState } from '../navigation/reset-client-state';
 import { hasPendingAppleWebSignIn } from '../api/social-auth';
-import { fetchWebSessionOnApex } from '../api/session-bridge';
+import {
+  adoptWebSession,
+  fetchWebSessionOnApex,
+} from '../api/session-bridge';
 import { showSignUp } from '../components/modal/sign-up-modal';
 
 ExpoSplashScreen.preventAutoHideAsync();
@@ -142,8 +145,7 @@ const useAppStartup = (
     if (!existingPersonUuid || !existingSessionToken) {
       const bridged = await fetchWebSessionOnApex();
       if (bridged) {
-        await sessionToken(bridged.sessionToken);
-        await sessionPersonUuid(bridged.personUuid);
+        await adoptWebSession(bridged);
         existingSessionToken = bridged.sessionToken;
         existingPersonUuid = bridged.personUuid;
       }

--- a/frontend/app-startup/app-startup.tsx
+++ b/frontend/app-startup/app-startup.tsx
@@ -31,6 +31,7 @@ import { computeStartupNavigationState } from '../navigation/startup';
 import { createLinking, focusedConversationHandle } from '../navigation/linking';
 import { resetUserScopedClientState } from '../navigation/reset-client-state';
 import { hasPendingAppleWebSignIn } from '../api/social-auth';
+import { fetchWebSessionOnApex } from '../api/session-bridge';
 import { showSignUp } from '../components/modal/sign-up-modal';
 
 ExpoSplashScreen.preventAutoHideAsync();
@@ -134,9 +135,19 @@ const useAppStartup = (
   );
 
   const restoreSessionAndNavigate = useCallback(async () => {
-    const existingPersonUuid = await sessionPersonUuid();
-    const existingSessionToken = await sessionToken();
+    let existingPersonUuid = await sessionPersonUuid();
+    let existingSessionToken = await sessionToken();
     const notification = await getLastNotificationResponseOnMobile();
+
+    if (!existingPersonUuid || !existingSessionToken) {
+      const bridged = await fetchWebSessionOnApex();
+      if (bridged) {
+        await sessionToken(bridged.sessionToken);
+        await sessionPersonUuid(bridged.personUuid);
+        existingSessionToken = bridged.sessionToken;
+        existingPersonUuid = bridged.personUuid;
+      }
+    }
 
     // `computeStartupNavigationState` owns every routing decision at startup:
     // URL deep-links, public-vs-protected screens, push notifications, the

--- a/frontend/kv-storage/kv-storage.tsx
+++ b/frontend/kv-storage/kv-storage.tsx
@@ -18,6 +18,7 @@ const KEYS = [
   'seen_search_filters_hint',
   'session_token',
   'was_review_requested',
+  'web_session_bridge_answered',
 ] as const;
 
 type Key = typeof KEYS[number];

--- a/frontend/kv-storage/kv-storage.tsx
+++ b/frontend/kv-storage/kv-storage.tsx
@@ -136,6 +136,8 @@ const clearAllKvExceptSessionToken = async () => {
 };
 
 export {
+  KEYS,
+  Key,
   storeKv,
   clearAllKv,
   clearAllKvExceptSessionToken,

--- a/frontend/kv-storage/session-bridge.tsx
+++ b/frontend/kv-storage/session-bridge.tsx
@@ -2,20 +2,27 @@ import { Platform } from 'react-native';
 import { KEYS, Key, storeKv } from './kv-storage';
 
 // Sessions live in origin-scoped localStorage, so users who signed in on
-// web.duolicious.app arrive at duolicious.app logged out. This fetches
-// their session -- and the rest of the app's stored state, like drafts,
-// theme and seen-hints -- from the old origin via a hidden iframe of the
-// static bridge page (public/assets/session-bridge.html), which posts
-// its entire localStorage back; only keys in the kv-storage allowlist
-// are adopted. It works because the two domains are the same site
-// (registrable domain duolicious.app), so browsers don't partition the
-// iframe's storage. The handed-over token is treated as untrusted: the
-// caller runs it through the ordinary /check-session-token validation,
-// and a dead or bogus token just lands on the welcome screen.
+// web.duolicious.app arrive at duolicious.app logged out.
+// `adoptWebSessionOnApex`, called once at startup before the session is
+// read from kv-storage, fetches their session -- and the rest of the
+// app's stored state, like drafts, theme and seen-hints -- from the old
+// origin via a hidden iframe of the static bridge page
+// (public/assets/session-bridge.html), which posts its entire
+// localStorage back; only keys in the kv-storage allowlist are adopted.
+// It works because the two domains are the same site (registrable
+// domain duolicious.app), so browsers don't partition the iframe's
+// storage. The handed-over token is treated as untrusted: startup runs
+// it through the ordinary /check-session-token validation, and a dead
+// or bogus token just lands on the welcome screen.
 //
 // A definitive answer (including "no session there") is recorded in
 // kv-storage so each browser only ever pays for the bridge once; a
 // timeout isn't recorded, so transient failures retry on the next load.
+//
+// The whole mechanism is a migration aid: once web.duolicious.app
+// traffic dwindles, delete this module, its single call site in
+// app-startup, public/assets/session-bridge.html, and the _headers
+// carve-out in frontend-publish.yml.
 
 const BRIDGE_ORIGIN = 'https://web.duolicious.app';
 const BRIDGE_URL = `${BRIDGE_ORIGIN}/assets/session-bridge`;
@@ -92,15 +99,15 @@ const runBridge = (): Promise<BridgedSession | null> =>
     document.body.appendChild(iframe);
   });
 
-const fetchWebSessionOnApex = async (): Promise<BridgedSession | null> => {
-  if (Platform.OS !== 'web') return null;
-  if (window.location.hostname !== 'duolicious.app') return null;
-  if (await storeKv('web_session_bridge_answered')) return null;
+const adoptWebSessionOnApex = async (): Promise<void> => {
+  if (Platform.OS !== 'web') return;
+  if (window.location.hostname !== 'duolicious.app') return;
+  if (await storeKv('session_token') && await storeKv('person_uuid')) return;
+  if (await storeKv('web_session_bridge_answered')) return;
 
-  return await runBridge();
-};
+  const bridged = await runBridge();
+  if (!bridged) return;
 
-const adoptWebSession = async (bridged: BridgedSession): Promise<void> => {
   await storeKv('session_token', bridged.sessionToken);
   await storeKv('person_uuid', bridged.personUuid);
   for (const key of KEYS) {
@@ -112,7 +119,5 @@ const adoptWebSession = async (bridged: BridgedSession): Promise<void> => {
 };
 
 export {
-  BridgedSession,
-  adoptWebSession,
-  fetchWebSessionOnApex,
+  adoptWebSessionOnApex,
 };

--- a/frontend/kv-storage/session-bridge.tsx
+++ b/frontend/kv-storage/session-bridge.tsx
@@ -1,5 +1,5 @@
 import { Platform } from 'react-native';
-import { KEYS, Key, storeKv } from '../kv-storage/kv-storage';
+import { KEYS, Key, storeKv } from './kv-storage';
 
 // Sessions live in origin-scoped localStorage, so users who signed in on
 // web.duolicious.app arrive at duolicious.app logged out. This fetches

--- a/frontend/patches/index.html.patch
+++ b/frontend/patches/index.html.patch
@@ -1,13 +1,14 @@
---- dist/index.html	2024-12-28 11:15:49.721827442 +1100
-+++ patches/index.html	2024-12-28 11:19:34.400805692 +1100
-@@ -4,0 +5 @@
+--- dist/index.html
++++ patches/index.html
+@@ -4,0 +5,2 @@
 +    <meta name="description" content="Free dating online. Zero ads. Unlimited messages. Over 2000 match questions from anime to life goals. Fall in love and find a relationship at Duolicious." />
-@@ -6 +7 @@
++    <link rel="preconnect" href="https://web.duolicious.app" />
+@@ -6 +8 @@
 -    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 +    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, maximum-scale=1, user-scalable=no" />
-@@ -17,0 +19 @@
+@@ -17,0 +20 @@
 +        margin: 0;
-@@ -24,0 +27,18 @@
+@@ -24,0 +28,18 @@
 +      #splash-root {
 +        z-index: 9999;
 +        position: absolute;
@@ -26,7 +27,7 @@
 +      #splash-root.fade-out {
 +        opacity: 0; /* Start fading out */
 +      }
-@@ -34,0 +55,123 @@
+@@ -34,0 +56,123 @@
 +    <div id="splash-root">
 +      <svg id="mySvg" width="96" height="96" viewBox="0 0 4.2333331 4.2333332">
 +        <g id="myGroup"></g>

--- a/frontend/public/assets/session-bridge.html
+++ b/frontend/public/assets/session-bridge.html
@@ -8,24 +8,23 @@
 <body>
   <script>
     // Loaded in a hidden iframe by the app on duolicious.app (see
-    // frontend/api/session-bridge.tsx) to carry the signed-in session over
-    // from this origin's localStorage, which the apex origin can't read
-    // itself. The fixed targetOrigin means the message is only ever
+    // frontend/api/session-bridge.tsx) to carry the signed-in session --
+    // and the rest of the app's stored state -- over from this origin's
+    // localStorage, which the apex origin can't read itself. The receiver
+    // filters the keys; sending everything means this page needs no
+    // maintained key list. The fixed targetOrigin means the message is only ever
     // delivered to a duolicious.app parent, no matter who embeds this page;
     // the deploy pipeline additionally restricts framing to that origin via
     // a Content-Security-Policy header (see frontend-publish.yml).
-    var sessionToken = null;
-    var personUuid = null;
+    var storage = {};
     try {
-      sessionToken = localStorage.getItem('session_token');
-      personUuid = localStorage.getItem('person_uuid');
+      for (var i = 0; i < localStorage.length; i++) {
+        var key = localStorage.key(i);
+        storage[key] = localStorage.getItem(key);
+      }
     } catch (e) {}
     parent.postMessage(
-      {
-        type: 'session-bridge',
-        sessionToken: sessionToken,
-        personUuid: personUuid,
-      },
+      { type: 'session-bridge', storage: storage },
       'https://duolicious.app'
     );
   </script>

--- a/frontend/public/assets/session-bridge.html
+++ b/frontend/public/assets/session-bridge.html
@@ -8,7 +8,7 @@
 <body>
   <script>
     // Loaded in a hidden iframe by the app on duolicious.app (see
-    // frontend/api/session-bridge.tsx) to carry the signed-in session --
+    // frontend/kv-storage/session-bridge.tsx) to carry the signed-in session --
     // and the rest of the app's stored state -- over from this origin's
     // localStorage, which the apex origin can't read itself. The receiver
     // filters the keys; sending everything means this page needs no

--- a/frontend/public/assets/session-bridge.html
+++ b/frontend/public/assets/session-bridge.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="robots" content="noindex">
+  <title>Duolicious session bridge</title>
+</head>
+<body>
+  <script>
+    // Loaded in a hidden iframe by the app on duolicious.app (see
+    // frontend/api/session-bridge.tsx) to carry the signed-in session over
+    // from this origin's localStorage, which the apex origin can't read
+    // itself. The fixed targetOrigin means the message is only ever
+    // delivered to a duolicious.app parent, no matter who embeds this page;
+    // the deploy pipeline additionally restricts framing to that origin via
+    // a Content-Security-Policy header (see frontend-publish.yml).
+    var sessionToken = null;
+    var personUuid = null;
+    try {
+      sessionToken = localStorage.getItem('session_token');
+      personUuid = localStorage.getItem('person_uuid');
+    } catch (e) {}
+    parent.postMessage(
+      {
+        type: 'session-bridge',
+        sessionToken: sessionToken,
+        personUuid: personUuid,
+      },
+      'https://duolicious.app'
+    );
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Users who signed in on web.duolicious.app arrive at duolicious.app logged out, because sessions live in origin-scoped localStorage. This carries their session over.

## How it works

- On startup, when the app is running on `duolicious.app` **and** has no local session, it mounts a hidden iframe of `https://web.duolicious.app/assets/session-bridge` — a self-contained, sub-kilobyte static page whose only content is an inline script that posts the old origin's entire localStorage to the parent — the typed receiver adopts only keys in kv-storage's allowlist (session, drafts, theme, inbox preferences, seen-hints, last path), so the static page needs no maintained key list. This works despite third-party storage partitioning because the two domains are the same *site* (registrable domain `duolicious.app`), which is the partitioning boundary.
- The handed-over token is treated as untrusted: it flows through the ordinary `/check-session-token` validation, so a stale or bogus token just lands on the welcome screen. Signing out invalidates the token server-side, so the bridge can't resurrect a deliberately ended session.
- A definitive answer (including "no session there") is recorded in kv-storage, so each browser pays the bridge's latency at most once. Timeouts (capped at 2s) aren't recorded and retry on the next load. A `preconnect` hint in the exported `index.html` warms the cross-host connection while the JS bundle is still downloading.
- Native apps, web.duolicious.app itself, and visitors who already have a session never run any of this code path.

## Security

- The bridge page's `postMessage` uses a fixed `targetOrigin` of `https://duolicious.app`, so the credentials can't be delivered to any other embedder, no matter who frames the page.
- The publish workflow's `_headers` detaches `X-Frame-Options` for the one bridge path and sets `Content-Security-Policy: frame-ancestors https://duolicious.app`; every other URL keeps `X-Frame-Options: DENY`, so the app itself remains unframeable.
- The apex side validates `event.origin`, `event.source`, and the message shape before accepting anything.

## Why `/assets/session-bridge`

A multi-segment path can never collide with a profile slug, and `assets` is already in the backend's `RESERVED_SLUGS` — so no new slug reservations or backend deploy are needed. (A top-level `session-bridge.html` wouldn't have been safe: Cloudflare Pages' pretty-URL behavior also serves it at extension-less `/session-bridge`, which is a mintable slug.)

## Verification

- `tsc --noEmit`, `eslint`, and the startup jest suite pass; the regenerated `patches/index.html.patch` applies cleanly to a pristine `expo export`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
