### PR TITLE
Point user-facing web.duolicious.app links at duolicious.app

### DIFF
--- a/.github/workflows/frontend-publish.yml
+++ b/.github/workflows/frontend-publish.yml
@@ -78,7 +78,6 @@ jobs:
           DUO_IMAGES_URL: https://user-images.duolicious.app
           DUO_AUDIO_URL: https://user-audio.duolicious.app
           DUO_STATUS_URL: https://status.duolicious.app
-          DUO_WEB_BASE_URL: https://web.duolicious.app
           DUO_GOOGLE_WEB_CLIENT_ID: 443037492722-11ai555h9htk0h5jb7dt2er5rdbpfvp1.apps.googleusercontent.com
           DUO_APPLE_WEB_CLIENT_ID: app.duolicious.web
           DUO_APPLE_REDIRECT_URI: https://api.duolicious.app/auth/apple/callback

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The world's most popular open-source dating app.</p>
 </p>
 
 <p align="center">
-<a href="https://web.duolicious.app/"><img src="https://img.shields.io/badge/web-web.duolicious.app-7700ff" alt="Duolicious on the web"/></a>
+<a href="https://duolicious.app/"><img src="https://img.shields.io/badge/web-duolicious.app-7700ff" alt="Duolicious on the web"/></a>
 <a href="https://play.google.com/store/apps/details?id=app.duolicious"><img src="https://img.shields.io/badge/Google%20Play-app.duolicious-7700ff?logo=googleplay&logoColor=white" alt="Duolicious on Google Play"/></a>
 <a href="https://apps.apple.com/us/app/duolicious-dating-app/id6499066647"><img src="https://img.shields.io/badge/App%20Store-Duolicious-7700ff?logo=appstore&logoColor=white" alt="Duolicious on the App Store"/></a>
 <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-7700ff" alt="AGPL-3.0 licensed"/></a>
@@ -19,7 +19,7 @@ There's no swiping; people connect by starting a conversation. The client and th
 servers behind it both live in this repo under the AGPL-3.0, so you're welcome to
 read how it works, run your own copy, or send a patch.
 
-Try it now in your browser at **[web.duolicious.app](https://web.duolicious.app/)**,
+Try it now in your browser at **[duolicious.app](https://duolicious.app/)**,
 or grab it on
 **[Google Play](https://play.google.com/store/apps/details?id=app.duolicious)**
 and the

--- a/frontend/components/navigation/faq.tsx
+++ b/frontend/components/navigation/faq.tsx
@@ -363,9 +363,8 @@ const FAQ_ITEMS: FaqItem[] = [
     question: 'What platforms is Duolicious available on?',
     Answer: () => <>
       <Paragraph>
-        Duolicious is available via our {}
-        <Link href="https://duolicious.app/">web app</Link>
-        . You can also download the app on {}
+        Duolicious is available via our web app, which you’re using right
+        now. You can also download the app on {}
         <Link href="https://play.google.com/store/apps/details?id=app.duolicious">
           Google Play
         </Link>

--- a/frontend/components/navigation/faq.tsx
+++ b/frontend/components/navigation/faq.tsx
@@ -364,7 +364,7 @@ const FAQ_ITEMS: FaqItem[] = [
     Answer: () => <>
       <Paragraph>
         Duolicious is available via our {}
-        <Link href="https://web.duolicious.app/">web app</Link>
+        <Link href="https://duolicious.app/">web app</Link>
         . You can also download the app on {}
         <Link href="https://play.google.com/store/apps/details?id=app.duolicious">
           Google Play

--- a/frontend/public/blog/psychoanalysing-chatgpt-using-statistics-to-make-a-decent-dating-app/index.html
+++ b/frontend/public/blog/psychoanalysing-chatgpt-using-statistics-to-make-a-decent-dating-app/index.html
@@ -182,7 +182,7 @@
       </p>
 
       <p>
-        How good? <a href="https://web.duolicious.app">Try the Duolicious app</a> to see
+        How good? <a href="https://duolicious.app">Try the Duolicious app</a> to see
         for yourself!
       </p>
 


### PR DESCRIPTION
The apex domain serves the app now, so the user-facing links follow:

- The psychoanalysing-ChatGPT blog article's "Try the Duolicious app" link now points at `https://duolicious.app/`. The FAQ's "web app" link is unlinked entirely: the FAQ only renders inside the web navigator, so the reader was always already on the page it pointed to.
- `DUO_WEB_BASE_URL` is removed from the publish workflow — nothing has ever consumed it.

Deliberately unchanged, because they must keep pointing at web.duolicious.app:

- the session bridge's `BRIDGE_ORIGIN` (it exists to read that origin's localStorage),
- the `preconnect` hint (it warms the bridge's connection),
- the Apple `web` redirect target in docker-compose (it's the return address for sign-ins started on that origin),
- the copied static pages' Sign Up buttons, which are already relative (`/`) and so follow whichever domain serves them.

## Deep links

Nothing in this repo: `get.duolicious.app` links open the native app directly when it's installed, and the no-app browser fallback lives in the [duolicious-deep-links](https://github.com/duolicious/duolicious-deep-links) repo — companion PR there flips its redirect to duolicious.app. The `duolicious.gg` share links 301 to `web.duolicious.app/<path>` via what looks like a Cloudflare redirect rule (it's in no repo), so that's a dashboard change. Both fallbacks keep working unchanged in the meantime since web.duolicious.app still serves the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
