### PR TITLE
Use logging instead of print statements

### DIFF
--- a/backend/answerspush/__init__.py
+++ b/backend/answerspush/__init__.py
@@ -5,9 +5,11 @@ must only publish publicly visible state (see `AnswerWriteResult` in `qanda`);
 nothing on this channel is access-controlled beyond the subscription checks in
 `service.api.chat.online`.
 """
-import traceback
+import logging
 from chatprotocol.outbound import AnswerUpdate, answer_to_wire, to_bus
 from redisclient import make_redis_client
+
+logger = logging.getLogger(__name__)
 
 _redis = make_redis_client()
 
@@ -31,4 +33,4 @@ async def publish_answer_update(
             )),
         )
     except Exception:
-        print(traceback.format_exc())
+        logger.exception('Publishing answer update failed')

--- a/backend/antiabuse/lodgereport/__init__.py
+++ b/backend/antiabuse/lodgereport/__init__.py
@@ -22,7 +22,7 @@ from antiabuse.lodgereport.constants import (
     TRUSTWORTHY_MIN_QUESTIONS_ANSWERED,
 )
 from smtp import aws_smtp
-import traceback
+import logging
 import threading
 import html
 import yaml
@@ -31,6 +31,8 @@ import re
 import random
 from collections.abc import Mapping, Sequence
 from antiabuse.lodgereport.constants import EmailEntry
+
+logger = logging.getLogger(__name__)
 
 
 def _repack_last_messages_in_place(
@@ -191,7 +193,7 @@ def _send_report_email(
             from_addr=PRIMARY_REPORT_EMAIL,
         )
     except:
-        print(traceback.format_exc())
+        logger.exception('Sending report email failed')
 
 
 async def lodge_report(

--- a/backend/antiabuse/lodgereport/constants.py
+++ b/backend/antiabuse/lodgereport/constants.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
+import logging
 import re
 
 from duoenv.shared import REPORT_EMAIL
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -29,7 +32,7 @@ def parse_email_string(email_string: str) -> list[EmailEntry]:
 
 REPORT_EMAILS = parse_email_string(REPORT_EMAIL)
 PRIMARY_REPORT_EMAIL = REPORT_EMAILS[0].email
-print(REPORT_EMAILS)
+logger.info(f'Report emails: {REPORT_EMAILS}')
 
 
 SHADOW_BAN_REPORT_THRESHOLD = 2

--- a/backend/batcher/__init__.py
+++ b/backend/batcher/__init__.py
@@ -2,8 +2,10 @@ from dataclasses import dataclass
 from typing import Awaitable, Callable, Generic, TypeVar
 import asyncio
 import inspect
+import logging
 import time
-import traceback
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar('T')
 
@@ -99,7 +101,7 @@ class Batcher(Generic[T]):
             if inspect.isawaitable(result):
                 await result
         except Exception:
-            print(traceback.format_exc())
+            logger.exception('Batcher callback failed')
 
     async def _process_batch(self, batch: list[BatchItem[T]]) -> None:
         try:
@@ -108,7 +110,7 @@ class Batcher(Generic[T]):
             if inspect.isawaitable(result):
                 await result
         except Exception:
-            print(traceback.format_exc())
+            logger.exception('Processing batch failed')
             if self._retry:
                 for bi in batch:
                     self._queue.put_nowait(bi)

--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -1,8 +1,8 @@
 import asyncio
+import logging
 import psycopg
 from psycopg_pool import AsyncConnectionPool
 import random
-import traceback
 from contextlib import asynccontextmanager, suppress
 from typing import Protocol
 from collections.abc import AsyncIterator, Iterable
@@ -27,6 +27,8 @@ from duoenv.shared import (
     DB_PORT,
     DB_USER,
 )
+
+logger = logging.getLogger(__name__)
 
 _valid_isolation_levels = [
     'SERIALIZABLE',
@@ -214,7 +216,7 @@ async def check_connections_forever() -> None:
         try:
             await _pool().check()
         except Exception:
-            print(traceback.format_exc())
+            logger.exception('Pool check failed')
         await asyncio.sleep(random.randint(30, 90))
 
 

--- a/backend/database/initapi.py
+++ b/backend/database/initapi.py
@@ -1,3 +1,15 @@
+import logging
+
+# This module doubles as the deploy-time entrypoint (see the bottom of the
+# file), so it configures logging the same way the services do.
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s:     %(asctime)s %(name)s: %(message)s',
+)
+
+logger = logging.getLogger(__name__)
+
+
 def create_dbs() -> None:
     # All this stuff just to run `CREATE DATABASE IF NOT EXISTS DB_NAME`
     import psycopg
@@ -18,18 +30,17 @@ def create_dbs() -> None:
                 with psycopg.connect(_conninfo, autocommit=True) as conn:
                     with conn.cursor() as cur:
                         cur.execute(f"CREATE DATABASE {name}")
-                print(f'Created database: {name}')
+                logger.info(f'Created database: {name}')
                 break
             except (
                 psycopg.errors.DuplicateDatabase,
                 psycopg.errors.UniqueViolation,
             ):
-                print(f'Database already exists: {name}')
+                logger.info(f'Database already exists: {name}')
                 break
             except psycopg.errors.OperationalError as e:
-                print(
-                    'Creating database(s) failed; waiting and trying again:',
-                    e
+                logger.warning(
+                    f'Creating database(s) failed; waiting and trying again: {e}'
                 )
                 time.sleep(1)
 
@@ -50,11 +61,11 @@ async def init_db() -> None:
 
     await open_db_pool()
 
-    print('Initializing api DB...')
+    logger.info('Initializing api DB...')
     for i, init_func in enumerate(init_funcs, start=1):
-        print(f'  * {i} of {len(init_funcs)}')
+        logger.info(f'  * {i} of {len(init_funcs)}')
         await init_func()
-    print('Finished initializing api DB')
+    logger.info('Finished initializing api DB')
 
 create_dbs()
 import asyncio

--- a/backend/duoaudio/__init__.py
+++ b/backend/duoaudio/__init__.py
@@ -6,7 +6,7 @@ import base64
 import binascii
 import constants
 from util import human_readable_size_metric
-import traceback
+import logging
 import asyncboto
 import boto3
 
@@ -17,6 +17,8 @@ from duoenv.shared import (
     R2_ACCT_ID,
     R2_AUDIO_BUCKET_NAME,
 )
+
+logger = logging.getLogger(__name__)
 
 s3 = boto3.resource(
     's3',
@@ -132,8 +134,7 @@ def transcode_and_trim_audio_from_base64(
             max_duration,
         ).getvalue()
     except:
-        print(traceback.format_exc())
-        print('base64 input was: ' + audio_base64)
+        logger.exception(f'Processing audio failed; base64 input was: {audio_base64}')
         return ValueError('Error while processing audio')
 
     return decoded_bytes, transcoded

--- a/backend/person/__init__.py
+++ b/backend/person/__init__.py
@@ -28,7 +28,7 @@ from service.api.chat.online import redis_publish_online
 from visitornotification import notify_of_visit
 from visitorspush import publish_visit
 from person.template import otp_template
-import traceback
+import logging
 import re
 from smtp import aws_smtp
 from starlette.responses import Response
@@ -78,6 +78,8 @@ from duoenv.shared import (
     R2_ACCT_ID,
     R2_BUCKET_NAME,
 )
+
+logger = logging.getLogger(__name__)
 
 s3 = boto3.resource(
     's3',
@@ -1617,7 +1619,7 @@ async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> objec
         try:
             await put_image_in_object_store(uuid, base64_file, crop_size)
         except:
-            print(traceback.format_exc())
+            logger.exception('Storing image failed')
             return '', 500
 
     if uuid and base64_audio_file:
@@ -1627,7 +1629,7 @@ async def patch_profile_info(req: t.PatchProfileInfo, s: t.SessionInfo) -> objec
                 audio_file_bytes=base64_audio_file.transcoded,
             )
         except:
-            print(traceback.format_exc())
+            logger.exception('Storing audio failed')
             return '', 500
 
     return None
@@ -2000,8 +2002,8 @@ async def post_verification_selfie(
     try:
         await put_image_in_object_store(
             photo_uuid, req.base64_file, crop_size, sizes=[450])
-    except Exception as e:
-        print('Upload failed with exception:', e)
+    except Exception:
+        logger.exception('Upload failed')
         return '', 500
 
     return None

--- a/backend/service/api/bootstrap.py
+++ b/backend/service/api/bootstrap.py
@@ -5,6 +5,7 @@ create the schema on a fresh database, apply migrations, load the domain and
 club seed data, and backfill normalized emails.
 """
 
+import logging
 import re
 from pathlib import Path
 
@@ -15,6 +16,8 @@ from constants import (
     LAST_ONLINE_NOW_SECONDS,
 )
 from database import api_tx
+
+logger = logging.getLogger(__name__)
 
 _init_sql_file = (
     Path(__file__).parent.parent.parent / 'init-api.sql')
@@ -61,25 +64,25 @@ async def migrate_unnormalized_emails() -> None:
         q = "SELECT 1 FROM person WHERE normalized_email ILIKE '%@googlemail.com' LIMIT 1"
         await tx.execute(q)
         if await tx.fetchone():
-            print('Unnormalized emails found. Normalizing...')
+            logger.info('Unnormalized emails found. Normalizing...')
         else:
-            print('Emails already normalized. Not performing normalization.')
+            logger.info('Emails already normalized. Not performing normalization.')
             return
 
     async with api_tx() as tx:
-        print('Selecting emails')
+        logger.info('Selecting emails')
         q = "SELECT email FROM person"
         await tx.execute('SET LOCAL statement_timeout = 300000') # 5 minutes
         await tx.execute(q)
         rows = await tx.fetchall()
-        print('Done selecting emails')
+        logger.info('Done selecting emails')
 
-    print('Computing normalized emails')
+    logger.info('Computing normalized emails')
     params_seq = [
         row | dict(normalized_email=normalize_email(row['email']))
         for row in rows
     ]
-    print('Done computing normalized emails')
+    logger.info('Done computing normalized emails')
 
     async with api_tx('read committed') as tx:
         q = """
@@ -87,10 +90,10 @@ async def migrate_unnormalized_emails() -> None:
         normalized_email = %(normalized_email)s
         WHERE email = %(email)s
         """
-        print('Updating normalized emails in `person` table')
+        logger.info('Updating normalized emails in `person` table')
         await tx.execute('SET LOCAL statement_timeout = 300000') # 5 minutes
         await tx.executemany(q, params_seq)
-        print('Done updating normalized emails in `person` table')
+        logger.info('Done updating normalized emails in `person` table')
 
         q = """
         UPDATE banned_person bp
@@ -109,16 +112,16 @@ async def migrate_unnormalized_emails() -> None:
                 ip_address = bp.ip_address
         )
         """
-        print('Updating normalized emails in `banned_person` table')
+        logger.info('Updating normalized emails in `banned_person` table')
         await tx.executemany(q, params_seq)
-        print('Done updating normalized emails in `banned_person` table')
+        logger.info('Done updating normalized emails in `banned_person` table')
 
 async def maybe_run_init() -> None:
     async with api_tx() as tx:
         row = await tx.require_one("SELECT to_regclass('person')")
 
     if row ['to_regclass'] is not None:
-        print('Database already initialized')
+        logger.info('Database already initialized')
         return
 
     init_sql_file = _read_sql(_init_sql_file)

--- a/backend/service/api/chat/audiomessage/__init__.py
+++ b/backend/service/api/chat/audiomessage/__init__.py
@@ -4,8 +4,10 @@ from duoaudio import (
 )
 from chatprotocol.message import AudioMessage
 import asyncio
+import logging
 import secrets
-import traceback
+
+logger = logging.getLogger(__name__)
 
 async def transcode_and_put(
     uuid: str,
@@ -24,7 +26,7 @@ async def transcode_and_put(
     try:
         await put_audio_in_object_store(uuid=uuid, audio_file_bytes=transcoded)
     except:
-        print(traceback.format_exc())
+        logger.exception('Storing audio message failed')
         return False
 
     return True

--- a/backend/service/api/chat/messagestorage/inbox/__init__.py
+++ b/backend/service/api/chat/messagestorage/inbox/__init__.py
@@ -1,4 +1,4 @@
-import traceback
+import logging
 
 from batcher import Batcher
 from constants import LAST_ONLINE_DEFAULT_SECONDS
@@ -30,6 +30,8 @@ from chatprotocol.outbound import (
     Outbound,
     ReadReceipt,
 )
+
+logger = logging.getLogger(__name__)
 
 Q_GET_INBOX = f"""
 SELECT
@@ -510,7 +512,7 @@ async def get_inbox(query_id: str, username: str) -> list[Outbound]:
             ))
 
         except Exception as e:
-            print(f"Error processing row: {e}")
+            logger.error(f'Error processing row: {e}')
             continue
 
     messages.append(InboxFin(query_id=query_id))
@@ -612,7 +614,7 @@ async def get_inbox_snapshot(username: str) -> list[Outbound]:
 
         return [InboxSnapshot(payload={'conversations': conversations})]
     except Exception:
-        print(traceback.format_exc())
+        logger.exception('Fetching inbox snapshot failed')
         return []
 
 
@@ -637,7 +639,7 @@ async def get_inbox_entry(
 
         return [InboxEntry(payload=conversations[0])]
     except Exception:
-        print(traceback.format_exc())
+        logger.exception('Fetching inbox entry failed')
         return []
 
 
@@ -761,7 +763,7 @@ async def _write_mark_displayed(
             ))
             rows = await tx.fetchall()
     except Exception:
-        print(traceback.format_exc())
+        logger.exception('Fetching displayed-at rows failed')
         return {}
 
     return {

--- a/backend/service/api/chat/online/__init__.py
+++ b/backend/service/api/chat/online/__init__.py
@@ -1,5 +1,5 @@
+import logging
 import redis.asyncio as redis
-import traceback
 from answerspush import answers_channel
 from service.api.chat.chatutil import (
     fetch_hides_online_status,
@@ -32,6 +32,8 @@ from constants import (
     MAX_ONLINE_SUBSCRIPTIONS,
     ONLINE_PRESENCE_TTL_SECONDS,
 )
+
+logger = logging.getLogger(__name__)
 
 _TEST_INPUT_DIR = Path(__file__).parents[4] / 'test' / 'input'
 
@@ -260,7 +262,7 @@ async def maybe_redis_subscribe_online(
                     username=to_username),
         ]
     except:
-        print(traceback.format_exc())
+        logger.exception('Subscribing failed')
         return [SubscribeBad(username=to_username)]
 
 
@@ -278,7 +280,7 @@ async def maybe_redis_unsubscribe_online(
 
         return [UnsubscribeOk(username=username)]
     except:
-        print(traceback.format_exc())
+        logger.exception('Unsubscribing failed')
         return [UnsubscribeBad(username=username)]
 
 
@@ -389,7 +391,7 @@ async def update_online_forever(
     except asyncio.exceptions.CancelledError:
         pass
     except:
-        print(traceback.format_exc())
+        logger.exception('Online-status loop failed')
         raise
 
 

--- a/backend/service/api/chat/visitors/__init__.py
+++ b/backend/service/api/chat/visitors/__init__.py
@@ -1,10 +1,12 @@
 import json
-import traceback
+import logging
 
 from database import api_tx
 from service.api.chat.chatutil import fetch_id_from_username
 from chatprotocol.outbound import Outbound, VisitorsSnapshot
 from visitorsql import Q_VISITORS, Q_MARK_VISITORS_CHECKED
+
+logger = logging.getLogger(__name__)
 
 
 async def get_visitors_snapshot(username: str) -> list[Outbound]:
@@ -18,7 +20,7 @@ async def get_visitors_snapshot(username: str) -> list[Outbound]:
 
         return [VisitorsSnapshot(payload_json=json.dumps(row['j']))]
     except Exception:
-        print(traceback.format_exc())
+        logger.exception('Fetching visitors snapshot failed')
         return []
 
 
@@ -34,4 +36,4 @@ async def mark_visitors_checked(username: str, when: str | None) -> None:
                 dict(person_id=person_id, when=when),
             )
     except Exception:
-        print(traceback.format_exc())
+        logger.exception('Marking visitors checked failed')

--- a/backend/service/cron/__init__.py
+++ b/backend/service/cron/__init__.py
@@ -1,3 +1,13 @@
+import logging
+
+# Nothing else configures logging in this process; give the app's loggers a
+# root handler in the same level-prefixed style as the api service. This runs
+# before the cron-module imports so their import-time logging isn't dropped.
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s:     %(asctime)s %(name)s: %(message)s',
+)
+
 from service.cron.checkphotos import check_photos_forever
 from service.cron.clubseo import (
     refresh_club_seo_forever,
@@ -21,6 +31,8 @@ from socketserver import TCPServer
 from database import db_pool_lifespan
 from batcher import start_all
 
+logger = logging.getLogger(__name__)
+
 class HealthCheckHandler(SimpleHTTPRequestHandler):
     def do_GET(self) -> None:
         if self.path == '/health':
@@ -33,7 +45,7 @@ class HealthCheckHandler(SimpleHTTPRequestHandler):
 
 async def http_server() -> None:
     with TCPServer(('0.0.0.0', 8080), HealthCheckHandler) as httpd:
-        print("Serving health check on port 8080...", flush=True)
+        logger.info('Serving health check on port 8080...')
         await asyncio.to_thread(httpd.serve_forever)
 
 async def main() -> None:

--- a/backend/service/cron/audiocleaner/__init__.py
+++ b/backend/service/cron/audiocleaner/__init__.py
@@ -3,17 +3,20 @@ from service.cron.audiocleaner.sql import *
 from service.cron.cronutil import (
     MAX_RANDOM_START_DELAY,
     delete_audio_from_object_store,
-    print_stacktrace,
+    log_stacktrace,
 )
 import asyncio
 import random
+import logging
 
 from duoenv.cron import (
     AUDIO_CLEANER_DRY_RUN as DRY_RUN,
     AUDIO_CLEANER_POLL_SECONDS,
 )
 
-print(f'Hello from cron module: {__name__}')
+logger = logging.getLogger(__name__)
+
+logger.info('Hello from cron module')
 
 async def clean_audio_once() -> None:
     params = dict(polling_interval_seconds=AUDIO_CLEANER_POLL_SECONDS)
@@ -32,5 +35,5 @@ async def clean_audio_once() -> None:
 async def clean_audio_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(clean_audio_once)
+        await log_stacktrace(clean_audio_once)
         await asyncio.sleep(AUDIO_CLEANER_POLL_SECONDS)

--- a/backend/service/cron/checkphotos/__init__.py
+++ b/backend/service/cron/checkphotos/__init__.py
@@ -4,7 +4,7 @@ from service.cron.cronutil import (
     MAX_RANDOM_START_DELAY,
     delete_images_from_object_store,
     download_450_images,
-    print_stacktrace,
+    log_stacktrace,
 )
 import asyncio
 import boto3
@@ -14,6 +14,7 @@ import blurhash
 import numpy
 from PIL import Image
 from collections.abc import Iterator
+import logging
 
 from duoenv.cron import (
     CHECK_PHOTOS_DRY_RUN as DRY_RUN,
@@ -27,7 +28,9 @@ from duoenv.shared import (
     R2_BUCKET_NAME,
 )
 
-print(f'Hello from cron module: {__name__}')
+logger = logging.getLogger(__name__)
+
+logger.info('Hello from cron module')
 
 s3_client = boto3.client(
     's3',
@@ -48,19 +51,19 @@ async def update_blurhashes(uuids: list[str]) -> None:
     q = "update photo set blurhash = %(blurhash)s where uuid = %(uuid)s"
 
     if DRY_RUN:
-        print(
-            'DUO_CHECK_PHOTOS_DRY_RUN env var prevented blurhash update:',
-            params_seq
+        logger.info(
+            'DUO_CHECK_PHOTOS_DRY_RUN env var prevented blurhash update: '
+            f'{params_seq}'
         )
         return
 
     async with api_tx() as tx:
         await tx.executemany(q, params_seq)
 
-    print('checkphotos: updated blurhashes', params_seq)
+    logger.info(f'checkphotos: updated blurhashes {params_seq}')
 
 def list_images_in_object_store() -> Iterator[list[str]]:
-    print(f'checkphotos: listing images in object store')
+    logger.info('checkphotos: listing images in object store')
     paginator = s3_client.get_paginator('list_objects_v2')
 
     count = 0
@@ -74,11 +77,11 @@ def list_images_in_object_store() -> Iterator[list[str]]:
 
             count += len(keys)
 
-            print(f'checkphotos: fetched {count} keys')
+            logger.info(f'checkphotos: fetched {count} keys')
 
             yield keys
 
-    print(f'checkphotos: fetched {count} keys in total')
+    logger.info(f'checkphotos: fetched {count} keys in total')
 
 def list_uuids_in_object_store() -> Iterator[list[str]]:
     for chunk in list_images_in_object_store():
@@ -127,11 +130,11 @@ def compute_blurhash(image_bytes: io.BytesIO) -> str:
     return blurhash.encode(numpy.array(image.convert("RGB")))
 
 def compute_blurhashes(images: list[io.BytesIO]) -> list[str]:
-    print('checkphotos: computing blurhashes')
+    logger.info('checkphotos: computing blurhashes')
 
     blurhashes = [compute_blurhash(i) for i in images]
 
-    print('checkphotos: computing blurhashes complete')
+    logger.info('checkphotos: computing blurhashes complete')
 
     return blurhashes
 
@@ -153,5 +156,5 @@ async def check_photos_once() -> None:
 async def check_photos_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(check_photos_once)
+        await log_stacktrace(check_photos_once)
         await asyncio.sleep(CHECK_PHOTOS_POLL_SECONDS)

--- a/backend/service/cron/clubseo/__init__.py
+++ b/backend/service/cron/clubseo/__init__.py
@@ -3,7 +3,7 @@ from constants import (
     MIN_NOTABLE_TRAIT_SCORE,
 )
 from database import api_tx
-from service.cron.cronutil import print_stacktrace, MAX_RANDOM_START_DELAY
+from service.cron.cronutil import log_stacktrace, MAX_RANDOM_START_DELAY
 from util import is_offpeak
 from util.coerce import (
     mapping,
@@ -28,8 +28,8 @@ from openai import AsyncOpenAI
 import asyncio
 import hashlib
 import json
+import logging
 import random
-import traceback
 from collections.abc import Mapping, Sequence
 
 from duoenv.cron import (
@@ -48,6 +48,8 @@ from duoenv.cron import (
     CLUB_TOP_ANSWERS_POLL_SECONDS,
 )
 
+logger = logging.getLogger(__name__)
+
 _openai_client = AsyncOpenAI() if not CLUB_SEO_MOCK_DESCRIPTION else None
 
 
@@ -64,13 +66,13 @@ async def refresh_club_stats_once() -> None:
         row = await cur.fetchone()
 
     if row and row['upserted_count']:
-        print(f"club_stats: recomputed {row['upserted_count']} clubs")
+        logger.info(f"club_stats: recomputed {row['upserted_count']} clubs")
 
 
 async def refresh_club_stats_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(refresh_club_stats_once)
+        await log_stacktrace(refresh_club_stats_once)
         await asyncio.sleep(CLUB_STATS_POLL_SECONDS)
 
 
@@ -88,13 +90,13 @@ async def refresh_club_top_answers_once() -> None:
         row = await cur.fetchone()
 
     if row and row['upserted_count']:
-        print(f"club_top_answers: recomputed {row['upserted_count']} clubs")
+        logger.info(f"club_top_answers: recomputed {row['upserted_count']} clubs")
 
 
 async def refresh_club_top_answers_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(refresh_club_top_answers_once)
+        await log_stacktrace(refresh_club_top_answers_once)
         await asyncio.sleep(CLUB_TOP_ANSWERS_POLL_SECONDS)
 
 
@@ -111,13 +113,13 @@ async def refresh_club_overlap_once() -> None:
         await tx.execute("SET LOCAL work_mem = '256MB'")
         await tx.execute(Q_CLUB_OVERLAP_DELETE)
         await tx.execute(Q_CLUB_OVERLAP_REBUILD)
-    print('club_overlap: rebuilt')
+    logger.info('club_overlap: rebuilt')
 
 
 async def refresh_club_overlap_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(refresh_club_overlap_once)
+        await log_stacktrace(refresh_club_overlap_once)
         await asyncio.sleep(CLUB_OVERLAP_POLL_SECONDS)
 
 
@@ -246,7 +248,7 @@ async def generate_description(payload: Mapping[str, object]) -> str | None:
         text = resp.choices[0].message.content
         return text.strip() if text else None
     except Exception:
-        print(traceback.format_exc())
+        logger.exception('club_seo: description generation failed')
         return None
 
 
@@ -278,7 +280,7 @@ async def _process_club_seo_row(
     if is_fresh_enough(old_hash, new_hash, age_days):
         async with api_tx() as tx:
             await tx.execute(Q_CLUB_SEO_TOUCH, dict(club_name=club_name))
-        print(f'club_seo: touched {club_name!r} (hash match, {age_days:.1f}d old)')
+        logger.info(f'club_seo: touched {club_name!r} (hash match, {age_days:.1f}d old)')
         return
 
     # Only the OpenAI call is gated by the semaphore; the DB work either
@@ -291,7 +293,7 @@ async def _process_club_seo_row(
         # queue instead of being re-selected every tick and starving the rest.
         async with api_tx() as tx:
             await tx.execute(Q_CLUB_SEO_MARK_ATTEMPTED, dict(club_name=club_name))
-        print(f'club_seo: generation failed for {club_name!r}; deferring')
+        logger.warning(f'club_seo: generation failed for {club_name!r}; deferring')
         return
 
     async with api_tx() as tx:
@@ -300,7 +302,7 @@ async def _process_club_seo_row(
             description=description,
             stats_hash=new_hash,
         ))
-    print(f'club_seo: regenerated {club_name!r} ({len(description)} chars)')
+    logger.info(f'club_seo: regenerated {club_name!r} ({len(description)} chars)')
 
 
 async def refresh_club_seo_once() -> None:
@@ -327,11 +329,14 @@ async def refresh_club_seo_once() -> None:
     )
     for row, res in zip(rows, results):
         if isinstance(res, BaseException):
-            print(f"club_seo: unexpected error for {row['name']!r}: {res!r}")
+            logger.error(
+                f"club_seo: unexpected error for {row['name']!r}",
+                exc_info=res,
+            )
 
 
 async def refresh_club_seo_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(refresh_club_seo_once)
+        await log_stacktrace(refresh_club_seo_once)
         await asyncio.sleep(CLUB_SEO_POLL_SECONDS)

--- a/backend/service/cron/cronutil/__init__.py
+++ b/backend/service/cron/cronutil/__init__.py
@@ -8,7 +8,7 @@ import asyncboto
 import asyncio
 import boto3
 import io
-import traceback
+import logging
 import time
 
 from duoenv.cron import MAX_RANDOM_START_DELAY
@@ -20,6 +20,8 @@ from duoenv.shared import (
     R2_AUDIO_BUCKET_NAME,
     R2_BUCKET_NAME,
 )
+
+logger = logging.getLogger(__name__)
 
 DISABLE_MOBILE_NOTIFICATIONS_FILE = (
     Path(__file__).parent.parent.parent.parent /
@@ -34,11 +36,11 @@ def disable_mobile_notifications() -> bool:
                 return True
     return False
 
-async def print_stacktrace(fun: Callable[[], Awaitable[object]]) -> None:
+async def log_stacktrace(fun: Callable[[], Awaitable[object]]) -> None:
     try:
         await fun()
     except:
-        print(traceback.format_exc())
+        logger.exception(f'{fun.__qualname__} failed')
 
 async def delete_images_from_object_store(
     uuids: list[str],
@@ -70,9 +72,9 @@ async def delete_images_from_object_store(
         ]
 
         if dry_run:
-            print(
-                f'{dry_run_env_var_name} env var prevented photo deletion:',
-                keys_to_delete
+            logger.info(
+                f'{dry_run_env_var_name} env var prevented photo deletion: '
+                f'{keys_to_delete}'
             )
             continue
 
@@ -89,13 +91,13 @@ async def delete_images_from_object_store(
 
         if 'Errors' in response:
             for error in response['Errors']:
-                print(f"Error deleting {error['Key']}: {error['Message']}")
+                logger.error(f"Error deleting {error['Key']}: {error['Message']}")
         else:
             for key in keys_to_delete:
-                print('Deleted object', key)
+                logger.info(f'Deleted object {key}')
             async with api_tx() as tx:
                 await tx.execute(Q_MARK_PHOTO_DELETED, dict(uuids=chunk))
-            print('Objects have been marked as deleted')
+            logger.info('Objects have been marked as deleted')
 
 async def delete_audio_from_object_store(
     uuids: list[str],
@@ -121,9 +123,9 @@ async def delete_audio_from_object_store(
         ]
 
         if dry_run:
-            print(
-                f'{dry_run_env_var_name} env var prevented audio deletion:',
-                keys_to_delete
+            logger.info(
+                f'{dry_run_env_var_name} env var prevented audio deletion: '
+                f'{keys_to_delete}'
             )
             continue
 
@@ -140,13 +142,13 @@ async def delete_audio_from_object_store(
 
         if 'Errors' in response:
             for error in response['Errors']:
-                print(f"Error deleting {error['Key']}: {error['Message']}")
+                logger.error(f"Error deleting {error['Key']}: {error['Message']}")
         else:
             for key in keys_to_delete:
-                print('Deleted object', key)
+                logger.info(f'Deleted object {key}')
             async with api_tx() as tx:
                 await tx.execute(Q_MARK_AUDIO_DELETED, dict(uuids=chunk))
-            print('Objects have been marked as deleted')
+            logger.info('Objects have been marked as deleted')
 
 async def download_450_images(
     uuids: list[str],
@@ -155,7 +157,7 @@ async def download_450_images(
     if not uuids:
         return []
 
-    print(f'Downloading {len(uuids)} images')
+    logger.info(f'Downloading {len(uuids)} images')
 
     s3_client = boto3.client(
         's3',
@@ -194,5 +196,5 @@ async def download_450_images(
 
     results = await asyncio.to_thread(download_many)
 
-    print(f'Downloading {len(uuids)} images complete')
+    logger.info(f'Downloading {len(uuids)} images complete')
     return results

--- a/backend/service/cron/garbagerecords/__init__.py
+++ b/backend/service/cron/garbagerecords/__init__.py
@@ -1,12 +1,15 @@
 from database import api_tx
 from service.cron.garbagerecords.sql import *
-from service.cron.cronutil import print_stacktrace, MAX_RANDOM_START_DELAY
+from service.cron.cronutil import log_stacktrace, MAX_RANDOM_START_DELAY
 import asyncio
 import random
+import logging
 
 from duoenv.cron import GARBAGE_RECORDS_POLL_SECONDS
 
-print(f'Hello from cron module: {__name__}')
+logger = logging.getLogger(__name__)
+
+logger.info('Hello from cron module')
 
 async def delete_garbage_records_once() -> None:
     async with api_tx() as tx:
@@ -19,10 +22,10 @@ async def delete_garbage_records_once() -> None:
         count = 0
 
     if count:
-        print(f'Deleted {count} garbage record(s)')
+        logger.info(f'Deleted {count} garbage record(s)')
 
 async def delete_garbage_records_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(delete_garbage_records_once)
+        await log_stacktrace(delete_garbage_records_once)
         await asyncio.sleep(GARBAGE_RECORDS_POLL_SECONDS)

--- a/backend/service/cron/messagenotifications/__init__.py
+++ b/backend/service/cron/messagenotifications/__init__.py
@@ -16,10 +16,13 @@ from service.cron.notificationdispatch import (
     NotificationKind,
     send_pending_notifications_forever,
 )
+import logging
 
 from duoenv.cron import EMAIL_POLL_SECONDS
 
-print(f'Hello from cron module: {__name__}')
+logger = logging.getLogger(__name__)
+
+logger.info('Hello from cron module')
 
 @dataclass
 class PersonNotification:

--- a/backend/service/cron/notificationdispatch/__init__.py
+++ b/backend/service/cron/notificationdispatch/__init__.py
@@ -5,15 +5,18 @@ from service.cron.cronutil import (
     DISABLE_MOBILE_NOTIFICATIONS_FILE,
     MAX_RANDOM_START_DELAY,
     disable_mobile_notifications,
-    print_stacktrace,
+    log_stacktrace,
 )
 from smtp import make_aws_smtp
 from typing import Generic, Protocol, TypeVar
 from unseennotificationcount import increment_unseen_notification_count
 from util import Json
 import asyncio
+import logging
 import notify
 import random
+
+logger = logging.getLogger(__name__)
 
 class NotificationRow(Protocol):
     person_uuid: str
@@ -42,7 +45,7 @@ def do_send_email_notification(kind: NotificationKind[N], row: N) -> bool:
 
 async def send_email_notification(kind: NotificationKind[N], row: N) -> None:
     if not do_send_email_notification(kind, row):
-        print('Email notification failed because it ends with @example.com')
+        logger.info('Email notification failed because it ends with @example.com')
         return
 
     subject = kind.subject(row)
@@ -61,9 +64,9 @@ def send_mobile_notification(
     badge: int | None,
 ) -> None:
     if disable_mobile_notifications():
-        print(
-            'File prevented mobile notifications',
-            str(DISABLE_MOBILE_NOTIFICATIONS_FILE.absolute())
+        logger.info(
+            'File prevented mobile notifications: '
+            f'{DISABLE_MOBILE_NOTIFICATIONS_FILE.absolute()}'
         )
     else:
         notify.enqueue_mobile_notification(
@@ -106,10 +109,10 @@ async def send_notification(
     badge: int | None,
 ) -> None:
     if not row.token:
-        print(f'Sending {kind.name} email notification:', str(row))
+        logger.info(f'Sending {kind.name} email notification: {row}')
         return await send_email_notification(kind, row)
 
-    print(f'Sending {kind.name} mobile notification:', str(row))
+    logger.info(f'Sending {kind.name} mobile notification: {row}')
     send_mobile_notification(kind, row, badge=badge)
 
 async def maybe_send_notification(
@@ -139,6 +142,6 @@ async def send_pending_notifications_once(kind: NotificationKind[N]) -> None:
 async def send_pending_notifications_forever(kind: NotificationKind[N]) -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(
+        await log_stacktrace(
             lambda: send_pending_notifications_once(kind))
         await asyncio.sleep(kind.poll_seconds)

--- a/backend/service/cron/nsfwphotorunner/__init__.py
+++ b/backend/service/cron/nsfwphotorunner/__init__.py
@@ -4,14 +4,17 @@ from service.cron.nsfwphotorunner.sql import *
 from service.cron.cronutil import (
     MAX_RANDOM_START_DELAY,
     download_450_images,
-    print_stacktrace,
+    log_stacktrace,
 )
 import asyncio
 import random
+import logging
 
 from duoenv.cron import NSFW_PHOTO_RUNNER_POLL_SECONDS
 
-print(f'Hello from cron module: {__name__}')
+logger = logging.getLogger(__name__)
+
+logger.info('Hello from cron module')
 
 async def predict_nsfw_photos_once() -> None:
     async with api_tx() as tx:
@@ -54,5 +57,5 @@ async def predict_nsfw_photos_once() -> None:
 async def predict_nsfw_photos_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(predict_nsfw_photos_once)
+        await log_stacktrace(predict_nsfw_photos_once)
         await asyncio.sleep(NSFW_PHOTO_RUNNER_POLL_SECONDS)

--- a/backend/service/cron/photocleaner/__init__.py
+++ b/backend/service/cron/photocleaner/__init__.py
@@ -3,17 +3,20 @@ from service.cron.photocleaner.sql import *
 from service.cron.cronutil import (
     MAX_RANDOM_START_DELAY,
     delete_images_from_object_store,
-    print_stacktrace,
+    log_stacktrace,
 )
 import asyncio
 import random
+import logging
 
 from duoenv.cron import (
     PHOTO_CLEANER_DRY_RUN as DRY_RUN,
     PHOTO_CLEANER_POLL_SECONDS,
 )
 
-print(f'Hello from cron module: {__name__}')
+logger = logging.getLogger(__name__)
+
+logger.info('Hello from cron module')
 
 async def clean_photos_once() -> None:
     params = dict(polling_interval_seconds=PHOTO_CLEANER_POLL_SECONDS)
@@ -32,5 +35,5 @@ async def clean_photos_once() -> None:
 async def clean_photos_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(clean_photos_once)
+        await log_stacktrace(clean_photos_once)
         await asyncio.sleep(PHOTO_CLEANER_POLL_SECONDS)

--- a/backend/service/cron/profilereporter/__init__.py
+++ b/backend/service/cron/profilereporter/__init__.py
@@ -5,16 +5,19 @@ from service.cron.profilereporter.sql import (
 )
 from service.cron.cronutil import (
     MAX_RANDOM_START_DELAY,
-    print_stacktrace,
+    log_stacktrace,
 )
 import asyncio
 import random
 from antiabuse.childsafety import potential_minor
 from antiabuse.lodgereport import skip_by_uuid
+import logging
 
 from duoenv.cron import PROFILE_REPORTER_POLL_SECONDS
 
-print(f'Hello from cron module: {__name__}')
+logger = logging.getLogger(__name__)
+
+logger.info('Hello from cron module')
 
 async def report_profiles_once() -> None:
     async with api_tx() as tx:
@@ -24,14 +27,14 @@ async def report_profiles_once() -> None:
 
     for row in rows:
         if potential_minor(row['about']):
-            print(f'{__name__} -', row['object_uuid'], 'reported')
+            logger.info(f"{row['object_uuid']} reported")
             await skip_by_uuid(
                 subject_uuid=row['subject_uuid'],
                 object_uuid=row['object_uuid'],
                 reason='Automatically lodged report: Child safety'
             )
         else:
-            print(f'{__name__} -', row['object_uuid'], 'not reported')
+            logger.info(f"{row['object_uuid']} not reported")
 
     params_seq = [dict(uuid=row['object_uuid']) for row in rows]
     async with api_tx() as tx:
@@ -41,5 +44,5 @@ async def report_profiles_once() -> None:
 async def report_profiles_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(report_profiles_once)
+        await log_stacktrace(report_profiles_once)
         await asyncio.sleep(PROFILE_REPORTER_POLL_SECONDS)

--- a/backend/service/cron/verificationjobrunner/__init__.py
+++ b/backend/service/cron/verificationjobrunner/__init__.py
@@ -4,14 +4,17 @@ from verification import verify
 from verification.messages import (
     V_SOMETHING_WENT_WRONG,
 )
-from service.cron.cronutil import print_stacktrace, MAX_RANDOM_START_DELAY
+from service.cron.cronutil import log_stacktrace, MAX_RANDOM_START_DELAY
 import asyncio
 import random
 from dataclasses import dataclass
+import logging
 
 from duoenv.cron import VERIFICATION_POLL_SECONDS
 
-print(f'Hello from cron module: {__name__}')
+logger = logging.getLogger(__name__)
+
+logger.info('Hello from cron module')
 
 @dataclass
 class VerificationJob:
@@ -100,5 +103,5 @@ async def verify_once() -> None:
 async def verify_forever() -> None:
     await asyncio.sleep(random.randint(0, MAX_RANDOM_START_DELAY))
     while True:
-        await print_stacktrace(verify_once)
+        await log_stacktrace(verify_once)
         await asyncio.sleep(VERIFICATION_POLL_SECONDS)

--- a/backend/service/cron/visitornotifications/__init__.py
+++ b/backend/service/cron/visitornotifications/__init__.py
@@ -15,10 +15,13 @@ from service.cron.visitornotifications.template import (
     title_part,
     visitor_emailtemplate,
 )
+import logging
 
 from duoenv.cron import EMAIL_POLL_SECONDS as VISITOR_POLL_SECONDS
 
-print(f'Hello from cron module: {__name__}')
+logger = logging.getLogger(__name__)
+
+logger.info('Hello from cron module')
 
 @dataclass
 class VisitorNotification:

--- a/backend/service/firehol/__init__.py
+++ b/backend/service/firehol/__init__.py
@@ -31,11 +31,11 @@ Run with `python3 service/firehol/__init__.py`. Endpoints:
 
 import ipaddress
 import json
+import logging
 import os
 import threading
 import time
-import traceback
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Dict, Iterable, Tuple, Union
@@ -68,8 +68,12 @@ cache_dir = Path("/tmp/duolicious-firehol")
 cache_dir.mkdir(parents=True, exist_ok=True)
 
 
-def _log(message: str) -> None:
-    print(f"{datetime.now(timezone.utc).isoformat()} {message}")
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s:     %(asctime)s %(name)s: %(message)s',
+)
+
+logger = logging.getLogger('firehol')
 
 
 # ---------------------------------------------------------------------------
@@ -109,15 +113,15 @@ def _download_or_load(name: ListName, update_interval: timedelta) -> str:
     if path.exists():
         age = time.time() - path.stat().st_mtime
         if age < update_interval.total_seconds():
-            _log(f"Loading {name} from disk cache")
+            logger.info(f"Loading {name} from disk cache")
             return path.read_text(encoding="utf-8", errors="ignore")
 
     url = _blocklist_url(name)
-    _log(f"Downloading {url}")
+    logger.info(f"Downloading {url}")
     request = Request(url, headers={"User-Agent": "Mozilla/5.0"})
     with urlopen(request, timeout=30) as resp:
         text = resp.read().decode("utf-8", errors="ignore")
-    _log(f"Finished downloading {url}")
+    logger.info(f"Finished downloading {url}")
 
     # Atomic write: write to tmp → replace
     tmp = path.with_suffix(".tmp")
@@ -221,9 +225,9 @@ def _refresh_forever() -> None:
         try:
             data = _collect_all(DEFAULT_LISTS, UPDATE_INTERVAL)
             _tries = _build_tries(data)  # atomic swap
-            _log("FireHOL lists loaded")
+            logger.info("FireHOL lists loaded")
         except Exception:
-            _log("FireHOL refresh failed:\n" + traceback.format_exc())
+            logger.exception("FireHOL refresh failed")
         time.sleep(UPDATE_INTERVAL.total_seconds())
 
 
@@ -250,9 +254,9 @@ class _Handler(BaseHTTPRequestHandler):
                 return
             lists = lookup(ip)
             if lists:
-                _log(f"lookup {ip} -> BLOCKED by {', '.join(sorted(lists))}")
+                logger.info(f"lookup {ip} -> BLOCKED by {', '.join(sorted(lists))}")
             else:
-                _log(f"lookup {ip} -> ACCEPTED")
+                logger.info(f"lookup {ip} -> ACCEPTED")
             self._send_json(200, lists)
         elif parsed.path == "/ready":
             self._send_json(200, {"ready": _tries is not None})
@@ -269,7 +273,7 @@ class _Handler(BaseHTTPRequestHandler):
 def main() -> None:
     threading.Thread(target=_refresh_forever, daemon=True).start()
     server = ThreadingHTTPServer(("0.0.0.0", FIREHOL_PORT), _Handler)
-    _log(f"FireHOL server listening on 0.0.0.0:{FIREHOL_PORT}")
+    logger.info(f"FireHOL server listening on 0.0.0.0:{FIREHOL_PORT}")
     server.serve_forever()
 
 

--- a/backend/smtp/__init__.py
+++ b/backend/smtp/__init__.py
@@ -1,15 +1,17 @@
 """Thread‑safe SMTP helper with typed API and automatic retries.
 """
 
+import logging
 import smtplib
 import threading
 import time
-import traceback
 from contextlib import suppress
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 from duoenv.shared import SMTP_HOST, SMTP_PASS, SMTP_PORT, SMTP_USER
+
+logger = logging.getLogger(__name__)
 
 
 class Smtp:
@@ -41,22 +43,22 @@ class Smtp:
                     self._smtp = None
 
             try:
-                print(f"Establishing connection to SMTP server at {self.host}")
+                logger.info(f'Establishing connection to SMTP server at {self.host}')
                 smtp = smtplib.SMTP(self.host, self.port, timeout=30)
                 smtp.ehlo()
 
                 if smtp.has_extn("starttls"):
                     smtp.starttls()
                     smtp.ehlo()  # re-identify as TLS is now in effect
-                    print("STARTTLS supported and initiated.")
+                    logger.info('STARTTLS supported and initiated.')
                 else:
-                    print("STARTTLS not supported by server.")
+                    logger.info('STARTTLS not supported by server.')
 
                 smtp.login(self.username, self.password)
                 self._smtp = smtp
-                print(f"Connection to SMTP server at {self.host} established")
+                logger.info(f'Connection to SMTP server at {self.host} established')
             except Exception as exc:
-                print(f"Failed to connect to SMTP server: {exc}")
+                logger.error(f'Failed to connect to SMTP server: {exc}')
                 self._smtp = None
                 raise
 
@@ -116,13 +118,13 @@ class Smtp:
                     )
                 return  # Success
             except Exception:
-                print(traceback.format_exc())
+                logger.exception('Sending email failed')
                 if attempt == max_attempts:
-                    print("All retry attempts exhausted. Giving up.")
+                    logger.error('All retry attempts exhausted. Giving up.')
 
                 delay_base: float = 1.0 if backoff is None else backoff
                 delay = delay_base * (2 ** (attempt - 1))
-                print(f"Attempt {attempt} failed; retrying in {delay:.1f}s.")
+                logger.warning(f'Attempt {attempt} failed; retrying in {delay:.1f}s.')
                 time.sleep(delay)
 
                 # Best effort reconnect for the next iteration
@@ -138,7 +140,7 @@ class Smtp:
                 try:
                     self._smtp.quit()
                 except Exception as exc:
-                    print(f"Error while quitting SMTP connection: {exc}")
+                    logger.warning(f'Error while quitting SMTP connection: {exc}')
                 finally:
                     self._smtp = None
 

--- a/backend/util/__init__.py
+++ b/backend/util/__init__.py
@@ -3,6 +3,7 @@ from urllib.parse import quote
 from typing import Callable, Iterator, TypeAlias, Union
 import contextlib
 import ipaddress
+import logging
 import os
 import time
 
@@ -16,15 +17,18 @@ Json: TypeAlias = (
 )
 
 
+logger = logging.getLogger(__name__)
+
+
 def log(message: str) -> None:
-    print(f"{datetime.now(timezone.utc).isoformat()} {message}")
+    logger.info(message)
 
 
 @contextlib.contextmanager
-def timed(label: str = 'block', log: Callable[[str], None] = print) -> Iterator[None]:
+def timed(label: str = 'block', log: Callable[[str], None] = log) -> Iterator[None]:
     """Context manager that logs how long the block took, even if it raises.
 
-    `log` receives the formatted message (default `print`).
+    `log` receives the formatted message.
     """
     start = time.monotonic()
     try:
@@ -95,7 +99,7 @@ def is_offpeak(max_load_pct: float = 75.0, suppressed_action: str = '') -> bool:
     if _is_offpeak:
         return True
 
-    print(
+    logger.info(
         f'is_offpeak returned False '
         f'load 1m={pct_1min:.0f}%, 5m={pct_5min:.0f}% '
         f'(target < {max_load_pct:.0f}%)'

--- a/backend/verification/__init__.py
+++ b/backend/verification/__init__.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import Literal
 import json
 import base64
-import traceback
+import logging
 from pathlib import Path
 from httpxclient import make_http_client
 from verification.messages import *
@@ -22,6 +22,8 @@ from duoenv.shared import (
     VERIFICATION_IMAGE_BASE_URL,
     VERIFICATION_MOCK_RESPONSE_FILE,
 )
+
+logger = logging.getLogger(__name__)
 
 _mock_response_file = (
      Path(__file__).parent.parent / VERIFICATION_MOCK_RESPONSE_FILE
@@ -235,8 +237,7 @@ def process_response(
         image_1_has_person_from_image_7 = float(image_1_has_person_from_image_7) if image_1_has_person_from_image_7 is not None else None
         image_1_has_person_from_image_8 = float(image_1_has_person_from_image_8) if image_1_has_person_from_image_8 is not None else None
     except:
-        print(traceback.format_exc())
-        print('JSON was:', response_str)
+        logger.exception(f'Parsing verification response failed; JSON was: {response_str}')
         return failure(V_SOMETHING_WENT_WRONG, response_str)
 
     # These settings are tuned to gpt-4-turbo. gpt-4o worked better with higher
@@ -328,7 +329,7 @@ async def get_image_url(uuid: str) -> str:
     # Everything after this point is only intended for use in development.
     # This shouldn't be used in production.
     intermediate_image_url = f"{VERIFICATION_IMAGE_BASE_URL}/450-{uuid}.jpg"
-    print(f'Fetching for verification: {intermediate_image_url}')
+    logger.info(f'Fetching for verification: {intermediate_image_url}')
 
     async with make_http_client() as client:
         response = await client.get(intermediate_image_url)
@@ -409,7 +410,7 @@ async def real_verification_response(
             timeout=45,
         )).choices[0].message.content
     except:
-        print(traceback.format_exc())
+        logger.exception('Verification completion failed')
 
     return None
 

--- a/backend/visitornotification/__init__.py
+++ b/backend/visitornotification/__init__.py
@@ -1,4 +1,4 @@
-import traceback
+import logging
 import notify
 from commonsql import Q_UPSERT_LAST_VISITOR_NOTIFICATION_TIME
 from constants import (
@@ -12,6 +12,8 @@ from visitorsql import (
     Q_VISITOR_ITEM,
     Q_WANTS_IMMEDIATE_VISITOR_NOTIFICATION,
 )
+
+logger = logging.getLogger(__name__)
 
 
 async def _wants_immediate_notification(prospect_id: int) -> bool:
@@ -107,4 +109,4 @@ async def notify_of_visit(
 
         await _push(prospect_uuid, name, prospect_online)
     except Exception:
-        print(traceback.format_exc())
+        logger.exception('Sending visitor notification failed')

--- a/backend/visitorspush/__init__.py
+++ b/backend/visitorspush/__init__.py
@@ -1,9 +1,11 @@
 import json
-import traceback
+import logging
 from database import api_tx
 from redisclient import make_redis_client
 from chatprotocol.outbound import Visitor, to_bus
 from visitorsql import Q_VISITOR_ITEM
+
+logger = logging.getLogger(__name__)
 
 _redis = make_redis_client()
 
@@ -19,7 +21,7 @@ async def _publish(channel: str, section: str, item: dict) -> None:
             )),
         )
     except Exception:
-        print(traceback.format_exc())
+        logger.exception('Publishing visitor update failed')
 
 
 async def publish_visit(
@@ -58,4 +60,4 @@ async def publish_visit(
         if owner_item:
             await _publish(prospect_uuid, 'visited_you', owner_item)
     except Exception:
-        print(traceback.format_exc())
+        logger.exception('Publishing visit failed')


### PR DESCRIPTION
Converts every print-as-logging site in the backend services (~100 across 32 files) to the stdlib `logging` module, so log lines carry a level, a timestamp, and the emitting module, and stack traces come via `logger.exception` instead of `print(traceback.format_exc())`.

## Setup

- The api service already had `logging.basicConfig` in `asgi.py`; the cron and firehol services had none. Both now configure logging in the same level-prefixed format. In `service/cron/__init__.py` the config deliberately runs **before** the cron-module imports, so import-time log lines (the "Hello from cron module" boot markers) aren't dropped by a not-yet-configured root logger.
- `database/initapi.py` gets the same config since it doubles as the deploy-time entrypoint (`bootstrap.py`'s migration logging flows through it).
- Every converted module uses a module-level `logger = logging.getLogger(__name__)`, so the module name in each line replaces hand-rolled prefixes like `print(f'{__name__} -', ...)` and `'checkphotos: ...'` stays only where it distinguishes sub-crons sharing a module.

## Notable conversions

- `cronutil.print_stacktrace` → `log_stacktrace` (renamed to match what it now does); it logs `f'{fun.__qualname__} failed'` with the traceback, so cron failures now say which task failed.
- `util.log()` keeps its signature but delegates to logging; its hand-rolled UTC timestamp is superseded by the root handler's. `timed()`'s default sink is now `util.log` rather than `print`.
- `service/firehol` (which can't import shared code) gets its own three-line config and drops its private `_log` helper.
- Levels: routine progress → `info`, transient/retryable failures → `warning`, failed operations → `error`/`exception`.

Left alone: the one-off CLI scripts in `questions/` (stdout is their interface) and a pre-existing unused `import traceback` in `duotypes`.

## Verification

- `backend/mypy.sh`: clean (190 files).
- Smoke-imported `service.cron` with stub env: boot logs render as `INFO:     2026-08-10 00:17:10,724 service.cron.checkphotos: Hello from cron module` (the import then stops at smtp's pre-existing eager connect, which needs a real SMTP host).
- No functionality test asserts on printed log strings (checked `backend/test/`).

Note for #1438: its `service/cron/__init__.py` hunk adds the same `basicConfig` after the imports; on rebase, keep this branch's before-imports placement and its `logging`/`logger` usage slots in unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)