### PR TITLE
Add the touch-grass hook to the FAQ panel

### DIFF
--- a/frontend/components/navigation/faq.tsx
+++ b/frontend/components/navigation/faq.tsx
@@ -439,6 +439,32 @@ const FaqDetails = ({ question, Answer, isFirst }: FaqItem & {
   );
 };
 
+const SectionHeading = ({ children, isFirst }: {
+  children: React.ReactNode
+  isFirst?: boolean
+}) => {
+  const { appTheme } = useAppTheme();
+
+  return (
+    <h2
+      style={{
+        margin: 0,
+        color: appTheme.secondaryColor,
+        fontFamily: 'MontserratBlack',
+        fontWeight: 'normal',
+        fontSize: 18,
+        padding: '14px 16px',
+        borderBottom: `1px solid ${appTheme.interactiveBorderColor}`,
+        borderTop: isFirst ?
+          undefined :
+          `1px solid ${appTheme.interactiveBorderColor}`,
+      }}
+    >
+      {children}
+    </h2>
+  );
+};
+
 const Faq = () => {
   const { appTheme } = useAppTheme();
 
@@ -452,24 +478,27 @@ const Faq = () => {
         ...appTheme.card,
       }}
     >
-      <h2
-        style={{
-          margin: 0,
-          color: appTheme.secondaryColor,
-          fontFamily: 'MontserratBlack',
-          fontWeight: 'normal',
-          fontSize: 18,
-          padding: '14px 16px',
-          borderBottom: `1px solid ${appTheme.interactiveBorderColor}`,
-        }}
-      >
-        Frequently Asked Questions
-      </h2>
+      <ScrollView>
+        <SectionHeading isFirst={true}>Touch grass? No.</SectionHeading>
 
-      <ScrollView contentContainerStyle={{ paddingHorizontal: 16 }}>
-        {FAQ_ITEMS.map((faqItem, i) =>
-          <FaqDetails key={faqItem.question} {...faqItem} isFirst={i === 0}/>
-        )}
+        <div style={{ padding: '14px 16px' }}>
+          <Paragraph>
+            <Bold>Touch hearts.</Bold> Match with femcels, femboys, NEETs,
+            gymcels, /lit/ pseudointellectuals, and that one person who’s also
+            weirdly into trains. 100% free messaging and matching because
+            monetizing loneliness is cringe and we’re broke too. Your body
+            pillow had a good run. Now it’s time to romance someone who says
+            “based” back.
+          </Paragraph>
+        </div>
+
+        <SectionHeading>Frequently Asked Questions</SectionHeading>
+
+        <div style={{ paddingLeft: 16, paddingRight: 16 }}>
+          {FAQ_ITEMS.map((faqItem, i) =>
+            <FaqDetails key={faqItem.question} {...faqItem} isFirst={i === 0}/>
+          )}
+        </div>
       </ScrollView>
     </View>
   );

--- a/frontend/components/navigation/faq.tsx
+++ b/frontend/components/navigation/faq.tsx
@@ -453,11 +453,7 @@ const SectionHeading = ({ children, isFirst }: {
         fontFamily: 'MontserratBlack',
         fontWeight: 'normal',
         fontSize: 18,
-        padding: '14px 16px',
-        borderBottom: `1px solid ${appTheme.interactiveBorderColor}`,
-        borderTop: isFirst ?
-          undefined :
-          `1px solid ${appTheme.interactiveBorderColor}`,
+        padding: `${isFirst ? 14 : 32}px 16px 6px`,
       }}
     >
       {children}
@@ -481,7 +477,7 @@ const Faq = () => {
       <ScrollView>
         <SectionHeading isFirst={true}>Touch grass? No.</SectionHeading>
 
-        <div style={{ padding: '14px 16px' }}>
+        <div style={{ padding: '0 16px 14px' }}>
           <Paragraph>
             <Bold>Touch hearts.</Bold> Match with femcels, femboys, NEETs,
             gymcels, /lit/ pseudointellectuals, and that one person who’s also
@@ -492,7 +488,7 @@ const Faq = () => {
           </Paragraph>
         </div>
 
-        <SectionHeading>Frequently Asked Questions</SectionHeading>
+        <SectionHeading>Frequently asked questions</SectionHeading>
 
         <div style={{ paddingLeft: 16, paddingRight: 16 }}>
           {FAQ_ITEMS.map((faqItem, i) =>

--- a/frontend/components/navigation/faq.tsx
+++ b/frontend/components/navigation/faq.tsx
@@ -170,12 +170,13 @@ const FAQ_ITEMS: FaqItem[] = [
     Answer: () => <>
       <Paragraph>
         No, though the other information on your profile (e.g. age, gender)
-        must still be accurate.
+        must still be accurate. Avatars are fine, but pics of another person
+        that could be mistaken for you aren’t.
       </Paragraph>
       <Paragraph>
         In locations where age verification is a legal requirement, you’ll
-        need to upload a selfie to verify your age. Your selfie won’t be shown
-        on your profile and verification is free.
+        need to upload a selfie to verify your age. Verification is free and
+        your selfie stays private – it never goes on your profile.
       </Paragraph>
     </>,
   },

--- a/frontend/patches/index.html
+++ b/frontend/patches/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="description" content="Free dating online. Zero ads. Unlimited messages. Over 2000 match questions from anime to life goals. Fall in love and find a relationship at Duolicious." />
+    <meta name="description" content="Free dating online. Zero ads. Free matching. Free messaging. Over 2000 match questions from anime to life goals. Fall in love and find a relationship at Duolicious." />
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, maximum-scale=1, user-scalable=no" />
     <title>Duolicious</title>

--- a/frontend/patches/index.html.patch
+++ b/frontend/patches/index.html.patch
@@ -1,7 +1,7 @@
 --- dist/index.html
 +++ patches/index.html
 @@ -4,0 +5,2 @@
-+    <meta name="description" content="Free dating online. Zero ads. Unlimited messages. Over 2000 match questions from anime to life goals. Fall in love and find a relationship at Duolicious." />
++    <meta name="description" content="Free dating online. Zero ads. Free matching. Free messaging. Over 2000 match questions from anime to life goals. Fall in love and find a relationship at Duolicious." />
 +    <link rel="preconnect" href="https://web.duolicious.app" />
 @@ -6 +8 @@
 -    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />


### PR DESCRIPTION
Adds the "Touch grass? No." copy to the desktop web right panel as a standalone heading with always-visible text — not an expandable FAQ entry — followed by the "Frequently Asked Questions" heading and the existing expandable list. Both headings share one style (`SectionHeading`) and now scroll with the panel's content instead of the FAQ title being pinned.

Also includes a meta-description tweak to the exported index.html (via `frontend/patches/`): "Unlimited messages" becomes "Free matching. Free messaging."

Worth a visual once-over in the browser before merging — the restructure moves the panel heading into the scroll flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)